### PR TITLE
Generate RIJNDAEL keys if openssl is disabled

### DIFF
--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader16.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader16.php
@@ -63,7 +63,8 @@ class CoreUpgrader16 extends CoreUpgrader
         if (defined('_RIJNDAEL_KEY_') && defined('_RIJNDAEL_IV_')) {
             $datas['_RIJNDAEL_KEY_'] = _RIJNDAEL_KEY_;
             $datas['_RIJNDAEL_IV_'] = _RIJNDAEL_IV_;
-        } elseif (function_exists('mcrypt_encrypt')) {
+        } elseif (! function_exists('openssl_encrypt') && function_exists('mcrypt_encrypt')) {
+            // If only mcrypt is available, generate keys.
            $datas['_RIJNDAEL_KEY_'] = Tools::passwdGen(mcrypt_get_key_size(MCRYPT_RIJNDAEL_128, MCRYPT_MODE_CBC));
            $datas['_RIJNDAEL_IV_'] = base64_encode(mcrypt_create_iv(mcrypt_get_iv_size(MCRYPT_RIJNDAEL_128, MCRYPT_MODE_CBC), MCRYPT_RAND));
         }


### PR DESCRIPTION
On [build.prestashop.com](http://build.prestashop.com/news/prestashop-1-7-3-4-1-6-1-20-maintenance-releases/#comment-3966528433), merchants told us that using PHP 7.2 with PS 1.6.2.0 may bring some issues regarding the RIJNDAEL consts, marked as deprecated.

During the new settings.inc.php generation, we check that openSSL is not available before using mcrypt. This will avoid these deprecation notices.