### PR TITLE
Use install autoloader for classes in install/

### DIFF
--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -186,6 +186,10 @@ abstract class CoreUpgrader
         if (!defined('_THEMES_DIR_')) {
             define('_THEMES_DIR_', __PS_BASE_URI__.'themes/');
         }
+
+        if (file_exists(INSTALL_PATH . DIRECTORY_SEPARATOR . 'autoload.php')) {
+            require_once INSTALL_PATH . DIRECTORY_SEPARATOR . 'autoload.php';
+        }
         $this->db = \Db::getInstance();
     }
 


### PR DESCRIPTION
Fixes #158, where some classes could not be found because not handled by the core autoloader.

From now, we also load the install autoloader to use the classes present in the install/ folder.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/autoupgrade/163)
<!-- Reviewable:end -->
