### PR TITLE
Avoid fatal errors to be displayed with JSON messages

### DIFF
--- a/classes/ErrorHandler.php
+++ b/classes/ErrorHandler.php
@@ -53,6 +53,7 @@ class ErrorHandler
     public function enable()
     {
         error_reporting(E_ALL);
+        ini_set('display_errors', 0);
         set_error_handler(array($this, 'errorHandler'));
         set_exception_handler(array($this, 'exceptionHandler'));
         register_shutdown_function(array($this, 'fatalHandler'));


### PR DESCRIPTION
Some upgrade process have been reported as broken because the JSON could not be parsed. That was caused by PHP fatal errors being displayed even if they were caught by the error handler.

Once the error handler is enable, we ask PHP to not display the error mesages anymore.