### PR TITLE
Fix display of selected archive

### DIFF
--- a/views/templates/block/upgradeButtonBlock.twig
+++ b/views/templates/block/upgradeButtonBlock.twig
@@ -111,7 +111,7 @@
                                     <option value="">{{ 'Choose an archive'|trans }}</option>
                                     {% for file in archiveFiles %}
                                         {% set fileName = file|replace({(downloadPath): ''}) %}
-                                        <option {% if archiveFileName %} selected{% endif %} value="{{ fileName }}">{{ fileName }}</option>
+                                        <option {% if archiveFileName == fileName %} selected{% endif %} value="{{ fileName }}">{{ fileName }}</option>
                                     {% endfor %}
                                 </select>
                                 <br>


### PR DESCRIPTION
Even if the upgrade configuration was properly saved, the latest archive of the list was always selected.