### PR TITLE
Update AdminSelfUpgrade.php

### DIFF
--- a/AdminSelfUpgrade.php
+++ b/AdminSelfUpgrade.php
@@ -1847,7 +1847,6 @@ class AdminSelfUpgrade extends AdminSelfTab
 				$modules_to_delete['mobile_theme'] = 'The 1.4 mobile_theme';
 				$modules_to_delete['trustedshops'] = 'Trustedshops';
 				$modules_to_delete['dejala'] = 'Dejala';
-				$modules_to_delete['stripejs'] = 'Stripejs';
 				$modules_to_delete['blockvariouslinks'] = 'Block Various Links';
 
 				foreach($modules_to_delete as $key => $module)


### PR DESCRIPTION
Stripejs is a valid module sold on the Prestashop Addons store as "Stripe Reloaded".  The autoupgrade module should not be deleting it.
