### PR TITLE
Disable modules with 1.6 method

### DIFF
--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -241,7 +241,13 @@ abstract class CoreUpgrader
         }
     }
 
-    abstract protected function disableCustomModules();
+    /**
+     * Ask the core to disable the modules not coming from PrestaShop
+     */
+    protected function disableCustomModules()
+    {
+        $this->container->getModuleAdapter()->disableNonNativeModules();
+    }
 
     protected function upgradeDb($oldversion)
     {

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader16.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader16.php
@@ -85,12 +85,6 @@ class CoreUpgrader16 extends CoreUpgrader
         return _PS_VERSION_;
     }
 
-    protected function disableCustomModules()
-    {
-        require_once _PS_INSTALLER_PHP_UPGRADE_DIR_.'deactivate_custom_modules.php';
-        deactivate_custom_modules();
-    }
-
     protected function upgradeLanguage($lang)
     {
         require_once _PS_TOOL_DIR_.'tar/Archive_Tar.php';

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader17.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader17.php
@@ -47,11 +47,6 @@ class CoreUpgrader17 extends CoreUpgrader
         }*/
     }
 
-    protected function disableCustomModules()
-    {
-        $this->container->getModuleAdapter()->disableNonNativeModules();
-    }
-
     protected function upgradeDb($oldversion)
     {
         parent::upgradeDb($oldversion);

--- a/classes/UpgradeTools/ModuleAdapter.php
+++ b/classes/UpgradeTools/ModuleAdapter.php
@@ -86,60 +86,8 @@ class ModuleAdapter
      */
     public function disableNonNativeModules()
     {
-        $this->disableNonNativeModules16();
-    }
-
-    /**
-     * Upgrade action, disabling all modules not made by PrestaShop.
-     *
-     * Backward compatibility function
-     */
-    protected function disableNonNativeModules16()
-    {
         require_once _PS_INSTALLER_PHP_UPGRADE_DIR_.'deactivate_custom_modules.php';
         deactivate_custom_modules();
-    }
-
-    /**
-     * Upgrade action, disabling all modules not made by PrestaShop.
-     *
-     * Available only from 1.7. Can't be called on PS 1.6
-     * `use` statements for namespaces are not used, as they can throw errors where the class does not exist
-     */
-    protected function disableNonNativeModules17()
-    {
-        $moduleManagerBuilder = \PrestaShop\PrestaShop\Core\Addon\Module\ModuleManagerBuilder::getInstance();
-        $moduleRepository = $moduleManagerBuilder->buildRepository();
-        $moduleRepository->clearCache();
-
-        $filters = new \PrestaShop\PrestaShop\Core\Addon\AddonListFilter();
-        $filters->setType(\PrestaShop\PrestaShop\Core\Addon\AddonListFilterType::MODULE)
-            ->removeStatus(\PrestaShop\PrestaShop\Core\Addon\AddonListFilterStatus::UNINSTALLED);
-
-        $installedProducts = $moduleRepository->getFilteredList($filters);
-
-        $modules = array();
-        foreach ($installedProducts as $installedProduct) {
-            if (!(
-                    $installedProduct->attributes->has('origin_filter_value')
-                    && in_array(
-                        $installedProduct->attributes->get('origin_filter_value'),
-                        array(
-                            \PrestaShop\PrestaShop\Core\Addon\AddonListFilterOrigin::ADDONS_NATIVE,
-                            \PrestaShop\PrestaShop\Core\Addon\AddonListFilterOrigin::ADDONS_NATIVE_ALL,
-                        )
-                    )
-                    && 'PrestaShop' === $installedProduct->attributes->get('author')
-                )
-                && 'autoupgrade' !== $installedProduct->attributes->get('name')) {
-                $modules[] = $installedProduct->database->get('id');
-            }
-        }
-
-        if (!empty($modules)) {
-            $this->db->execute('UPDATE `'._DB_PREFIX_.'module` SET `active` = 0 WHERE `id_module` IN ('.implode(',', $modules).')');
-            $this->db->execute('DELETE FROM `'._DB_PREFIX_.'module_shop` WHERE `id_module` IN ('.implode(',', $modules).')');
-        }
     }
 
     /**

--- a/classes/UpgradeTools/ModuleAdapter.php
+++ b/classes/UpgradeTools/ModuleAdapter.php
@@ -81,12 +81,12 @@ class ModuleAdapter
 
     /**
      * Upgrade action, disabling all modules not made by PrestaShop.
+     *
+     * It seems the 1.6 version of is the safest, as it does not actually load the modules.
      */
     public function disableNonNativeModules()
     {
-        version_compare($this->upgradeVersion, '1.7.0.0', '>=') ?
-            $this->disableNonNativeModules17() :
-            $this->disableNonNativeModules16();
+        $this->disableNonNativeModules16();
     }
 
     /**


### PR DESCRIPTION
It appeared disabling modules triggered many errors during the upgrade file, as we were trying to find which one had to be disabled. To find these, we had to instantiate them, generally throwing errors on the new core.

From this PR, we try to use the 1.6 method, which only reads the config.xml files.