### PR TITLE
Fix issue about [] operator on string

### DIFF
--- a/AdminSelfUpgrade.php
+++ b/AdminSelfUpgrade.php
@@ -657,8 +657,8 @@ class AdminSelfUpgrade extends AdminSelfTab
             $this->cleanTmpFiles();
         } else {
             foreach ($this->ajaxParams as $prop) {
-                if (property_exists($this, $prop)) {
-                    $this->{$prop} = isset($this->currentParams[$prop])?$this->currentParams[$prop]:'';
+                if (property_exists($this, $prop) && isset($this->currentParams[$prop])) {
+                    $this->{$prop} = $this->currentParams[$prop];
                 }
             }
         }


### PR DESCRIPTION
Rollbacks can't be done on PHP 7.1+, because we try to add values with [] on a variable defined as a string.

```
[15-Feb-2018 10:57:48 Europe/Paris] PHP Fatal error:  Uncaught Error: [] operator not supported for strings in /homepages/40/d644053448/htdocs/prestashop_1.7.2.4/modules/autoupgrade/AdminSelfUpgrade.php:2995
Stack trace:
#0 /homepages/40/d644053448/htdocs/prestashop_1.7.2.4/admin-dev/autoupgrade/ajax-upgradetab.php(90): AdminSelfUpgrade->ajaxProcessRollback()
#1 {main}
  thrown in /homepages/40/d644053448/htdocs/prestashop_1.7.2.4/modules/autoupgrade/AdminSelfUpgrade.php on line 2995
