### PR TITLE
Do not clean empty conf values

### DIFF
--- a/classes/TaskRunner/Upgrade/CleanDatabase.php
+++ b/classes/TaskRunner/Upgrade/CleanDatabase.php
@@ -44,9 +44,6 @@ class CleanDatabase extends AbstractTask
             }
         }
 
-        /* Clean configuration integrity */
-        $this->container->getDb()->Execute('DELETE FROM `'._DB_PREFIX_.'configuration_lang` WHERE (`value` IS NULL AND `date_upd` IS NULL) OR `value` LIKE ""', false);
-
         $this->status = 'ok';
         $this->next = 'upgradeComplete';
         $this->logger->info($this->translator->trans('The database has been cleaned.', array(), 'Modules.Autoupgrade.Admin'));


### PR DESCRIPTION
It seems starting with PrestaShop 1.7.3.0, we need to have empty but localized configuration data. See http://forge.prestashop.com/browse/BOOM-5982 for more details.

This conflicts with the integrity check from the upgrade.