### PR TITLE
MO: fix bug when using php7.1

### DIFF
--- a/db/DbQuery.php
+++ b/db/DbQuery.php
@@ -36,7 +36,7 @@ class DbQueryCore
 	 */
 	protected $query = array(
 		'select' => array(),
-		'from' => 	'',
+		'from' => 	array(),
 		'join' => 	array(),
 		'where' => 	array(),
 		'group' => 	array(),


### PR DESCRIPTION
Fix PHP Fatal error: Uncaught Error: [] operator not supported for strings in /modules/autoupgrade/db/DbQuery.php:70