### PR TITLE
Improve report of errors and fix notices

### DIFF
--- a/ajax-upgradetab.php
+++ b/ajax-upgradetab.php
@@ -44,6 +44,7 @@ if (!$container->getCookie()->check($_COOKIE)) {
         ob_clean();
     }
     echo '{wrong token}';
+    http_response_code(401);
     die(1);
 }
 

--- a/ajax-upgradetabconfig.php
+++ b/ajax-upgradetabconfig.php
@@ -41,7 +41,10 @@ if (function_exists('date_default_timezone_set')) {
 function autoupgrade_init_container($callerFilePath)
 {
     if (PHP_SAPI === 'cli') {
-        $_POST['dir'] = getopt('', array('dir:'))['dir'];
+        $options = getopt('', array('dir:'));
+        if (isset($options['dir'])) {
+            $_POST['dir'] = $options['dir'];
+        }
     }
 
     // the following test confirm the directory exists

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader17.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader17.php
@@ -67,7 +67,18 @@ class CoreUpgrader17 extends CoreUpgrader
         }
         $errorsLanguage = array();
 
-        \Language::downloadLanguagePack($isoCode, _PS_VERSION_, $errorsLanguage);
+        if (!\Language::downloadLanguagePack($isoCode, _PS_VERSION_, $errorsLanguage)) {
+            throw new UpgradeException(
+                $this->container->getTranslator()->trans(
+                    'Download of the language pack %lang% failed. %details%',
+                    [
+                        '%lang%' => $isoCode,
+                        '%details%' => implode('; ', $errorsLanguage)
+                    ],
+                    'Modules.Autoupgrade.Admin'
+                )
+            );
+        }
 
         $lang_pack = \Language::getLangDetails($isoCode);
         \Language::installSfLanguagePack($lang_pack['locale'], $errorsLanguage);
@@ -77,7 +88,16 @@ class CoreUpgrader17 extends CoreUpgrader
         }
 
         if (!empty($errorsLanguage)) {
-            throw new UpgradeException($this->container->getTranslator()->trans('Error updating translations', array(), 'Modules.Autoupgrade.Admin'));
+            throw new UpgradeException(
+                $this->container->getTranslator()->trans(
+                    'Error while updating translations for lang %lang%. %details%',
+                    [
+                        '%lang%' => $isoCode,
+                        '%details%' => implode('; ', $errorsLanguage)
+                    ],
+                    'Modules.Autoupgrade.Admin'
+                )
+            );
         }
         \Language::loadLanguages();
 

--- a/classes/ZipAction.php
+++ b/classes/ZipAction.php
@@ -151,11 +151,19 @@ class ZipAction
             return false;
         }
 
-        if (!$zip->extractTo($to_dir)) {
-            $zip->close();
-            $this->logger->error($this->translator->trans('zip->extractTo(): unable to use %s as extract destination.', array($to_dir), 'Modules.Autoupgrade.Admin'));
+        for($i = 0; $i < $zip->numFiles; $i++) {
+            if (!$zip->extractTo($to_dir, array($zip->getNameIndex($i)))) {
+                $this->logger->error(
+                    $this->translator->trans(
+                        'Could not extract %file% from backup, the destination might not be writable.', 
+                        ['%file%' => $zip->statIndex($i)['name']],
+                        'Modules.Autoupgrade.Admin'
+                    )
+                );
+                $zip->close();
 
-            return false;
+                return false;
+            }
         }
 
         $zip->close();


### PR DESCRIPTION
PR content:

* When an ajax requests fails the security checks, we set its code as 401.
* Better retrieval of the `dir` parameter
* When extracting files from a zip file, report the concerned file in case of failure
* Split error messages when upgrading languages