### PR TITLE
Avoid storing whole file content in memory

### DIFF
--- a/classes/Upgrader.php
+++ b/classes/Upgrader.php
@@ -27,6 +27,8 @@
 
 namespace PrestaShop\Module\AutoUpgrade;
 
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Exception\IOException;
 use Configuration;
 
 class Upgrader
@@ -104,7 +106,14 @@ class Upgrader
 
         $destPath = realpath($dest) . DIRECTORY_SEPARATOR . $filename;
 
-        Tools14::copy($this->link, $destPath);
+        try {
+            $filesystem = new Filesystem();
+            $filesystem->copy($this->link, $destPath);
+        } catch (IOException $e) {
+            // If the Symfony filesystem failed, we can try with
+            // the legacy method which uses curl.
+            Tools14::copy($this->link, $destPath);
+        }
 
         return is_file($destPath);
     }


### PR DESCRIPTION
Reported in https://github.com/PrestaShop/PrestaShop/issues/11409

The download of the PrestaShop release was stored in the memory, which threw exception on small configuration. This updates the process to use a buffer instead.