### PR TITLE
Store hidden files in backups

### DIFF
--- a/classes/UpgradeTools/FilesystemAdapter.php
+++ b/classes/UpgradeTools/FilesystemAdapter.php
@@ -94,7 +94,7 @@ class FilesystemAdapter
             if (is_link($fullPath) && !is_readable($fullPath)) {
                 continue;
             }
-            if ($file[0] == '.' || $this->isFileSkipped($file, $fullPath, $way)) {
+            if ($this->isFileSkipped($file, $fullPath, $way)) {
                 continue;
             }
             if (is_dir($fullPath)) {


### PR DESCRIPTION
Files like .htaccess must be stored in backups, or restores won't bring shops at their previous state.