### PR TITLE
add realpath() to $this->adminDir for IIS

### DIFF
--- a/AdminSelfUpgrade.php
+++ b/AdminSelfUpgrade.php
@@ -580,7 +580,7 @@ class AdminSelfUpgrade extends AdminSelfTab
         // For later use, let's set up prodRootDir and adminDir
         // This way it will be easier to upgrade a different path if needed
         $this->prodRootDir = _PS_ROOT_DIR_;
-        $this->adminDir = _PS_ADMIN_DIR_;
+        $this->adminDir = realpath(_PS_ADMIN_DIR_);
         if (!defined('__PS_BASE_URI__')) {
             // _PS_DIRECTORY_ replaces __PS_BASE_URI__ in 1.5
             if (defined('_PS_DIRECTORY_')) {


### PR DESCRIPTION
On IIS (Windows Server) the admin/autoupgrade-directory would not be writable. This is due to the drive-letter being undercase on _PS_ADMIN_DIR_ and uppercase on _PS_ROOT_DIR_. See tracker issue PNM3927 for more info.