### PR TITLE
Add placeholder for PrestaShop version

### DIFF
--- a/views/templates/block/upgradeButtonBlock.twig
+++ b/views/templates/block/upgradeButtonBlock.twig
@@ -116,7 +116,7 @@
                                 </select>
                                 <br>
                                 <label for="archive_num">{{ 'Number of the version you want to upgrade to:'|trans }} * </label>
-                                <input type="text" size="10" id="archive_num" name="archive_num" value="{{ archiveVersionNumber }}" />
+                                <input type="text" size="10" id="archive_num" name="archive_num" value="{{ archiveVersionNumber }}" placeholder="1.7.0.1" />
                             </div>
                         {% else %}
                             <div class="alert alert-warning">{{ 'No archive found in your admin/autoupgrade/download directory'|trans }}</div>
@@ -132,7 +132,7 @@
                             {{ 'Save in the following directory the uncompressed PrestaShop files of the version you want to upgrade to: %s'|trans(['<b>/admin/autoupgrade/latest/prestashop/</b>'])|raw }}
                             <br><br>
                             <label for="directory_num">{{ 'Please tell us which version you are upgrading to [1](1.7.0.1 for instance)[/1]'|trans({'[1]': '<small>', '[/1]': '</small>'})|raw }}</label>
-                            <input type="text" size="10" id="directory_num" name="directory_num" value="{{ directoryVersionNumber }}">
+                            <input type="text" size="10" id="directory_num" name="directory_num" value="{{ directoryVersionNumber }}" placeholder="1.7.0.1">
                             <div class="margin-form">
                                 {{ 'Click "Save" once the archive is there.'|trans }}<br>
                                 * {{ 'This option will skip both download and unzip steps and will use %1$s as the source directory'|trans(['<b>/admin/autoupgrade/download/prestashop/</b>'])|raw }}


### PR DESCRIPTION
There were some misunderstanding about the "local archive" of the module. Users didn't understand they had to write the destination version of PrestaShop in a field.

This could get a validator later, but first we just add a placeholder to give an example of expected value.

![capture du 2018-07-09 11-36-49](https://user-images.githubusercontent.com/6768917/42445995-b8dc8894-836c-11e8-9ded-b6a47118f256.png)
