### PR TITLE
Check subfolder prestashop/ exists in 1.6 releases

### DIFF
--- a/classes/TaskRunner/Upgrade/Unzip.php
+++ b/classes/TaskRunner/Upgrade/Unzip.php
@@ -97,6 +97,12 @@ class Unzip extends AbstractTask
         } else {
             $filesystem = new Filesystem();
             $zipSubfolder = $destExtract.'/prestashop/';
+            if (!is_dir($zipSubfolder)) {
+                $this->next = 'error';
+                $this->logger->error(
+                    $this->translator->trans('No prestashop/ folder found in the ZIP file. Aborting.', array(), 'Modules.Autoupgrade.Admin'));
+                return;
+            }
             // /!\ On PS 1.6, files are unzipped in a subfolder PrestaShop
             foreach (scandir($zipSubfolder) as $file) {
                 if ($file[0] === '.') {


### PR DESCRIPTION
This PR covers a case where a missing `prestashop/` folder in a release ZIP will drop the whole shop.