### PR TITLE
Display a notice if PHP is below v7.1

### DIFF
--- a/AdminSelfUpgrade.php
+++ b/AdminSelfUpgrade.php
@@ -333,27 +333,6 @@ class AdminSelfUpgrade extends AdminController
         parent::postProcess();
     }
 
-    /**
-     * update module configuration (saved in file UpgradeFiles::configFilename) with $new_config.
-     *
-     * @param array $new_config
-     *
-     * @return bool true if success
-     */
-//    public function writeConfig($config)
-//    {
-//        if (!$this->upgradeContainer->getFileConfigurationStorage()->exists(UpgradeFileNames::configFilename) && !empty($config['channel'])) {
-//            $this->upgradeContainer->getUpgrader()->channel = $config['channel'];
-//            $this->upgradeContainer->getUpgrader()->checkPSVersion();
-//
-//            $this->upgradeContainer->getState()->setInstallVersion($this->upgradeContainer->getUpgrader()->version_num);
-//        }
-//
-//        $this->upgradeContainer->getUpgradeConfiguration()->merge($config);
-//        $this->upgradeContainer->getLogger()->info($this->trans('Configuration successfully updated.', array(), 'Modules.Autoupgrade.Admin').' <strong>'.$this->trans('This page will now be reloaded and the module will check if a new version is available.', array(), 'Modules.Autoupgrade.Admin').'</strong>');
-//        return (new UpgradeConfigurationStorage($this->autoupgradePath.DIRECTORY_SEPARATOR))->save($this->upgradeContainer->getUpgradeConfiguration(), UpgradeFileNames::configFilename);
-//    }
-
     public function display()
     {
         // Make sure the user has configured the upgrade options, or set default values

--- a/AdminSelfUpgrade.php
+++ b/AdminSelfUpgrade.php
@@ -293,6 +293,10 @@ class AdminSelfUpgrade extends AdminController
             Configuration::updateValue('PS_AUTOUP_IGNORE_REQS', 1);
         }
 
+        if (Tools14::isSubmit('ignorePhpOutdated')) {
+            Configuration::updateValue('PS_AUTOUP_IGNORE_PHP_UPGRADE', 1);
+        }
+
         if (Tools14::isSubmit('customSubmitAutoUpgrade')) {
             $config_keys = array_keys(array_merge($this->_fieldsUpgradeOptions, $this->_fieldsBackupOptions));
             $config = array();

--- a/autoupgrade.php
+++ b/autoupgrade.php
@@ -159,13 +159,15 @@ class Autoupgrade extends Module
     {
         if ($this->registerHook($hookName)) {
             // Update module position in Dashboard
-            $query = "SELECT id_hook FROM "._DB_PREFIX_."hook WHERE name = '" . pSQL($hookName) . "'";
+            $query = 'SELECT id_hook FROM ' . _DB_PREFIX_ . "hook WHERE name = '" . pSQL($hookName) . "'";
             $result = Db::getInstance()->ExecuteS($query);
             $id_hook = $result['0']['id_hook'];
 
             $this->updatePosition((int) $id_hook, 0);
+
             return true;
         }
+
         return false;
     }
 
@@ -188,15 +190,15 @@ class Autoupgrade extends Module
             return false;
         }
 
-        $this->context->controller->addCSS($this->_path.'/css/styles.css');
-        $this->context->controller->addJS($this->_path.'/js/dashboard.js');
+        $this->context->controller->addCSS($this->_path . '/css/styles.css');
+        $this->context->controller->addJS($this->_path . '/js/dashboard.js');
 
         $this->context->smarty->assign([
             'ignore_link' => Context::getContext()->link->getAdminLink('AdminSelfUpgrade') . '&ignorePhpOutdated=1',
             'learn_more_link' => 'http://build.prestashop.com/news/announcing-end-of-support-for-obsolete-php-versions/',
         ]);
 
-        return $this->context->smarty->fetch($this->local_path.'views/templates/hook/dashboard_zone_one.tpl');
+        return $this->context->smarty->fetch($this->local_path . 'views/templates/hook/dashboard_zone_one.tpl');
     }
 
     public function getContent()

--- a/autoupgrade.php
+++ b/autoupgrade.php
@@ -155,20 +155,16 @@ class Autoupgrade extends Module
         return parent::uninstall();
     }
 
+    /**
+     * Register the current module to a given hook and moves it at the first position.
+     *
+     * @param string $hookName
+     *
+     * @return bool
+     */
     private function registerHookAndSetToTop($hookName)
     {
-        if ($this->registerHook($hookName)) {
-            // Update module position in Dashboard
-            $query = 'SELECT id_hook FROM ' . _DB_PREFIX_ . "hook WHERE name = '" . pSQL($hookName) . "'";
-            $result = Db::getInstance()->ExecuteS($query);
-            $id_hook = $result['0']['id_hook'];
-
-            $this->updatePosition((int) $id_hook, 0);
-
-            return true;
-        }
-
-        return false;
+        return $this->registerHook($hookName) && $this->updatePosition((int) Hook::getIdByName($hookName), 0);
     }
 
     public function hookDashboardZoneOne($params)

--- a/autoupgrade.php
+++ b/autoupgrade.php
@@ -193,7 +193,7 @@ class Autoupgrade extends Module
 
         $this->context->smarty->assign([
             'ignore_link' => Context::getContext()->link->getAdminLink('AdminSelfUpgrade') . '&ignorePhpOutdated=1',
-            'learn_more_link' => $upgradeNotice,
+            'learn_more_link' => 'http://build.prestashop.com/news/announcing-end-of-support-for-obsolete-php-versions/',
         ]);
 
         return $this->context->smarty->fetch($this->local_path.'views/templates/hook/dashboard_zone_one.tpl');

--- a/autoupgrade.php
+++ b/autoupgrade.php
@@ -174,7 +174,7 @@ class Autoupgrade extends Module
 
         $upgradeContainer = new \PrestaShop\Module\AutoUpgrade\UpgradeContainer(_PS_ROOT_DIR_, _PS_ADMIN_DIR_);
         $upgrader = $upgradeContainer->getUpgrader();
-        $upgradeSelfCheck = new  \PrestaShop\Module\AutoUpgrade\UpgradeSelfCheck(
+        $upgradeSelfCheck = new \PrestaShop\Module\AutoUpgrade\UpgradeSelfCheck(
             $upgrader,
             _PS_ROOT_DIR_,
             _PS_ADMIN_DIR_,
@@ -183,7 +183,7 @@ class Autoupgrade extends Module
 
         $upgradeNotice = $upgradeSelfCheck->isPhpUpgradeRequired();
         if (false === $upgradeNotice) {
-            return false;
+            return '';
         }
 
         $this->context->controller->addCSS($this->_path . '/css/styles.css');

--- a/classes/Twig/Block/UpgradeChecklist.php
+++ b/classes/Twig/Block/UpgradeChecklist.php
@@ -127,6 +127,7 @@ class UpgradeChecklist
             'token' => $this->token,
             'cachingIsDisabled' => $this->selfCheck->isCacheDisabled(),
             'maxExecutionTime' => $this->selfCheck->getMaxExecutionTime(),
+            'phpUpgradeRequired' => $this->selfCheck->isPhpUpgradeRequired(),
             'isPrestaShopReady' => $this->selfCheck->isPrestaShopReady(),
         );
 

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -98,9 +98,9 @@ class UpgradeSelfCheck
     private $maxExecutionTime;
 
     /**
-     * False if PHP version is maintained, url to a website otherxise.
+     * Warning flag for an old running PHP server.
      *
-     * @var bool|string
+     * @var bool
      */
     private $phpUpgradeNoticelink;
 

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -99,7 +99,7 @@ class UpgradeSelfCheck
 
     /**
      * False if PHP version is maintained, url to a website otherxise.
-     * 
+     *
      * @var bool|string
      */
     private $phpUpgradeNoticelink;
@@ -118,21 +118,24 @@ class UpgradeSelfCheck
      * @var Upgrader
      */
     private $upgrader;
-    
+
     /**
      * Path to the root folder of PS
+     *
      * @var string
      */
     private $prodRootPath;
 
     /**
      * Path to the admin folder of PS
+     *
      * @var string
      */
     private $adminPath;
 
     /**
      * Path to the root folder of the upgrade module
+     *
      * @var string
      */
     private $autoUpgradePath;
@@ -242,7 +245,7 @@ class UpgradeSelfCheck
             return $this->safeModeDisabled;
         }
 
-        return $this->safeModeDisabled = $this->checkSafeModeIsDisabled();;
+        return $this->safeModeDisabled = $this->checkSafeModeIsDisabled();
     }
 
     /**
@@ -268,6 +271,7 @@ class UpgradeSelfCheck
 
         $this->rootWritableReport = '';
         $this->isRootDirectoryWritable();
+
         return $this->rootWritableReport;
     }
 
@@ -279,6 +283,7 @@ class UpgradeSelfCheck
         if (null !== $this->moduleVersion) {
             return $this->moduleVersion;
         }
+
         return $this->moduleVersion = $this->checkModuleVersion();
     }
 
@@ -307,7 +312,7 @@ class UpgradeSelfCheck
      */
     public function isPhpUpgradeRequired()
     {
-        if (1 === (int)  Configuration::get('PS_AUTOUP_IGNORE_PHP_UPGRADE')) {
+        if (1 === (int) Configuration::get('PS_AUTOUP_IGNORE_PHP_UPGRADE')) {
             return false;
         }
 
@@ -326,6 +331,7 @@ class UpgradeSelfCheck
         if (null === $this->prestashopReady) {
             $this->prestashopReady = $this->runPrestaShopCoreChecks();
         }
+
         return $this->prestashopReady || 1 === (int) Configuration::get('PS_AUTOUP_IGNORE_REQS');
     }
 
@@ -382,7 +388,7 @@ class UpgradeSelfCheck
 
     /**
      * Check current PHP version is supported.
-     * 
+     *
      * @return bool
      */
     private function checkPhpVersionNeedsUpgrade()

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -85,7 +85,7 @@ class UpgradeSelfCheck
     /**
      * @var string
      */
-    private $rootWritableReport = '';
+    private $rootWritableReport;
 
     /**
      * @var false|string
@@ -114,6 +114,11 @@ class UpgradeSelfCheck
      */
     private $configDir = '/modules/autoupgrade/config.xml';
 
+    private$upgrader;
+    private $prodRootPath;
+    private $adminPath;
+    private $autoUpgradePath;
+
     /**
      * UpgradeSelfCheck constructor.
      *
@@ -124,18 +129,10 @@ class UpgradeSelfCheck
      */
     public function __construct(Upgrader $upgrader, $prodRootPath, $adminPath, $autoUpgradePath)
     {
-        $this->moduleVersion = $this->checkModuleVersion();
-        $this->fOpenOrCurlEnabled = ConfigurationTest::test_fopen() || extension_loaded('curl');
-        $this->zipEnabled = extension_loaded('zip');
-        $this->rootDirectoryWritable = $this->checkRootWritable();
-        $this->adminAutoUpgradeDirectoryWritable = $this->checkAdminDirectoryWritable($prodRootPath, $adminPath, $autoUpgradePath);
-        $this->shopDeactivated = $this->checkShopIsDeactivated();
-        $this->cacheDisabled = !(defined('_PS_CACHE_ENABLED_') && false != _PS_CACHE_ENABLED_);
-        $this->safeModeDisabled = $this->checkSafeModeIsDisabled();
-        $this->moduleVersionIsLatest = $this->checkModuleVersionIsLastest($upgrader);
-        $this->maxExecutionTime = $this->checkMaxExecutionTime();
-        $this->prestashopReady = $this->runPrestaShopCoreChecks();
-        $this->phpUpgradeNoticelink = $this->checkPhpVersionNeedsUpgrade();
+        $this->upgrader = $upgrader;
+        $this->prodRootPath = $prodRootPath;
+        $this->adminPath = $adminPath;
+        $this->autoUpgradePath = $autoUpgradePath;
     }
 
     /**
@@ -143,7 +140,11 @@ class UpgradeSelfCheck
      */
     public function isFOpenOrCurlEnabled()
     {
-        return $this->fOpenOrCurlEnabled;
+        if (null !== $this->fOpenOrCurlEnabled) {
+            return $this->fOpenOrCurlEnabled;
+        }
+
+        return $this->fOpenOrCurlEnabled = ConfigurationTest::test_fopen() || extension_loaded('curl');
     }
 
     /**
@@ -151,7 +152,11 @@ class UpgradeSelfCheck
      */
     public function isZipEnabled()
     {
-        return $this->zipEnabled;
+        if (null !== $this->zipEnabled) {
+            return $this->zipEnabled;
+        }
+
+        return $this->zipEnabled = extension_loaded('zip');
     }
 
     /**
@@ -159,7 +164,11 @@ class UpgradeSelfCheck
      */
     public function isRootDirectoryWritable()
     {
-        return $this->rootDirectoryWritable;
+        if (null !== $this->rootDirectoryWritable) {
+            return $this->rootDirectoryWritable;
+        }
+
+        return $this->rootDirectoryWritable = $this->checkRootWritable();
     }
 
     /**
@@ -167,7 +176,11 @@ class UpgradeSelfCheck
      */
     public function isAdminAutoUpgradeDirectoryWritable()
     {
-        return $this->adminAutoUpgradeDirectoryWritable;
+        if (null !== $this->adminAutoUpgradeDirectoryWritable) {
+            return $this->adminAutoUpgradeDirectoryWritable;
+        }
+
+        return $this->adminAutoUpgradeDirectoryWritable = $this->checkAdminDirectoryWritable($this->prodRootPath, $this->adminPath, $this->autoUpgradePath);
     }
 
     /**
@@ -183,7 +196,11 @@ class UpgradeSelfCheck
      */
     public function isShopDeactivated()
     {
-        return $this->shopDeactivated;
+        if (null !== $this->shopDeactivated) {
+            return $this->shopDeactivated;
+        }
+
+        return $this->shopDeactivated = $this->checkShopIsDeactivated();
     }
 
     /**
@@ -191,7 +208,11 @@ class UpgradeSelfCheck
      */
     public function isCacheDisabled()
     {
-        return $this->cacheDisabled;
+        if (null !== $this->cacheDisabled) {
+            return $this->cacheDisabled;
+        }
+
+        return $this->cacheDisabled = !(defined('_PS_CACHE_ENABLED_') && false != _PS_CACHE_ENABLED_);
     }
 
     /**
@@ -199,7 +220,11 @@ class UpgradeSelfCheck
      */
     public function isSafeModeDisabled()
     {
-        return $this->safeModeDisabled;
+        if (null !== $this->safeModeDisabled) {
+            return $this->safeModeDisabled;
+        }
+
+        return $this->safeModeDisabled = $this->checkSafeModeIsDisabled();;
     }
 
     /**
@@ -207,7 +232,11 @@ class UpgradeSelfCheck
      */
     public function isModuleVersionLatest()
     {
-        return $this->moduleVersionIsLatest;
+        if (null !== $this->moduleVersionIsLatest) {
+            return $this->moduleVersionIsLatest;
+        }
+
+        return $this->moduleVersionIsLatest = $this->checkModuleVersionIsLastest($this->upgrader);
     }
 
     /**
@@ -215,6 +244,12 @@ class UpgradeSelfCheck
      */
     public function getRootWritableReport()
     {
+        if (null !== $this->rootWritableReport) {
+            return $this->rootWritableReport;
+        }
+
+        $this->rootWritableReport = '';
+        $this->isRootDirectoryWritable();
         return $this->rootWritableReport;
     }
 
@@ -223,7 +258,10 @@ class UpgradeSelfCheck
      */
     public function getModuleVersion()
     {
-        return $this->moduleVersion;
+        if (null !== $this->moduleVersion) {
+            return $this->moduleVersion;
+        }
+        return $this->moduleVersion = $this->checkModuleVersion();
     }
 
     /**
@@ -239,7 +277,11 @@ class UpgradeSelfCheck
      */
     public function getMaxExecutionTime()
     {
-        return $this->maxExecutionTime;
+        if (null !== $this->maxExecutionTime) {
+            return $this->maxExecutionTime;
+        }
+
+        return $this->maxExecutionTime = $this->checkMaxExecutionTime();
     }
 
     /**
@@ -250,7 +292,12 @@ class UpgradeSelfCheck
         if (1 === (int)  Configuration::get('PS_AUTOUP_IGNORE_PHP_UPGRADE')) {
             return false;
         }
-        return $this->phpUpgradeNoticelink;
+
+        if (null !== $this->phpUpgradeNoticelink) {
+            return $this->phpUpgradeNoticelink;
+        }
+
+        return $this->phpUpgradeNoticelink = $this->checkPhpVersionNeedsUpgrade();
     }
 
     /**
@@ -258,6 +305,9 @@ class UpgradeSelfCheck
      */
     public function isPrestaShopReady()
     {
+        if (null === $this->prestashopReady) {
+            $this->prestashopReady = $this->runPrestaShopCoreChecks();
+        }
         return $this->prestashopReady || 1 === (int) Configuration::get('PS_AUTOUP_IGNORE_REQS');
     }
 
@@ -295,7 +345,7 @@ class UpgradeSelfCheck
      */
     private function checkModuleVersionIsLastest(Upgrader $upgrader)
     {
-        return version_compare($this->moduleVersion, $upgrader->autoupgrade_last_version, '>=');
+        return version_compare($this->getModuleVersion(), $upgrader->autoupgrade_last_version, '>=');
     }
 
     /**

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -382,29 +382,12 @@ class UpgradeSelfCheck
 
     /**
      * Check current PHP version is supported.
-     * Returns an URL if unmaintained.
      * 
-     * @return bool|string
+     * @return bool
      */
     private function checkPhpVersionNeedsUpgrade()
     {
-        if (PHP_VERSION_ID >= self::RECOMMENDED_PHP_VERSION) {
-            return false;
-        }
-
-        // Informative only. These links will be declared in the translation files.
-        /*$articles = [
-            'de' => 'https://www.prestashop.com/de/blog/php-5-6-Sicherheit-Online-Shop',
-            'en' => 'https://www.prestashop.com/en/blog/php-5-6-online-store-security',
-            'es' => 'https://www.prestashop.com/es/blog/php-5-6-seguridad-tienda-prestashop',
-            'fr' => 'https://www.prestashop.com/fr/blog/php-5-6-securite-boutique-en-ligne',
-            'it' => 'https://www.prestashop.com/it/blog/php-5-6-sicurezza-shop-on-line',
-            'nl' => 'https://www.prestashop.com/nl/blog/php-5-6-veiligheid-webwinkel',
-            'pl' => 'https://www.prestashop.com/pl/blog/php-5-6-bezpieczenstwo-sklepu-internetowego',
-            'pt' => 'https://www.prestashop.com/pt/blog/php-5-6-seguranca-loja-on-line',
-        ];*/
-
-        return 'https://www.prestashop.com/en/blog/php-5-6-online-store-security';
+        return PHP_VERSION_ID < self::RECOMMENDED_PHP_VERSION;
     }
 
     /**

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -35,7 +35,7 @@ class UpgradeSelfCheck
     /**
      * Recommended PHP Version. If below, display a notice.
      */
-    const RECOMMENDED_PHP_VERSION = 70000;
+    const RECOMMENDED_PHP_VERSION = 70100;
 
     /**
      * @var bool

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -33,6 +33,11 @@ use ConfigurationTest;
 class UpgradeSelfCheck
 {
     /**
+     * Recommended PHP Version. If below, display a notice.
+     */
+    const RECOMMENDED_PHP_VERSION = 70000;
+
+    /**
      * @var bool
      */
     private $fOpenOrCurlEnabled;
@@ -93,6 +98,13 @@ class UpgradeSelfCheck
     private $maxExecutionTime;
 
     /**
+     * False if PHP version is maintained, url to a website otherxise.
+     * 
+     * @var bool|string
+     */
+    private $phpUpgradeNoticelink;
+
+    /**
      * @var bool
      */
     private $prestashopReady;
@@ -123,6 +135,7 @@ class UpgradeSelfCheck
         $this->moduleVersionIsLatest = $this->checkModuleVersionIsLastest($upgrader);
         $this->maxExecutionTime = $this->checkMaxExecutionTime();
         $this->prestashopReady = $this->runPrestaShopCoreChecks();
+        $this->phpUpgradeNoticelink = $this->checkPhpVersionNeedsUpgrade();
     }
 
     /**
@@ -229,6 +242,20 @@ class UpgradeSelfCheck
         return $this->maxExecutionTime;
     }
 
+    /**
+     * @return bool
+     */
+    public function isPhpUpgradeRequired()
+    {
+        if (1 === (int)  Configuration::get('PS_AUTOUP_IGNORE_PHP_UPGRADE')) {
+            return false;
+        }
+        return $this->phpUpgradeNoticelink;
+    }
+
+    /**
+     * @return bool
+     */
     public function isPrestaShopReady()
     {
         return $this->prestashopReady || 1 === (int) Configuration::get('PS_AUTOUP_IGNORE_REQS');
@@ -283,6 +310,33 @@ class UpgradeSelfCheck
         }
 
         return false;
+    }
+
+    /**
+     * Check current PHP version is supported.
+     * Returns an URL if unmaintained.
+     * 
+     * @return bool|string
+     */
+    private function checkPhpVersionNeedsUpgrade()
+    {
+        if (PHP_VERSION_ID >= self::RECOMMENDED_PHP_VERSION) {
+            return false;
+        }
+
+        // Informative only. These links will be declared in the translation files.
+        /*$articles = [
+            'de' => 'https://www.prestashop.com/de/blog/php-5-6-Sicherheit-Online-Shop',
+            'en' => 'https://www.prestashop.com/en/blog/php-5-6-online-store-security',
+            'es' => 'https://www.prestashop.com/es/blog/php-5-6-seguridad-tienda-prestashop',
+            'fr' => 'https://www.prestashop.com/fr/blog/php-5-6-securite-boutique-en-ligne',
+            'it' => 'https://www.prestashop.com/it/blog/php-5-6-sicurezza-shop-on-line',
+            'nl' => 'https://www.prestashop.com/nl/blog/php-5-6-veiligheid-webwinkel',
+            'pl' => 'https://www.prestashop.com/pl/blog/php-5-6-bezpieczenstwo-sklepu-internetowego',
+            'pt' => 'https://www.prestashop.com/pt/blog/php-5-6-seguranca-loja-on-line',
+        ];*/
+
+        return 'https://www.prestashop.com/en/blog/php-5-6-online-store-security';
     }
 
     /**

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -35,7 +35,7 @@ class UpgradeSelfCheck
     /**
      * Recommended PHP Version. If below, display a notice.
      */
-    const RECOMMENDED_PHP_VERSION = 70100;
+    const RECOMMENDED_PHP_VERSION = 70103;
 
     /**
      * @var bool

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -114,9 +114,27 @@ class UpgradeSelfCheck
      */
     private $configDir = '/modules/autoupgrade/config.xml';
 
-    private$upgrader;
+    /**
+     * @var Upgrader
+     */
+    private $upgrader;
+    
+    /**
+     * Path to the root folder of PS
+     * @var string
+     */
     private $prodRootPath;
+
+    /**
+     * Path to the admin folder of PS
+     * @var string
+     */
     private $adminPath;
+
+    /**
+     * Path to the root folder of the upgrade module
+     * @var string
+     */
     private $autoUpgradePath;
 
     /**

--- a/css/styles.css
+++ b/css/styles.css
@@ -17,3 +17,5 @@
 .margin-form-small {padding: 0 0 1em 130px;}
 .nextStep {font-weight: bold;}
 #diffList, #changedList {margin-top: 20px;}
+#autoupgradePhpWarningMainIcon {font-size: 3em;}
+#autoupgradePhpWarn .icon-stack-text {color: white;}

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1,0 +1,13 @@
+$(document).ready(function(){
+  var autoUpgradePanel = $("#autoupgradePhpWarn");
+
+  $(".list-toolbar-btn", autoUpgradePanel).click(function(event) {
+
+    event.preventDefault();
+    autoUpgradePanel.fadeOut();
+
+    $.post(
+      $(this).attr("href")
+    );
+  });
+});

--- a/upgrade/install-4-7-0.php
+++ b/upgrade/install-4-7-0.php
@@ -1,0 +1,30 @@
+<?php
+/*
+* 2007-2016 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2016 PrestaShop SA
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+
+function upgrade_module_4_7_0($module)
+{
+    return $module->registerHookAndSetToTop('dashboardZoneOne');
+}

--- a/upgrade/install-4-9-0.php
+++ b/upgrade/install-4-9-0.php
@@ -24,7 +24,7 @@
 *  International Registered Trademark & Property of PrestaShop SA
 */
 
-function upgrade_module_4_7_0($module)
+function upgrade_module_4_9_0($module)
 {
     return $module->registerHookAndSetToTop('dashboardZoneOne');
 }

--- a/views/templates/block/checklist.twig
+++ b/views/templates/block/checklist.twig
@@ -30,6 +30,27 @@
                     </td>
                 </tr>
                 <tr>
+                    <td>
+                        {% if not phpUpgradeRequired %}
+                            {{ 'Your server is running on a supported PHP version.'|trans }}
+                        {% else %}
+                            {{ 'The PHP version your server is running on is obsolete and needs to be upgraded. [1]Learn more why[/1] or [2]ignore[/2].'|trans({
+                                '[1]': '<a href="' ~ phpUpgradeRequired|trans ~'" target="_blank">',
+                                '[/1]': '</a>',
+                                '[2]': '<a href="' ~ currentIndex ~ '&token=' ~ token ~ '&ignorePhpOutdated=1">',
+                                '[/2]': '</a>',
+                            })|raw }}
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% if not phpUpgradeRequired %}
+                            {{ icons.ok }}
+                        {% else %}
+                            {{ icons.warning }}
+                        {% endif %}
+                    </td>
+                </tr>
+                <tr>
                     <td>{{ 'Your store\'s root directory is writable (with appropriate CHMOD permissions)'|trans }}</td>
                     <td>
                         {% if rootDirectoryIsWritable %}

--- a/views/templates/block/checklist.twig
+++ b/views/templates/block/checklist.twig
@@ -151,7 +151,7 @@
                             {{ 'PrestaShop requirements are satisfied.'|trans }}
                         {% else %}
                             {{ 'PrestaShop requirements are not satisfied. [1]See details[/1] or [2]ignore[/2].'|trans({
-                                '[1]': '<a href="' ~ informationsLink ~'">',
+                                '[1]': '<a href="http://build.prestashop.com/news/announcing-end-of-support-for-obsolete-php-versions/">',
                                 '[/1]': '</a>',
                                 '[2]': '<a href="' ~ currentIndex ~ '&token=' ~ token ~ '&ignorePsRequirements=1">',
                                 '[/2]': '</a>',

--- a/views/templates/hook/dashboard_zone_one.tpl
+++ b/views/templates/hook/dashboard_zone_one.tpl
@@ -24,20 +24,20 @@
 *}
 
 <section id="autoupgradePhpWarn" class="panel widget">
-	<div class="panel-heading">
+  <div class="panel-heading">
     <span class="icon-stack text-danger">
       <span class="icon icon-circle icon-stack-2x"></span>
       <strong class="icon-stack-1x icon-stack-text">1</strong>
     </span>
-		{l s='PHP Version notice' mod='autoupgrade'}
+    {l s='PHP Version notice' mod='autoupgrade'}
 
 
     <span class="panel-heading-action">
-			<a class="list-toolbar-btn" href="{$ignore_link}" title="Ignore">
-				<i class="process-icon-close"></i>
-			</a>
-		</span>
-	</div>
+      <a class="list-toolbar-btn" href="{$ignore_link}" title="Ignore">
+        <i class="process-icon-close"></i>
+      </a>
+    </span>
+  </div>
 
   <p class="text-muted text-center">
     <i id="autoupgradePhpWarningMainIcon" class="icon-history icon-flip-horizontal"></i>

--- a/views/templates/hook/dashboard_zone_one.tpl
+++ b/views/templates/hook/dashboard_zone_one.tpl
@@ -1,0 +1,57 @@
+{*
+* 2007-2017 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+* @author    PrestaShop SA <contact@prestashop.com>
+* @copyright 2007-2017 PrestaShop SA
+* @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+* International Registered Trademark & Property of PrestaShop SA
+*}
+
+<section id="autoupgradePhpWarn" class="panel widget">
+	<div class="panel-heading">
+    <span class="icon-stack text-danger">
+      <span class="icon icon-circle icon-stack-2x"></span>
+      <strong class="icon-stack-1x icon-stack-text">1</strong>
+    </span>
+		{l s='PHP Version notice' mod='autoupgrade'}
+
+
+    <span class="panel-heading-action">
+			<a class="list-toolbar-btn" href="{$ignore_link}" title="Ignore">
+				<i class="process-icon-close"></i>
+			</a>
+		</span>
+	</div>
+
+  <p class="text-muted text-center">
+    <i id="autoupgradePhpWarningMainIcon" class="icon-history icon-flip-horizontal"></i>
+  </p>
+  <span>
+    <p>
+      {l s='The PHP version your shop is running on is insecure.' mod='autoupgrade'}<br>
+      {l s='It reached its end-of-life, which means it won\'t get security updates anymore and projects will stop supporting it.' mod='autoupgrade'} </span> <p><br>
+
+      {l s='Upgrading will keep your shop secured and performant.' mod='autoupgrade'} </span> <p><br>
+    </p>
+    <div align="center">
+      <a class="btn btn-primary" style="white-space: unset;" href="{$learn_more_link}" target="_blank">
+          <i class="icon-external-link"></i> {l s='Learn more about PHP and upgrading' mod='autoupgrade'}
+      </a>
+  </div>
+</section>


### PR DESCRIPTION
This PRs notifies when the running PHP server reached its end of life at 2 places, but the module remains compatible with PHP v5.6.

## Module configuration: Check list

![capture d ecran du 2019-02-27 11-32-28](https://user-images.githubusercontent.com/6768917/53487515-ae3ef880-3a83-11e9-8062-45c1079a91cd.png)

Not OK: ` The PHP version your server is running on is obsolete and needs to be upgraded. Learn more why or ignore.`
OK: `Your server is running on a supported PHP version.`

## Backoffice dashboard

![capture d ecran du 2019-02-27 11-32-54](https://user-images.githubusercontent.com/6768917/53487534-bdbe4180-3a83-11e9-99d1-818930b8c820.png)

```
<head>PHP Version notice

<body>The PHP version your shop is running on is insecure.
It reached its end-of-life, which means it won't get security updates anymore and projects will stop supporting it.

Upgrading will keep your shop secured and performant.

<button>Learn more about PHP and upgrading
```