### PR TITLE
Force composer autoload to be appended

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
   },
   "config": {
     "preferred-install": "dist",
+    "prepend-autoloader": false,
     "platform": {
         "php": "5.6"
     }


### PR DESCRIPTION
To avoid core libraries to be overridden, we append the module autoloader instead of preppending it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/autoupgrade/132)
<!-- Reviewable:end -->
