### PR TITLE
Revert "Force composer autoload to be appended"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
   },
   "config": {
     "preferred-install": "dist",
-    "prepend-autoloader": false,
     "platform": {
         "php": "5.6"
     }


### PR DESCRIPTION
Reverts PrestaShop/autoupgrade#136

Saw on PrestaShop 1.6.0.4. Fixes 
```
 Fatal error: require(): Failed opening required '/var/www/html/' (include_path='.:/usr/local/lib/php') in /var/www/html/classes/PrestaShopAutoload.php on line 121
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/autoupgrade/144)
<!-- Reviewable:end -->
