### PR TITLE
Use Prestashop requirements in Upgrade check list

### DIFF
--- a/classes/Twig/Block/UpgradeChecklist.php
+++ b/classes/Twig/Block/UpgradeChecklist.php
@@ -29,6 +29,7 @@ namespace PrestaShop\Module\AutoUpgrade\Twig\Block;
 
 use PrestaShop\Module\AutoUpgrade\UpgradeSelfCheck;
 use PrestaShop\Module\AutoUpgrade\Tools14;
+use Context;
 use Twig_Environment;
 
 /**
@@ -113,6 +114,7 @@ class UpgradeChecklist
             'moduleIsUpToDate' => $this->selfCheck->isModuleVersionLatest(),
             'versionGreaterThan1_5_3' => version_compare(_PS_VERSION_, '1.5.3.0', '>'),
             'adminToken' => Tools14::getAdminTokenLite('AdminModules'),
+            'informationsLink' => Context::getContext()->link->getAdminLink('AdminInformation'),
             'rootDirectoryIsWritable' => $this->selfCheck->isRootDirectoryWritable(),
             'rootDirectoryWritableReport' => $this->selfCheck->getRootWritableReport(),
             'adminDirectoryIsWritable' => $this->selfCheck->isAdminAutoUpgradeDirectoryWritable(),
@@ -124,6 +126,7 @@ class UpgradeChecklist
             'token' => $this->token,
             'cachingIsDisabled' => $this->selfCheck->isCacheDisabled(),
             'maxExecutionTime' => $this->selfCheck->getMaxExecutionTime(),
+            'isPrestaShopReady' => $this->selfCheck->isPrestaShopReady(),
         );
 
         return $this->twig->render('@ModuleAutoUpgrade/block/checklist.twig', $data);

--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -367,9 +367,7 @@ class UpgradeContainer
         // Using independant template engine for 1.6 & 1.7 compatibility
         $loader = new Twig_Loader_Filesystem();
         $loader->addPath(realpath(__DIR__.'/..').'/views/templates', 'ModuleAutoUpgrade');
-        $twig = new Twig_Environment($loader, array(
-            'cache' => $this->getProperty(self::TMP_PATH),
-        ));
+        $twig = new Twig_Environment($loader);
         $twig->addExtension(new TransFilterExtension($this->getTranslator()));
 
         $this->twig = $twig;

--- a/views/templates/block/checklist.twig
+++ b/views/templates/block/checklist.twig
@@ -114,6 +114,22 @@
                         {% endif %}
                     </td>
                 </tr>
+                <tr>
+                    <td>
+                        {% if isPrestaShopReady %}
+                            {{ 'PrestaShop requirements are satisfied. '|trans }}
+                        {% else %}
+                            {{ 'PrestaShop requirements are not satisfied. '|trans }} <a href="{{ informationsLink }}">{{ 'See details.'|trans }}</a>
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% if isPrestaShopReady %}
+                            {{ icons.ok }}
+                        {% else %}
+                            {{ icons.warning }}
+                        {% endif %}
+                    </td>
+                </tr>
             </table>
             <br>
             <p class="alert alert-info">{{ 'Please also make sure you make a full manual backup of your files and database.'|trans }}</p>


### PR DESCRIPTION
Some checks are done by PrestaShop and can be found in the AdminInformation page.

Some errors found during the upgrade were caused by this requirements not satisfied, so we added them to the preliminary checklist.

**Note:** The performance will decrease with this PR, as it checks the folders permissions.

OK:
![capture du 2018-06-28 14-54-53](https://user-images.githubusercontent.com/6768917/42040728-347b37e4-7ae8-11e8-8a37-dd8f4e04ea35.png)

Non-OK:
![capture du 2018-06-28 14-54-39](https://user-images.githubusercontent.com/6768917/42040737-39c6cdd0-7ae8-11e8-97a5-fa4a56e86889.png)
