### PR TITLE
Fix ignored files outside shop folder

### DIFF
--- a/classes/TaskRunner/Upgrade/UpgradeFiles.php
+++ b/classes/TaskRunner/Upgrade/UpgradeFiles.php
@@ -111,7 +111,7 @@ class UpgradeFiles extends AbstractTask
         foreach ($allFiles as $file) {
             $fullPath = $dir.DIRECTORY_SEPARATOR.$file;
 
-            if ($this->container->getFilesystemAdapter()->isFileSkipped($file, $fullPath, 'upgrade')) {
+            if ($this->container->getFilesystemAdapter()->isFileSkipped($file, $fullPath, 'upgrade', $this->container->getProperty(UpgradeContainer::LATEST_PATH))) {
                 if (!in_array($file, array('.', '..'))) {
                     $this->logger->debug($this->translator->trans('File %s is preserved', array($file), 'Modules.Autoupgrade.Admin'));
                 }

--- a/classes/UpgradeTools/FileFilter.php
+++ b/classes/UpgradeTools/FileFilter.php
@@ -118,7 +118,7 @@ class FileFilter
 
         // this will exclude autoupgrade dir from admin, and autoupgrade from modules
         // If set to false, we need to preserve the default themes
-        if (!$this->configuration->get('PS_AUTOUP_UPDATE_DEFAULT_THEME')) {
+        if (!$this->configuration->shouldUpdateDefaultTheme()) {
             $excludeAbsoluteFilesFromUpgrade[] = '/themes/classic';
         }
 

--- a/classes/UpgradeTools/FileFilter.php
+++ b/classes/UpgradeTools/FileFilter.php
@@ -120,6 +120,7 @@ class FileFilter
         // If set to false, we need to preserve the default themes
         if (!$this->configuration->shouldUpdateDefaultTheme()) {
             $excludeAbsoluteFilesFromUpgrade[] = '/themes/classic';
+            $excludeAbsoluteFilesFromUpgrade[] = '/themes/default-bootstrap';
         }
 
         return $excludeAbsoluteFilesFromUpgrade;

--- a/classes/UpgradeTools/FilesystemAdapter.php
+++ b/classes/UpgradeTools/FilesystemAdapter.php
@@ -199,59 +199,40 @@ class FilesystemAdapter
     /**
      *	bool _skipFile : check whether a file is in backup or restore skip list.
      *
-     * @param type $file     : current file or directory name eg:'.svn' , 'settings.inc.php'
-     * @param type $fullpath : current file or directory fullpath eg:'/home/web/www/prestashop/app/config/parameters.php'
-     * @param type $way      : 'backup' , 'upgrade'
+     * @param string $file     : current file or directory name eg:'.svn' , 'settings.inc.php'
+     * @param string $fullpath : current file or directory fullpath eg:'/home/web/www/prestashop/app/config/parameters.php'
+     * @param string $way      : 'backup' , 'upgrade'
+     * @param string $temporaryWorkspace : If needed, another folder than the shop root can be used (used for releases)
      */
-    public function isFileSkipped($file, $fullpath, $way = 'backup')
+    public function isFileSkipped($file, $fullpath, $way = 'backup', $temporaryWorkspace = null)
     {
         $fullpath = str_replace('\\', '/', $fullpath); // wamp compliant
-        $rootpath = str_replace('\\', '/', $this->prodRootDir);
-        switch ($way) {
-            case 'backup':
-                if (in_array($file, $this->fileFilter->getExcludeFiles())) {
-                    return true;
-                }
-
-                foreach ($this->fileFilter->getFilesToIgnoreOnBackup() as $path) {
-                    $path = str_replace(DIRECTORY_SEPARATOR.'admin', DIRECTORY_SEPARATOR.$this->adminSubDir, $path);
-                    if ($fullpath === $rootpath.$path) {
-                        return true;
-                    }
-                }
-                break;
-                // restore or upgrade way : ignore the same files
-                // note the restore process use skipFiles only if xml md5 files
-                // are unavailable
-            case 'restore':
-                if (in_array($file, $this->fileFilter->getExcludeFiles())) {
-                    return true;
-                }
-
-                foreach ($this->fileFilter->getFilesToIgnoreOnRestore() as $path) {
-                    $path = str_replace(DIRECTORY_SEPARATOR.'admin', DIRECTORY_SEPARATOR.$this->adminSubDir, $path);
-                    if ($fullpath === $rootpath.$path) {
-                        return true;
-                    }
-                }
-                break;
-            case 'upgrade':
-                if (in_array($file, $this->fileFilter->getExcludeFiles())) {
-                    return true;
-                }
-
-                foreach ($this->fileFilter->getFilesToIgnoreOnUpgrade() as $path) {
-                    $path = str_replace(DIRECTORY_SEPARATOR.'admin', DIRECTORY_SEPARATOR.$this->adminSubDir, $path);
-                    if ($fullpath === $rootpath.$path) {
-                        return true;
-                    }
-                }
-
-                break;
-                // default : if it's not a backup or an upgrade, do not skip the file
-            default:
-                return false;
+        if (null !== $temporaryWorkspace) {
+            $rootpath = str_replace('\\', '/', $temporaryWorkspace);
+        } else {
+            $rootpath = str_replace('\\', '/', $this->prodRootDir);
         }
+
+        if (in_array($file, $this->fileFilter->getExcludeFiles())) {
+            return true;
+        }
+
+        $ignoreList = array();
+        if ('backup' === $way) {
+            $ignoreList = $this->fileFilter->getFilesToIgnoreOnBackup();
+        } elseif ('restore' === $way) {
+            $ignoreList = $this->fileFilter->getFilesToIgnoreOnRestore();
+        } elseif ('upgrade' === $way) {
+            $ignoreList = $this->fileFilter->getFilesToIgnoreOnUpgrade();
+        }
+
+        foreach ($ignoreList as $path) {
+            $path = str_replace(DIRECTORY_SEPARATOR.'admin', DIRECTORY_SEPARATOR.$this->adminSubDir, $path);
+            if ($fullpath === $rootpath . $path) {
+                return true;
+            }
+        }
+
         // by default, don't skip
         return false;
     }

--- a/tests/FilesystemAdapterTest.php
+++ b/tests/FilesystemAdapterTest.php
@@ -37,6 +37,8 @@ class FilesystemAdapterTest extends TestCase
     {
         parent::setUp();
         $this->container = new UpgradeContainer('/html', '/html/admin');
+        // We expect in these tests to NOT update the theme
+        $this->container->getUpgradeConfiguration()->set('PS_AUTOUP_UPDATE_DEFAULT_THEME', false);
         $this->filesystemAdapter = $this->container->getFilesystemAdapter();
     }
 
@@ -50,6 +52,22 @@ class FilesystemAdapterTest extends TestCase
             $this->filesystemAdapter->isFileSkipped(
                 $file,
                 $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH).$fullpath,
+                $process));
+    }
+
+    /**
+     * When we list the files to get from a release, we are not working in the current shop.
+     * Paths mismatch but we should expect the same results.
+     *
+     * @dataProvider ignoredFilesProvider
+     */
+    public function testFileFromReleaseIsIgnored($file, $fullpath, $process)
+    {
+        $this->assertSame(
+            true,
+            $this->filesystemAdapter->isFileSkipped(
+                $file,
+                $this->container->getProperty(UpgradeContainer::LATEST_PATH).$fullpath,
                 $process));
     }
 
@@ -80,6 +98,8 @@ class FilesystemAdapterTest extends TestCase
             array('autoupgrade', '/modules/autoupgrade', 'backup'),
 
             array('parameters.yml', '/app/config/parameters.yml', 'upgrade'),
+
+            array('classic', '/themes/classic', 'upgrade'),
         );
     }
 

--- a/tests/FilesystemAdapterTest.php
+++ b/tests/FilesystemAdapterTest.php
@@ -68,7 +68,9 @@ class FilesystemAdapterTest extends TestCase
             $this->filesystemAdapter->isFileSkipped(
                 $file,
                 $this->container->getProperty(UpgradeContainer::LATEST_PATH).$fullpath,
-                $process));
+                $process,
+                $this->container->getProperty(UpgradeContainer::LATEST_PATH)
+            ));
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/PrestaShop/autoupgrade/issues/159

When checking the files to ignore during the process, using the temporary folder where release are stored make the results wrong. That was caused by a file path strict check from the filesystem root.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/autoupgrade/160)
<!-- Reviewable:end -->
