### PR TITLE
Do not display exception when running unit tests

### DIFF
--- a/tests/ErrorHandlerTest.php
+++ b/tests/ErrorHandlerTest.php
@@ -50,7 +50,11 @@ class ErrorHandlerTest extends TestCase
     {
         $exception = new Exception('ERMAGHERD');
         $line = __LINE__ - 1;
+        // The exception will be sent to the stdout,
+        // we enable the output buffering
+        ob_start();
         $this->errorHandler->exceptionHandler($exception);
+        ob_end_clean();
 
         $errors = $this->logger->getErrors();
         $this->assertCount(1, $errors);


### PR DESCRIPTION
This PR removes unexpected output to be displayed while running php tests.

**Before:**

```
$ php vendor/phpunit/phpunit/phpunit tests
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.
.........{"nextQuickInfo":[],"nextErrors":["[INTERNAL] \/home\/travis\/build\/PrestaShop\/autoupgrade\/tests\/ErrorHandlerTest.php line 51 - Exception: ERMAGHERD\n#0 [internal function]: ErrorHandlerTest->testCheckExceptionAndContent()\n#1 \/home\/travis\/build\/PrestaShop\/autoupgrade\/vendor\/phpunit\/phpunit\/src\/Framework\/TestCase.php(1062): ReflectionMethod->invokeArgs(Object(ErrorHandlerTest), Array)\n#2 \/home\/travis\/build\/PrestaShop\/autoupgrade\/vendor\/phpunit\/phpunit\/src\/Framework\/TestCase.php(913): PHPUnit_Framework_TestCase->runTest()\n#3 \/home\/travis\/build\/PrestaShop\/autoupgrade\/vendor\/phpunit\/phpunit\/src\/Framework\/TestResult.php(686): PHPUnit_Framework_TestCase->runBare()\n#4 \/home\/travis\/build\/PrestaShop\/autoupgrade\/vendor\/phpunit\/phpunit\/src\/Framework\/TestCase.php(868): PHPUnit_Framework_TestResult->run(Object(ErrorHandlerTest))\n#5 \/home\/travis\/build\/PrestaShop\/autoupgrade\/vendor\/phpunit\/phpunit\/src\/Framework\/TestSuite.php(733): PHPUnit_Framework_TestCase->run(Object(PHPUnit_Framework_TestResult))\n#6 \/home\/travis\/build\/PrestaShop\/autoupgrade\/vendor\/phpunit\/phpunit\/src\/Framework\/TestSuite.php(733): PHPUnit_Framework_TestSuite->run(Object(PHPUnit_Framework_TestResult))\n#7 \/home\/travis\/build\/PrestaShop\/autoupgrade\/vendor\/phpunit\/phpunit\/src\/TextUI\/TestRunner.php(517): PHPUnit_Framework_TestSuite->run(Object(PHPUnit_Framework_TestResult))\n#8 \/home\/travis\/build\/PrestaShop\/autoupgrade\/vendor\/phpunit\/phpunit\/src\/TextUI\/Command.php(186): PHPUnit_TextUI_TestRunner->doRun(Object(PHPUnit_Framework_TestSuite), Array, true)\n#9 \/home\/travis\/build\/PrestaShop\/autoupgrade\/vendor\/phpunit\/phpunit\/src\/TextUI\/Command.php(116): PHPUnit_TextUI_Command->run(Array, true)\n#10 \/home\/travis\/build\/PrestaShop\/autoupgrade\/vendor\/phpunit\/phpunit\/phpunit(52): PHPUnit_TextUI_Command::main()\n#11 {main}"],"error":true,"next":"error"}........................................................ 65 / 74 ( 87%)
.........                                                         74 / 74 (100%)
Time: 193 ms, Memory: 10.75MB
OK (74 tests, 108 assertions)
```

**Expected:**

```
$ php vendor/phpunit/phpunit/phpunit tests
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.
................................................................. 65 / 74 ( 87%)
.........                                                         74 / 74 (100%)
Time: 228 ms, Memory: 10.75MB
OK (74 tests, 108 assertions)
```