### PR TITLE
Handle folder var/cache in module

### DIFF
--- a/classes/TaskRunner/Upgrade/AllUpgradeTasks.php
+++ b/classes/TaskRunner/Upgrade/AllUpgradeTasks.php
@@ -37,6 +37,7 @@ use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 class AllUpgradeTasks extends ChainedTasks
 {
     const initialTask = 'upgradeNow';
+    const TASKS_WITH_RESTART = ['upgradeFiles', 'upgradeDb'];
 
     protected $step = self::initialTask;
 
@@ -83,7 +84,7 @@ class AllUpgradeTasks extends ChainedTasks
             return false;
         }
 
-        if (!in_array($this->step, array('upgradeFiles'))) {
+        if (!in_array($this->step, self::TASKS_WITH_RESTART)) {
             return false;
         }
 

--- a/classes/TaskRunner/Upgrade/UpgradeDb.php
+++ b/classes/TaskRunner/Upgrade/UpgradeDb.php
@@ -53,8 +53,6 @@ class UpgradeDb extends AbstractTask
         $this->next = 'upgradeModules';
         $this->logger->info($this->translator->trans('Database upgraded. Now upgrading your Addons modules...', array(), 'Modules.Autoupgrade.Admin'));
 
-        $this->container->getSymfonyAdapter()->clearMigrationCache();
-
         return true;
     }
 

--- a/classes/TaskRunner/Upgrade/UpgradeDb.php
+++ b/classes/TaskRunner/Upgrade/UpgradeDb.php
@@ -69,6 +69,8 @@ class UpgradeDb extends AbstractTask
 
     public function init()
     {
+        $this->container->getCacheCleaner()->cleanFolders();
+
         // Migrating settings file
         $this->container->initPrestaShopAutoloader();
         (new SettingsFileWriter($this->translator))->migrateSettingsFile($this->logger);

--- a/classes/TaskRunner/Upgrade/UpgradeFiles.php
+++ b/classes/TaskRunner/Upgrade/UpgradeFiles.php
@@ -79,8 +79,6 @@ class UpgradeFiles extends AbstractTask
         if (count($filesToUpgrade) > 0) {
             $this->logger->info($this->translator->trans('%s files left to upgrade.', array(count($filesToUpgrade)), 'Modules.Autoupgrade.Admin'));
             $this->stepDone = false;
-            @unlink(_PS_ROOT_DIR_ . DIRECTORY_SEPARATOR . 'app' . DIRECTORY_SEPARATOR . 'cache' . DIRECTORY_SEPARATOR . 'dev' . DIRECTORY_SEPARATOR . 'class_index.php');
-            @unlink(_PS_ROOT_DIR_ . DIRECTORY_SEPARATOR . 'app' . DIRECTORY_SEPARATOR . 'cache' . DIRECTORY_SEPARATOR . 'prod' . DIRECTORY_SEPARATOR . 'class_index.php');
         }
 
         return true;

--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -29,6 +29,7 @@ namespace PrestaShop\Module\AutoUpgrade;
 
 use PrestaShop\Module\AutoUpgrade\Log\LegacyLogger;
 use PrestaShop\Module\AutoUpgrade\Log\Logger;
+use PrestaShop\Module\AutoUpgrade\UpgradeTools\CacheCleaner;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\FileFilter;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\FilesystemAdapter;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\ModuleAdapter;
@@ -61,6 +62,11 @@ class UpgradeContainer
     const ARCHIVE_FILENAME = 'destDownloadFilename';
     const ARCHIVE_FILEPATH = 'destDownloadFilepath';
     const PS_VERSION = 'version';
+
+    /**
+     * @var CacheCleaner
+     */
+    private $cacheCleaner;
 
     /**
      * @var Cookie
@@ -190,6 +196,20 @@ class UpgradeContainer
             case self::PS_VERSION:
                 return $this->getPrestaShopConfiguration()->getPrestaShopVersion();
         }
+    }
+
+    /**
+     * Init and return CacheCleaner
+     *
+     * @return CacheCleaner
+     */
+    public function getCacheCleaner()
+    {
+        if (null !== $this->cacheCleaner) {
+            return $this->cacheCleaner;
+        }
+
+        return $this->cacheCleaner = new CacheCleaner($this, $this->getLogger());
     }
 
     public function getCookie()

--- a/classes/UpgradeTools/CacheCleaner.php
+++ b/classes/UpgradeTools/CacheCleaner.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * 2007-2019 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author PrestaShop SA <contact@prestashop.com>
+ *  @copyright  2007-2019 PrestaShop SA
+ *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\Module\AutoUpgrade\UpgradeTools;
+
+use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
+use Psr\Log\LoggerInterface;
+
+class CacheCleaner
+{
+    /**
+     * @var UpgradeContainer
+     */
+    private $container;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(UpgradeContainer $container, LoggerInterface $logger)
+    {
+        $this->container = $container;
+        $this->logger = $logger;
+    }
+
+    public function cleanFolders()
+    {
+        $dirsToClean = array(
+            $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH) . '/app/cache/',
+            $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH) . '/cache/smarty/cache/',
+            $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH) . '/cache/smarty/compile/',
+            $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH) . '/var/cache/',
+        );
+
+        $defaultThemeNames = array(
+            'default',
+            'prestashop',
+            'default-boostrap',
+            'classic',
+        );
+
+        if (defined('_THEME_NAME_') && $this->container->getUpgradeConfiguration()->shouldUpdateDefaultTheme() && in_array(_THEME_NAME_, $defaultThemeNames)) {
+            $dirsToClean[] = $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH) . '/themes/' . _THEME_NAME_ . '/cache/';
+        }
+
+        foreach ($dirsToClean as $dir) {
+            if (!file_exists($dir)) {
+                $this->logger->debug($this->container->getTranslator()->trans('[SKIP] directory "%s" does not exist and cannot be emptied.', array(str_replace($this->container->getProperty(UpgradeContainer::PS_ROOT_PATH), '', $dir)), 'Modules.Autoupgrade.Admin'));
+                continue;
+            }
+            foreach (scandir($dir) as $file) {
+                if ($file[0] === '.' || $file === 'index.php') {
+                    continue;
+                }
+                // ToDo: Use Filesystem instead ?
+                if (is_file($dir . $file)) {
+                    unlink($dir . $file);
+                } elseif (is_dir($dir . $file . DIRECTORY_SEPARATOR)) {
+                    FilesystemAdapter::deleteDirectory($dir . $file . DIRECTORY_SEPARATOR);
+                }
+                $this->logger->debug($this->container->getTranslator()->trans('[CLEANING CACHE] File %s removed', array($file), 'Modules.Autoupgrade.Admin'));
+            }
+        }
+    }
+}

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -471,6 +471,7 @@ abstract class CoreUpgrader
             $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH) . '/app/cache/',
             $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH) . '/cache/smarty/cache/',
             $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH) . '/cache/smarty/compile/',
+            $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH) . '/var/cache/',
         );
 
         $defaultThemeNames = array(
@@ -680,6 +681,8 @@ abstract class CoreUpgrader
             _PS_ROOT_DIR_ . '/config/xml/tab_modules_list.xml',
             _PS_ROOT_DIR_ . '/config/xml/trusted_modules_list.xml',
             _PS_ROOT_DIR_ . '/config/xml/untrusted_modules_list.xml',
+            _PS_ROOT_DIR_ . '/var/cache/dev/class_index.php',
+            _PS_ROOT_DIR_ . '/var/cache/prod/class_index.php',
         );
         foreach ($files as $path) {
             if (file_exists($path)) {

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader17.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader17.php
@@ -47,7 +47,6 @@ class CoreUpgrader17 extends CoreUpgrader
         }*/
 
         // Container may be needed to run upgrade scripts
-        $this->cleanFolders();
         $this->container->getSymfonyAdapter()->initAppKernel();
     }
 

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader17.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader17.php
@@ -47,6 +47,7 @@ class CoreUpgrader17 extends CoreUpgrader
         }*/
 
         // Container may be needed to run upgrade scripts
+        $this->cleanFolders();
         $this->container->getSymfonyAdapter()->initAppKernel();
     }
 

--- a/classes/UpgradeTools/FileFilter.php
+++ b/classes/UpgradeTools/FileFilter.php
@@ -61,6 +61,7 @@ class FileFilter
             '/cache/smarty/cache',
             '/cache/tcpdf',
             '/cache/cachefs',
+            '/var/cache',
 
             // do not care about the two autoupgrade dir we use;
             '/modules/autoupgrade',

--- a/classes/UpgradeTools/SymfonyAdapter.php
+++ b/classes/UpgradeTools/SymfonyAdapter.php
@@ -42,25 +42,6 @@ class SymfonyAdapter
         $this->destinationPsVersion = $destinationPsVersion;
     }
 
-    /**
-     * Can be called only on PS 1.7.
-     */
-    public function clearMigrationCache()
-    {
-        if (version_compare($this->destinationPsVersion, '1.7.0.0', '<')) {
-            return;
-        }
-
-        \Tools::clearCache();
-        \Tools::clearXMLCache();
-        \Media::clearCache();
-        \Tools::generateIndex();
-
-        $sf2Refresh = new \PrestaShopBundle\Service\Cache\Refresh();
-        $sf2Refresh->addCacheClear();
-        $sf2Refresh->execute();
-    }
-
     public function runSchemaUpgradeCommand()
     {
         if (version_compare($this->destinationPsVersion, '1.7.1.1', '>=')) {

--- a/tests/UpgradeContainerTest.php
+++ b/tests/UpgradeContainerTest.php
@@ -52,6 +52,7 @@ class UpgradeContainerTest extends TestCase
     {
         // | Function to call | Expected class |
         return array(
+            array('getCacheCleaner', PrestaShop\Module\AutoUpgrade\UpgradeTools\CacheCleaner::class),
             array('getCookie', PrestaShop\Module\AutoUpgrade\Cookie::class),
             array('getFileConfigurationStorage', PrestaShop\Module\AutoUpgrade\Parameters\FileConfigurationStorage::class),
             array('getFileFilter', \PrestaShop\Module\AutoUpgrade\UpgradeTools\FileFilter::class),


### PR DESCRIPTION
Allow var/cache:
* to be cleaned during upgrade process
* to be ignored when creating backups

Also, this PR moves the cache cleanup between the steps "Files upgrade" & "DB upgrade", right before the core initialization.