### PR TITLE
Use _PS_ROOT_DIR_ in autoload paths

### DIFF
--- a/AdminSelfUpgrade.php
+++ b/AdminSelfUpgrade.php
@@ -35,7 +35,7 @@ use PrestaShop\Module\AutoUpgrade\Tools14;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\FilesystemAdapter;
 
-require __DIR__ . '/vendor/autoload.php';
+require_once _PS_ROOT_DIR_ . '/modules/autoupgrade/vendor/autoload.php';
 
 class AdminSelfUpgrade extends AdminController
 {

--- a/autoupgrade.php
+++ b/autoupgrade.php
@@ -24,9 +24,9 @@
  *  @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  *  International Registered Trademark & Property of PrestaShop SA
  */
-require __DIR__ . '/vendor/autoload.php';
+require_once _PS_ROOT_DIR_ . '/modules/autoupgrade/vendor/autoload.php';
 
-class autoupgrade extends Module
+class Autoupgrade extends Module
 {
     public function __construct()
     {


### PR DESCRIPTION
Avoid "Already registered autoload class" when used with symlink

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/autoupgrade/166)
<!-- Reviewable:end -->
