### PR TITLE
Store NULL is backups when NULL is in DB

### DIFF
--- a/classes/TaskRunner/Upgrade/BackupDb.php
+++ b/classes/TaskRunner/Upgrade/BackupDb.php
@@ -219,20 +219,10 @@ class BackupDb extends AbstractTask
                             // this starts a row
                             $s = '(';
                             foreach ($row as $field => $value) {
-                                $tmp = "'".$this->container->getDb()->escape($value, true)."',";
-                                if ($tmp != "'',") {
-                                    $s .= $tmp;
+                                if ($value === null) {
+                                    $s .= 'NULL,';
                                 } else {
-                                    foreach ($lines as $line) {
-                                        if (strpos($line, '`'.$field.'`') !== false) {
-                                            if (preg_match('/(.*NOT NULL.*)/Ui', $line)) {
-                                                $s .= "'',";
-                                            } else {
-                                                $s .= 'NULL,';
-                                            }
-                                            break;
-                                        }
-                                    }
+                                    $s .= "'".$this->container->getDb()->escape($value, true)."',";
                                 }
                             }
                             $s = rtrim($s, ',');


### PR DESCRIPTION
Fixes #106 

The module was trying to guess what value to store in the backup when it was empty, depending on the table structure.

Just stick to the original value, before escape. If it was NULL, store it directly as-is in the backup file.