### PR TITLE
Check bootstrap.php before require

### DIFF
--- a/classes/TaskRunner/Rollback/RestoreDb.php
+++ b/classes/TaskRunner/Rollback/RestoreDb.php
@@ -254,6 +254,8 @@ class RestoreDb extends AbstractTask
         $this->container->initPrestaShopAutoloader();
 
         // Loads the parameters.php file on PrestaShop 1.7, needed for accessing the database
-        require_once $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH).'/config/bootstrap.php';
+        if (file_exists($this->container->getProperty(UpgradeContainer::PS_ROOT_PATH).'/config/bootstrap.php')) {
+            require_once $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH).'/config/bootstrap.php';
+        }
     }
 }


### PR DESCRIPTION
On the first versions of PS 1.6, the file `bootstrap.php` does not exist. We add a check to prevent a fatal error during a restore.

To be done later: Implement a method checking and requiring a file for us.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/autoupgrade/145)
<!-- Reviewable:end -->
