### PR TITLE
Stop upgrade process if zip file can't be closed

### DIFF
--- a/classes/ZipAction.php
+++ b/classes/ZipAction.php
@@ -161,7 +161,15 @@ class ZipAction
                 'Modules.Autoupgrade.Admin'
             ));
         }
-        $zip->close();
+
+        if (!$zip->close()) {
+            $this->logger->error($this->translator->trans(
+                'Could not close the Zip file properly. Check you are allowed to write on the disk and there is available space on it.',
+                array(),
+                'Modules.Autoupgrade.Admin'
+            ));
+            return false;
+        }
 
         return true;
     }


### PR DESCRIPTION
On huge servers with many files to backup but limited storage, "no space left" errors may occurs.

When it happened, the process did not stop and was still trying to add even more files to the zip file.
With this PR, we stop the process as we can't go further.

![capture du 2018-06-21 12-21-52](https://user-images.githubusercontent.com/6768917/41716377-26a23fe0-754e-11e8-9eee-c9b0b5ddd636.png)

ping @LouiseBonnard for string review.
