### PR TITLE
Move composer files to move on the first place

### DIFF
--- a/AdminSelfUpgrade.php
+++ b/AdminSelfUpgrade.php
@@ -1651,7 +1651,7 @@ class AdminSelfUpgrade extends AdminSelfTab
             // also add files to remove
             $list_files_to_upgrade = array_merge($list_files_diff, $list_files_to_upgrade);
 
-            $filesToMoveToTheEnd = array(
+            $filesToMoveToTheBeginning = array(
                 DIRECTORY_SEPARATOR.'vendor'.DIRECTORY_SEPARATOR.'autoload.php',
                 DIRECTORY_SEPARATOR.'vendor'.DIRECTORY_SEPARATOR.'composer'.DIRECTORY_SEPARATOR.'ClassLoader.php',
                 DIRECTORY_SEPARATOR.'vendor'.DIRECTORY_SEPARATOR.'composer'.DIRECTORY_SEPARATOR.'autoload_classmap.php',
@@ -1663,10 +1663,10 @@ class AdminSelfUpgrade extends AdminSelfTab
                 DIRECTORY_SEPARATOR.'vendor'.DIRECTORY_SEPARATOR.'composer'.DIRECTORY_SEPARATOR.'include_paths.php',
             );
 
-            foreach ($filesToMoveToTheEnd as $file) {
+            foreach ($filesToMoveToTheBeginning as $file) {
                 if ($key = array_search($file, $list_files_to_upgrade)) {
-                  $list_files_to_upgrade[] = $list_files_to_upgrade[$key];
-                  unset($list_files_to_upgrade[$key]);
+                    unset($list_files_to_upgrade[$key]);
+                    $list_files_to_upgrade = array_merge(array($file), $list_files_to_upgrade);
                 }
             }
 


### PR DESCRIPTION
During the upgrade, file update / deletion is made is several ajax calls (400 files per call).

Sometimes, depending on the number of file in the release package, all the composer files are not copied in the same call. This trigger errors about undefined class etc, and this breaks the whole process. 

The objective is to move these files at the beginning of the array instead of the end. We then make sure all these files are handled in the same call.

Fixes http://forge.prestashop.com/browse/BOOM-4742