### PR TITLE
Continue on broken symlink in directory listing

### DIFF
--- a/AdminSelfUpgrade.php
+++ b/AdminSelfUpgrade.php
@@ -1517,7 +1517,7 @@ class AdminSelfUpgrade extends AdminSelfTab
             foreach ($allFiles as $file) {
                 if ($file[0] != '.') {
                     $fullPath = $dir.$file;
-                    // skip symbolic links
+                    // skip broken symbolic links
                     if (is_link($fullPath) && !is_readable($fullPath)) {
                         continue;
                     }

--- a/AdminSelfUpgrade.php
+++ b/AdminSelfUpgrade.php
@@ -1517,6 +1517,9 @@ class AdminSelfUpgrade extends AdminSelfTab
             foreach ($allFiles as $file) {
                 if ($file[0] != '.') {
                     $fullPath = $dir.$file;
+                    if (is_link($fullPath) && !is_readable($fullPath)) {
+                        continue;
+                    }
                     if (!$this->_skipFile($file, $fullPath, $way)) {
                         if (is_dir($fullPath)) {
                             $list = array_merge($list, $this->_listFilesInDir($fullPath, $way, $list_directories));

--- a/AdminSelfUpgrade.php
+++ b/AdminSelfUpgrade.php
@@ -1517,6 +1517,7 @@ class AdminSelfUpgrade extends AdminSelfTab
             foreach ($allFiles as $file) {
                 if ($file[0] != '.') {
                     $fullPath = $dir.$file;
+                    // skip symbolic links
                     if (is_link($fullPath) && !is_readable($fullPath)) {
                         continue;
                     }


### PR DESCRIPTION
When a **broken** symbolic link exists on the Filesystem, the module tries to backup it before proceeding with the upgrade.
Because the link destination does not exist, there is nothing to save. This PR asks the module to bypass this case.

Fixes http://forge.prestashop.com/browse/BOOM-4957