### PR TITLE
Prevent installation on old PHP versions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,6 +5,11 @@
 Provides an automated method to upgrade your shop to the latest version of PrestaShop.
 This module is compatible with all PrestaShop 1.6 & 1.7.
 
+# Prerequisites
+
+* PrestaShop 1.6 or 1.7
+* PHP 5.6+
+
 # Installation
 
 You must have [composer][4] installed on your computer. Then, execute:

--- a/autoupgrade.php
+++ b/autoupgrade.php
@@ -24,8 +24,6 @@
  *  @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  *  International Registered Trademark & Property of PrestaShop SA
  */
-require_once _PS_ROOT_DIR_ . '/modules/autoupgrade/vendor/autoload.php';
-
 class Autoupgrade extends Module
 {
     public function __construct()
@@ -57,6 +55,11 @@ class Autoupgrade extends Module
 
     public function install()
     {
+        if (50600 > PHP_VERSION_ID) {
+            $this->_errors[] = $this->trans('This version of 1-click upgrade requires PHP 5.6 to work properly. Please upgrade your server configuration.', array(), 'Modules.Autoupgrade.Admin');
+            return false;
+        }
+
         if (defined('_PS_HOST_MODE_') && _PS_HOST_MODE_) {
             return false;
         }
@@ -198,6 +201,9 @@ class Autoupgrade extends Module
      */
     public function trans($id, array $parameters = array(), $domain = null, $locale = null)
     {
-        return (new \PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator(get_class()))->trans($id, $parameters, $domain, $locale);
+        require_once _PS_ROOT_DIR_ . '/modules/autoupgrade/classes/UpgradeTools/Translator.php';
+
+        $translator = new \PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator(get_class());
+        return $translator->trans($id, $parameters, $domain, $locale);
     }
 }

--- a/classes/UpgradeTools/Translator.php
+++ b/classes/UpgradeTools/Translator.php
@@ -39,15 +39,15 @@ class Translator
     public function trans($id, array $parameters = array(), $domain = null, $locale = null)
     {
         // If PrestaShop core is not instancied properly, do not try to translate
-        if (!method_exists(\Context::class, 'getContext') || null === \Context::getContext()->language) {
+        if (!method_exists('\Context', 'getContext') || null === \Context::getContext()->language) {
             return $this->applyParameters($id, $parameters);
         }
 
-        if (method_exists(\Context::class, 'getTranslator')) {
+        if (method_exists('\Context', 'getTranslator')) {
             return \Context::getContext()->getTranslator()->trans($id, $parameters, $domain, $locale);
         }
 
-        if (method_exists(\Translate::class, 'getModuleTranslation')) {
+        if (method_exists('\Translate', 'getModuleTranslation')) {
             $translated = \Translate::getModuleTranslation('autoupgrade', $id, $this->caller, null);
             if (!count($parameters)) {
                 return $translated;

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": ">=5.4",
+    "php": ">=5.6",
     "symfony/filesystem": "~2.8",
     "doctrine/collections": "~1.3.0",
     "twig/twig": "^1.35",


### PR DESCRIPTION
Fixes #170 

This PR fixes the syntax errors on very old versions of PHP, but prevent its installation on the concerned shops.

![capture du 2018-09-13 10-43-38](https://user-images.githubusercontent.com/6768917/45480843-e35bc680-b741-11e8-9dfc-b23c42c8ee6a.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/autoupgrade/171)
<!-- Reviewable:end -->
