### PR TITLE
Detect error step

### DIFF
--- a/classes/TaskRunner/AllUpgradeTasks.php
+++ b/classes/TaskRunner/AllUpgradeTasks.php
@@ -56,7 +56,7 @@ class AllUpgradeTasks extends AbstractTask
             $this->step = $result->getNext();
         }
 
-        return (int) ($this->error || $this->next === 'error');
+        return (int) ($this->error || $this->step === 'error');
     }
 
     /**

--- a/classes/TaskRunner/Upgrade/Download.php
+++ b/classes/TaskRunner/Upgrade/Download.php
@@ -78,7 +78,7 @@ class Download extends AbstractTask
                     $this->logger->info($this->translator->trans('Download complete. Now extracting...', array(), 'Modules.Autoupgrade.Admin'));
                 } else {
                     $this->logger->error($this->translator->trans('Download complete but MD5 sum does not match (%s).', array($md5file), 'Modules.Autoupgrade.Admin'));
-                    $this->logger->info($this->translator->trans('Download complete but MD5 sum does not match (%s). Operation aborted.', array(), 'Modules.Autoupgrade.Admin'));
+                    $this->logger->info($this->translator->trans('Download complete but MD5 sum does not match (%s). Operation aborted.', array($md5file), 'Modules.Autoupgrade.Admin'));
                     $this->next = 'error';
                 }
             } else {


### PR DESCRIPTION
We currently have an issue with md5 check on 1.6 releases.

The issue was properly detected, but the Travis job wasn't set in failure. This PR fixes the issue.