### PR TITLE
Fix undefined class Tools

### DIFF
--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader16.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader16.php
@@ -64,10 +64,10 @@ class CoreUpgrader16 extends CoreUpgrader
             $datas['_RIJNDAEL_KEY_'] = _RIJNDAEL_KEY_;
             $datas['_RIJNDAEL_IV_'] = _RIJNDAEL_IV_;
         } elseif (function_exists('openssl_encrypt')) {
-            $datas['_RIJNDAEL_KEY_'] = Tools::passwdGen(32);
+            $datas['_RIJNDAEL_KEY_'] = Tools14::passwdGen(32);
             $datas['_RIJNDAEL_IV_'] = base64_encode(openssl_random_pseudo_bytes(openssl_cipher_iv_length('AES-128-CBC')));
         } elseif (function_exists('mcrypt_encrypt')) {
-            $datas['_RIJNDAEL_KEY_'] = Tools::passwdGen(mcrypt_get_key_size(MCRYPT_RIJNDAEL_128, MCRYPT_MODE_CBC));
+            $datas['_RIJNDAEL_KEY_'] = Tools14::passwdGen(mcrypt_get_key_size(MCRYPT_RIJNDAEL_128, MCRYPT_MODE_CBC));
             $datas['_RIJNDAEL_IV_'] = base64_encode(mcrypt_create_iv(mcrypt_get_iv_size(MCRYPT_RIJNDAEL_128, MCRYPT_MODE_CBC), MCRYPT_RAND));
         }
 


### PR DESCRIPTION
Fixes #140 

The class defined in the file `CoreUpgrader16` is `Tools14`. Calling `Tools` instead was throwing errors during an upgrade.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/autoupgrade/141)
<!-- Reviewable:end -->
