### PR TITLE
Allow users to ignore the PrestaShop requirements which can be incomplete

### DIFF
--- a/AdminSelfUpgrade.php
+++ b/AdminSelfUpgrade.php
@@ -289,6 +289,10 @@ class AdminSelfUpgrade extends AdminController
             Configuration::updateGlobalValue('PS_SHOP_ENABLE', 0);
         }
 
+        if (Tools14::isSubmit('ignorePsRequirements')) {
+            Configuration::updateValue('PS_AUTOUP_IGNORE_REQS', 1);
+        }
+
         if (Tools14::isSubmit('customSubmitAutoUpgrade')) {
             $config_keys = array_keys(array_merge($this->_fieldsUpgradeOptions, $this->_fieldsBackupOptions));
             $config = array();

--- a/classes/TaskRunner/Upgrade/UpgradeComplete.php
+++ b/classes/TaskRunner/Upgrade/UpgradeComplete.php
@@ -31,6 +31,8 @@ use PrestaShop\Module\AutoUpgrade\TaskRunner\AbstractTask;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\FilesystemAdapter;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 
+use Configuration;
+
 /**
  * Ends the upgrade process and displays the success message.
  */
@@ -58,5 +60,8 @@ class UpgradeComplete extends AbstractTask
         }
 
         $this->container->getSymfonyAdapter()->clearMigrationCache();
+
+        // Reinit config
+        Configuration::deleteByName('PS_AUTOUP_IGNORE_REQS');
     }
 }

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -217,7 +217,7 @@ class UpgradeSelfCheck
 
     public function isPrestaShopReady()
     {
-        return $this->prestashopReady;
+        return $this->prestashopReady || 1 === Configuration::get('PS_AUTOUP_IGNORE_REQS');
     }
 
     /**

--- a/views/templates/block/checklist.twig
+++ b/views/templates/block/checklist.twig
@@ -119,7 +119,12 @@
                         {% if isPrestaShopReady %}
                             {{ 'PrestaShop requirements are satisfied. '|trans }}
                         {% else %}
-                            {{ 'PrestaShop requirements are not satisfied. '|trans }} <a href="{{ informationsLink }}">{{ 'See details.'|trans }}</a>
+                            {{ 'PrestaShop requirements are not satisfied. [1]See details[/1] or [2]ignore[/2].'|trans({
+                                '[1]': '<a href="' ~ informationsLink ~'">',
+                                '[/1]': '</a>',
+                                '[2]': '<a href="' ~ currentIndex ~ '&token=' ~ token ~ '&ignorePsRequirements=1">',
+                                '[/2]': '</a>',
+                            })|raw }}
                         {% endif %}
                     </td>
                     <td>


### PR DESCRIPTION
This PR makes the PrestaShop requirements optional, because of known issues on the Information Page

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/autoupgrade/167)
<!-- Reviewable:end -->
