### PR TITLE
Avoid starting the upgrade when the source folder is not a PrestaShop release

### DIFF
--- a/classes/TaskRunner/Upgrade/RemoveSamples.php
+++ b/classes/TaskRunner/Upgrade/RemoveSamples.php
@@ -47,9 +47,8 @@ class RemoveSamples extends AbstractTask
         // This part runs at the first call of this step
         if (null === $removeList) {
             if (!$this->container->getFilesystemAdapter()->isReleaseValid($latestPath)) {
-                $this->logger->error(
-                    $this->translator->trans('The folder %s does not contain a valid PrestaShop release. Exiting.', array($latestPath), 'Modules.Autoupgrade.Admin')
-                );
+                $this->logger->error($this->translator->trans('Could not assert the folder %s contains a valid PrestaShop release, exiting.', array($latestPath), 'Modules.Autoupgrade.Admin'));
+                $this->logger->error($this->translator->trans('A file may be missing, or the release is stored in a subfolder by mistake.', array(), 'Modules.Autoupgrade.Admin'));
                 $this->next = 'error';
                 return;
             }

--- a/classes/TaskRunner/Upgrade/RemoveSamples.php
+++ b/classes/TaskRunner/Upgrade/RemoveSamples.php
@@ -46,24 +46,32 @@ class RemoveSamples extends AbstractTask
         // remove all sample pics in img subdir
         // This part runs at the first call of this step
         if (null === $removeList) {
+            if (!$this->container->getFilesystemAdapter()->isReleaseValid($latestPath)) {
+                $this->logger->error(
+                    $this->translator->trans('The folder %s does not contain a valid PrestaShop release. Exiting.', array($latestPath), 'Modules.Autoupgrade.Admin')
+                );
+                $this->next = 'error';
+                return;
+            }
+
             $removeList = $this->container->getFilesystemAdapter()->listSampleFilesFromArray(array(
-                array('path' => $latestPath.'/prestashop/img/c', 'filter' => '.jpg'),
-                array('path' => $latestPath.'/prestashop/img/cms', 'filter' => '.jpg'),
-                array('path' => $latestPath.'/prestashop/img/l', 'filter' => '.jpg'),
-                array('path' => $latestPath.'/prestashop/img/m', 'filter' => '.jpg'),
-                array('path' => $latestPath.'/prestashop/img/os', 'filter' => '.jpg'),
-                array('path' => $latestPath.'/prestashop/img/p', 'filter' => '.jpg'),
-                array('path' => $latestPath.'/prestashop/img/s', 'filter' => '.jpg'),
-                array('path' => $latestPath.'/prestashop/img/scenes', 'filter' => '.jpg'),
-                array('path' => $latestPath.'/prestashop/img/st', 'filter' => '.jpg'),
-                array('path' => $latestPath.'/prestashop/img/su', 'filter' => '.jpg'),
-                array('path' => $latestPath.'/prestashop/img', 'filter' => '404.gif'),
-                array('path' => $latestPath.'/prestashop/img', 'filter' => 'favicon.ico'),
-                array('path' => $latestPath.'/prestashop/img', 'filter' => 'logo.jpg'),
-                array('path' => $latestPath.'/prestashop/img', 'filter' => 'logo_stores.gif'),
-                array('path' => $latestPath.'/prestashop/modules/editorial', 'filter' => 'homepage_logo.jpg'),
+                array('path' => $latestPath.'/img/c', 'filter' => '.jpg'),
+                array('path' => $latestPath.'/img/cms', 'filter' => '.jpg'),
+                array('path' => $latestPath.'/img/l', 'filter' => '.jpg'),
+                array('path' => $latestPath.'/img/m', 'filter' => '.jpg'),
+                array('path' => $latestPath.'/img/os', 'filter' => '.jpg'),
+                array('path' => $latestPath.'/img/p', 'filter' => '.jpg'),
+                array('path' => $latestPath.'/img/s', 'filter' => '.jpg'),
+                array('path' => $latestPath.'/img/scenes', 'filter' => '.jpg'),
+                array('path' => $latestPath.'/img/st', 'filter' => '.jpg'),
+                array('path' => $latestPath.'/img/su', 'filter' => '.jpg'),
+                array('path' => $latestPath.'/img', 'filter' => '404.gif'),
+                array('path' => $latestPath.'/img', 'filter' => 'favicon.ico'),
+                array('path' => $latestPath.'/img', 'filter' => 'logo.jpg'),
+                array('path' => $latestPath.'/img', 'filter' => 'logo_stores.gif'),
+                array('path' => $latestPath.'/modules/editorial', 'filter' => 'homepage_logo.jpg'),
                 // remove all override present in the archive
-                array('path' => $latestPath.'/prestashop/override', 'filter' => '.php'),
+                array('path' => $latestPath.'/override', 'filter' => '.php'),
             ));
 
             $this->container->getState()->setRemoveList($removeList);

--- a/classes/TaskRunner/Upgrade/UpgradeFiles.php
+++ b/classes/TaskRunner/Upgrade/UpgradeFiles.php
@@ -222,9 +222,8 @@ class UpgradeFiles extends AbstractTask
     {
         $newReleasePath = $this->container->getProperty(UpgradeContainer::LATEST_PATH);
         if (!$this->container->getFilesystemAdapter()->isReleaseValid($newReleasePath)) {
-            $this->logger->error(
-                $this->translator->trans('The folder %s does not contain a valid PrestaShop release. Exiting.', array($newReleasePath), 'Modules.Autoupgrade.Admin')
-            );
+            $this->logger->error($this->translator->trans('Could not assert the folder %s contains a valid PrestaShop release, exiting.', array($newReleasePath), 'Modules.Autoupgrade.Admin'));
+            $this->logger->error($this->translator->trans('A file may be missing, or the release is stored in a subfolder by mistake.', array(), 'Modules.Autoupgrade.Admin'));
             $this->next = 'error';
             return;
         }

--- a/classes/TaskRunner/Upgrade/UpgradeFiles.php
+++ b/classes/TaskRunner/Upgrade/UpgradeFiles.php
@@ -220,14 +220,23 @@ class UpgradeFiles extends AbstractTask
      */
     protected function warmUp()
     {
-        $admin_dir = str_replace($this->container->getProperty(UpgradeContainer::PS_ROOT_PATH).DIRECTORY_SEPARATOR, '', $this->container->getProperty(UpgradeContainer::PS_ADMIN_PATH));
-        if (file_exists($this->container->getProperty(UpgradeContainer::LATEST_PATH).DIRECTORY_SEPARATOR.'admin')) {
-            rename($this->container->getProperty(UpgradeContainer::LATEST_PATH).DIRECTORY_SEPARATOR.'admin', $this->container->getProperty(UpgradeContainer::LATEST_PATH).DIRECTORY_SEPARATOR.$admin_dir);
-        } elseif (file_exists($this->container->getProperty(UpgradeContainer::LATEST_PATH).DIRECTORY_SEPARATOR.'admin-dev')) {
-            rename($this->container->getProperty(UpgradeContainer::LATEST_PATH).DIRECTORY_SEPARATOR.'admin-dev', $this->container->getProperty(UpgradeContainer::LATEST_PATH).DIRECTORY_SEPARATOR.$admin_dir);
+        $newReleasePath = $this->container->getProperty(UpgradeContainer::LATEST_PATH);
+        if (!$this->container->getFilesystemAdapter()->isReleaseValid($newReleasePath)) {
+            $this->logger->error(
+                $this->translator->trans('The folder %s does not contain a valid PrestaShop release. Exiting.', array($newReleasePath), 'Modules.Autoupgrade.Admin')
+            );
+            $this->next = 'error';
+            return;
         }
-        if (file_exists($this->container->getProperty(UpgradeContainer::LATEST_PATH).DIRECTORY_SEPARATOR.'install-dev')) {
-            rename($this->container->getProperty(UpgradeContainer::LATEST_PATH).DIRECTORY_SEPARATOR.'install-dev', $this->container->getProperty(UpgradeContainer::LATEST_PATH).DIRECTORY_SEPARATOR.'install');
+
+        $admin_dir = str_replace($this->container->getProperty(UpgradeContainer::PS_ROOT_PATH).DIRECTORY_SEPARATOR, '', $this->container->getProperty(UpgradeContainer::PS_ADMIN_PATH));
+        if (file_exists($newReleasePath.DIRECTORY_SEPARATOR.'admin')) {
+            rename($newReleasePath.DIRECTORY_SEPARATOR.'admin', $newReleasePath.DIRECTORY_SEPARATOR.$admin_dir);
+        } elseif (file_exists($newReleasePath.DIRECTORY_SEPARATOR.'admin-dev')) {
+            rename($newReleasePath.DIRECTORY_SEPARATOR.'admin-dev', $newReleasePath.DIRECTORY_SEPARATOR.$admin_dir);
+        }
+        if (file_exists($newReleasePath.DIRECTORY_SEPARATOR.'install-dev')) {
+            rename($newReleasePath.DIRECTORY_SEPARATOR.'install-dev', $newReleasePath.DIRECTORY_SEPARATOR.'install');
         }
 
         // list saved in UpgradeFileNames::toUpgradeFileList
@@ -248,7 +257,8 @@ class UpgradeFiles extends AbstractTask
             } // do not replace by DIRECTORY_SEPARATOR
         }
 
-        if (!($list_files_to_upgrade = $this->listFilesToUpgrade($this->container->getProperty(UpgradeContainer::LATEST_PATH)))) {
+        $list_files_to_upgrade = $this->listFilesToUpgrade($newReleasePath);
+        if (false === $list_files_to_upgrade) {
             return false;
         }
 

--- a/classes/UpgradeTools/FilesystemAdapter.php
+++ b/classes/UpgradeTools/FilesystemAdapter.php
@@ -39,6 +39,23 @@ class FilesystemAdapter
     private $adminSubDir;
     private $prodRootDir;
 
+    /**
+     * Somes elements to find in a folder.
+     * If one of them cannot be found, we can consider that the release is invalid.
+     *
+     * @var array
+     */
+    private $releaseFileChecks = array(
+        'files' => array(
+            'index.php',
+            'config/defines.inc.php',
+        ),
+        'folders' => array(
+            'classes',
+            'controllers',
+        ),
+    );
+
     public function __construct(FileFilter $fileFilter, $restoreFilesFilename,
         $autoupgradeDir, $adminSubDir, $prodRootDir)
     {
@@ -237,5 +254,27 @@ class FilesystemAdapter
         }
         // by default, don't skip
         return false;
+    }
+
+    /**
+     * Check a directory has some files available in every release of PrestaShop
+     *
+     * @param string $path Workspace to check
+     * @return boolean
+     */
+    public function isReleaseValid($path)
+    {
+        foreach($this->releaseFileChecks as $type => $elements) {
+            foreach ($elements as $element) {
+                $fullPath = $path . DIRECTORY_SEPARATOR . $element;
+                if ('files' === $type && !is_file($fullPath)) {
+                    return false;
+                }
+                if ('folders' === $type && !is_dir($fullPath)) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 }

--- a/tests/FilesystemAdapterTest.php
+++ b/tests/FilesystemAdapterTest.php
@@ -93,4 +93,48 @@ class FilesystemAdapterTest extends TestCase
             array('parameters.yml.dist', '/app/config/parameters.yml.dist', 'upgrade'),
         );
     }
+
+    public function testRandomFolderIsNotAPrestashopRelease()
+    {
+        $this->assertFalse(
+            $this->filesystemAdapter->isReleaseValid(__DIR__)
+        );
+    }
+
+    public function testTempFolderIsAPrestashopRelease()
+    {
+        // Create temp folder and fill it with the needed files
+        $folder = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'PSA' . rand(100, 2000);
+        $this->fillFolderWithPsAssets($folder);
+
+        $this->assertTrue(
+            $this->filesystemAdapter->isReleaseValid($folder)
+        );
+    }
+
+    /**
+     * Weird case where we have a file instead of a folder
+     */
+    public function testTempFolderIsNotAPrestashopReleaseAfterChanges()
+    {
+        // Create temp folder and fill it with the needed files
+        $folder = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'PSA' . rand(100, 2000);
+        $this->fillFolderWithPsAssets($folder);
+        rmdir($folder . DIRECTORY_SEPARATOR . 'classes');
+        touch($folder . DIRECTORY_SEPARATOR . 'classes');
+
+        $this->assertFalse(
+            $this->filesystemAdapter->isReleaseValid($folder)
+        );
+    }
+
+    protected function fillFolderWithPsAssets($folder)
+    {
+        mkdir($folder);
+        mkdir($folder . DIRECTORY_SEPARATOR . 'classes');
+        mkdir($folder . DIRECTORY_SEPARATOR . 'config');
+        touch($folder . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'defines.inc.php');
+        mkdir($folder . DIRECTORY_SEPARATOR . 'controllers');
+        touch($folder . DIRECTORY_SEPARATOR . 'index.php');
+    }
 }

--- a/views/templates/block/upgradeButtonBlock.twig
+++ b/views/templates/block/upgradeButtonBlock.twig
@@ -129,13 +129,13 @@
                     </div>
                     <div id="for-useDirectory">
                         <div>
-                            {{ 'Save in the following directory the uncompressed PrestaShop files of the version you want to upgrade to: %s'|trans(['<b>/admin/autoupgrade/latest/prestashop/</b>'])|raw }}
+                            {{ 'Save in the following directory the uncompressed PrestaShop files of the version you want to upgrade to: %s'|trans(['<b>/admin/autoupgrade/latest/</b>'])|raw }}
                             <br><br>
                             <label for="directory_num">{{ 'Please tell us which version you are upgrading to [1](1.7.0.1 for instance)[/1]'|trans({'[1]': '<small>', '[/1]': '</small>'})|raw }}</label>
                             <input type="text" size="10" id="directory_num" name="directory_num" value="{{ directoryVersionNumber }}" placeholder="1.7.0.1">
                             <div class="margin-form">
                                 {{ 'Click "Save" once the archive is there.'|trans }}<br>
-                                * {{ 'This option will skip both download and unzip steps and will use %1$s as the source directory'|trans(['<b>/admin/autoupgrade/download/prestashop/</b>'])|raw }}
+                                * {{ 'This option will skip both download and unzip steps and will use %1$s as the source directory'|trans(['<b>/admin/autoupgrade/latest/</b>'])|raw }}
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
While testing with the option "Local folder", it appeared the given folder was incorrect. Following the text made the shop being deleted. :fearful: 

This PR fixes the directory displayed, and adds a check verifying we have a PrestaShop release in a given folder. This will prevent an upgrade to run if the content is copied in a subfolder for instance.

![capture du 2018-07-23 18-14-09](https://user-images.githubusercontent.com/6768917/43089198-5a1d76ae-8ea4-11e8-8480-01a8ee7d75a7.png)
