### PR TITLE
Always load default conf data before saved conf files

### DIFF
--- a/classes/Parameters/UpgradeConfigurationStorage.php
+++ b/classes/Parameters/UpgradeConfigurationStorage.php
@@ -40,20 +40,10 @@ class UpgradeConfigurationStorage extends FileConfigurationStorage
      */
     public function load($configFileName = '')
     {
-        $data = parent::load($configFileName);
-        if (empty($data)) {
-            $data = array(
-                'PS_AUTOUP_PERFORMANCE' => 1,
-                'PS_AUTOUP_CUSTOM_MOD_DESACT' => 1,
-                'PS_AUTOUP_UPDATE_DEFAULT_THEME' => 1,
-                'PS_AUTOUP_CHANGE_DEFAULT_THEME' => 0,
-                'PS_AUTOUP_KEEP_MAILS' => 0,
-                'PS_AUTOUP_BACKUP' => 1,
-                'PS_AUTOUP_KEEP_IMAGES' => 0,
-                'channel' => Upgrader::DEFAULT_CHANNEL,
-                'archive.filename' => 'prestashop.zip',
-            );
-        }
+        $data = array_merge(
+            $this->getDefaultData(),
+            parent::load($configFileName)
+        );
 
         return new UpgradeConfiguration($data);
     }
@@ -71,5 +61,20 @@ class UpgradeConfigurationStorage extends FileConfigurationStorage
         }
 
         return parent::save($config->toArray(), $configFileName);
+    }
+
+    public function getDefaultData()
+    {
+        return array(
+            'PS_AUTOUP_PERFORMANCE' => 1,
+            'PS_AUTOUP_CUSTOM_MOD_DESACT' => 1,
+            'PS_AUTOUP_UPDATE_DEFAULT_THEME' => 1,
+            'PS_AUTOUP_CHANGE_DEFAULT_THEME' => 0,
+            'PS_AUTOUP_KEEP_MAILS' => 0,
+            'PS_AUTOUP_BACKUP' => 1,
+            'PS_AUTOUP_KEEP_IMAGES' => 0,
+            'channel' => Upgrader::DEFAULT_CHANNEL,
+            'archive.filename' => 'prestashop.zip',
+        );
     }
 }

--- a/tests/UpgradeConfigurationTest.php
+++ b/tests/UpgradeConfigurationTest.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ * 2007-2018 PrestaShop
+ * 
+ * NOTICE OF LICENSE
+ * 
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ * 
+ * DISCLAIMER
+ * 
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ * 
+ *  @author PrestaShop SA <contact@prestashop.com>
+ *  @copyright  2007-2018 PrestaShop SA
+ *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\Module\AutoUpgrade\Parameters\FileConfigurationStorage;
+use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfigurationStorage;
+
+class UpgradeConfigurationTest extends TestCase
+{
+    /**
+     * This method only initialize the configuration from empty data saves.
+     * We expect to find all the default data.
+     */
+    public function testDefaultValuesAreSet()
+    {
+        $filePath = sys_get_temp_dir();
+        $fileName = __FUNCTION__.'.dat';
+
+        $upgradeConfigurationStorage = new UpgradeConfigurationStorage($filePath.DIRECTORY_SEPARATOR);
+        $upgradeConfiguration = $upgradeConfigurationStorage->load($fileName);
+
+        foreach ($upgradeConfigurationStorage->getDefaultData() as $key => $value) {
+            $this->assertSame($value, $upgradeConfiguration->get($key));
+        }
+    }
+
+    /**
+     * In case the data save contains some values, we still expect to find the dault data
+     * to be defined, even if they can't be found in the saved file.
+     */
+    public function testDefaultValuesAreSetWhenNotExistingInSavedFile()
+    {
+        $filePath = sys_get_temp_dir();
+        $fileName = __FUNCTION__.'.dat';
+
+        (new FileConfigurationStorage($filePath.DIRECTORY_SEPARATOR))->save(['randomData' => 'trololo'], $fileName);
+
+        $upgradeConfigurationStorage = new UpgradeConfigurationStorage($filePath.DIRECTORY_SEPARATOR);
+        $upgradeConfiguration = $upgradeConfigurationStorage->load($fileName);
+
+        foreach ($upgradeConfigurationStorage->getDefaultData() as $key => $value) {
+            $this->assertSame($value, $upgradeConfiguration->get($key));
+        }
+    }
+}


### PR DESCRIPTION
This PR covers a case where the data saved in files may change between two release. It appeared upgrading a shop under 1.6 was impossible, because of download issues.

From now, even if the data does not exist in the saved content, it will be declared in the Configuration class.

Fixes http://forge.prestashop.com/browse/BOOM-4960