### PR TITLE
Avoid conflit with Psr\Log\LoggerInterface when loading core

### DIFF
--- a/classes/Log/Logger.php
+++ b/classes/Log/Logger.php
@@ -27,8 +27,6 @@
 
 namespace PrestaShop\Module\AutoUpgrade\Log;
 
-use Psr\Log\LoggerInterface;
-
 /**
  * This class retrieves all message to display during the upgrade / rollback tasks.
  */

--- a/classes/Log/LoggerInterface.php
+++ b/classes/Log/LoggerInterface.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * IMPORTANT NOTE.
+ *
+ * This class is taken from the composer dependancy psr/log.
+ * We copied it here to avoid conflicts with the same file loaded by the core
+ */
+
+namespace PrestaShop\Module\AutoUpgrade\Log;
+
+/**
+ * Describes a logger instance.
+ *
+ * The message MUST be a string or object implementing __toString().
+ *
+ * The message MAY contain placeholders in the form: {foo} where foo
+ * will be replaced by the context data in key "foo".
+ *
+ * The context array can contain arbitrary data. The only assumption that
+ * can be made by implementors is that if an Exception instance is given
+ * to produce a stack trace, it MUST be in a key named "exception".
+ *
+ * See https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md
+ * for the full interface specification.
+ */
+interface LoggerInterface
+{
+    /**
+     * System is unusable.
+     *
+     * @param string $message
+     * @param array $context
+     */
+    public function emergency($message, array $context = array());
+
+    /**
+     * Action must be taken immediately.
+     *
+     * Example: Entire website down, database unavailable, etc. This should
+     * trigger the SMS alerts and wake you up.
+     *
+     * @param string $message
+     * @param array $context
+     */
+    public function alert($message, array $context = array());
+
+    /**
+     * Critical conditions.
+     *
+     * Example: Application component unavailable, unexpected exception.
+     *
+     * @param string $message
+     * @param array $context
+     */
+    public function critical($message, array $context = array());
+
+    /**
+     * Runtime errors that do not require immediate action but should typically
+     * be logged and monitored.
+     *
+     * @param string $message
+     * @param array $context
+     */
+    public function error($message, array $context = array());
+
+    /**
+     * Exceptional occurrences that are not errors.
+     *
+     * Example: Use of deprecated APIs, poor use of an API, undesirable things
+     * that are not necessarily wrong.
+     *
+     * @param string $message
+     * @param array $context
+     */
+    public function warning($message, array $context = array());
+
+    /**
+     * Normal but significant events.
+     *
+     * @param string $message
+     * @param array $context
+     */
+    public function notice($message, array $context = array());
+
+    /**
+     * Interesting events.
+     *
+     * Example: User logs in, SQL logs.
+     *
+     * @param string $message
+     * @param array $context
+     */
+    public function info($message, array $context = array());
+
+    /**
+     * Detailed debug information.
+     *
+     * @param string $message
+     * @param array $context
+     */
+    public function debug($message, array $context = array());
+
+    /**
+     * Logs with an arbitrary level.
+     *
+     * @param mixed $level
+     * @param string $message
+     * @param array $context
+     */
+    public function log($level, $message, array $context = array());
+}

--- a/classes/Log/LoggerInterface.php
+++ b/classes/Log/LoggerInterface.php
@@ -2,7 +2,7 @@
 /**
  * IMPORTANT NOTE.
  *
- * This class is taken from the composer dependancy psr/log.
+ * This class is taken from the composer dependency psr/log.
  * We copied it here to avoid conflicts with the same file loaded by the core
  */
 

--- a/classes/LoggedEvent.php
+++ b/classes/LoggedEvent.php
@@ -33,7 +33,7 @@ namespace Composer\Script {
 
 namespace PrestaShop\Module\AutoUpgrade {
     use Composer\Script\Event;
-    use Psr\Log\LoggerInterface;
+    use PrestaShop\Module\AutoUpgrade\Log\LoggerInterface;
 
     class LoggedEvent extends Event
     {

--- a/classes/LoggedEventIo.php
+++ b/classes/LoggedEventIo.php
@@ -27,7 +27,7 @@
 
 namespace PrestaShop\Module\AutoUpgrade;
 
-use Psr\Log\LoggerInterface;
+use PrestaShop\Module\AutoUpgrade\Log\LoggerInterface;
 
 class LoggedEventIo
 {

--- a/classes/UpgradeTools/CacheCleaner.php
+++ b/classes/UpgradeTools/CacheCleaner.php
@@ -28,7 +28,7 @@
 namespace PrestaShop\Module\AutoUpgrade\UpgradeTools;
 
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
-use Psr\Log\LoggerInterface;
+use PrestaShop\Module\AutoUpgrade\Log\LoggerInterface;
 
 class CacheCleaner
 {

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -30,7 +30,7 @@ namespace PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 use PrestaShop\Module\AutoUpgrade\UpgradeException;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\ThemeAdapter;
-use Psr\Log\LoggerInterface;
+use PrestaShop\Module\AutoUpgrade\Log\LoggerInterface;
 
 /**
  * Class used to modify the core of PrestaShop, on the files are copied on the filesystem.

--- a/classes/UpgradeTools/SettingsFileWriter.php
+++ b/classes/UpgradeTools/SettingsFileWriter.php
@@ -28,7 +28,7 @@
 namespace PrestaShop\Module\AutoUpgrade\UpgradeTools;
 
 use PrestaShop\Module\AutoUpgrade\UpgradeException;
-use Psr\Log\LoggerInterface;
+use PrestaShop\Module\AutoUpgrade\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use PrestaShop\Module\AutoUpgrade\LoggedEvent;
 

--- a/classes/UpgradeTools/Translation.php
+++ b/classes/UpgradeTools/Translation.php
@@ -28,7 +28,7 @@
 namespace PrestaShop\Module\AutoUpgrade\UpgradeTools;
 
 use PrestaShop\Module\AutoUpgrade\Tools14;
-use Psr\Log\LoggerInterface;
+use PrestaShop\Module\AutoUpgrade\Log\LoggerInterface;
 
 class Translation
 {

--- a/classes/Workspace.php
+++ b/classes/Workspace.php
@@ -27,7 +27,7 @@
 
 namespace PrestaShop\Module\AutoUpgrade;
 
-use Psr\Log\LoggerInterface;
+use PrestaShop\Module\AutoUpgrade\Log\LoggerInterface;
 
 class Workspace
 {

--- a/classes/ZipAction.php
+++ b/classes/ZipAction.php
@@ -27,7 +27,7 @@
 
 namespace PrestaShop\Module\AutoUpgrade;
 
-use Psr\Log\LoggerInterface;
+use PrestaShop\Module\AutoUpgrade\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
     "ext-zip": "*",
     "symfony/filesystem": "~2.8",
     "doctrine/collections": "~1.3.0",
-    "twig/twig": "^1.35",
-    "psr/log": "^1.0"
+    "twig/twig": "^1.35"
   },
   "config": {
     "preferred-install": "dist",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7c7f0ce41d787156211892e58d404cbc",
+    "content-hash": "07d914ad01aee16ebb0b3e4e846fa9e2",
     "packages": [
         {
             "name": "doctrine/collections",
@@ -71,53 +71,6 @@
                 "iterator"
             ],
             "time": "2015-04-14T22:21:58+00:00"
-        },
-        {
-            "name": "psr/log",
-            "version": "1.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
-            "keywords": [
-                "log",
-                "psr",
-                "psr-3"
-            ],
-            "time": "2016-10-10T12:19:37+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -931,6 +884,7 @@
                 "mock",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2017-06-30T09:13:00+00:00"
         },
         {
@@ -1561,7 +1515,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.4"
+        "php": ">=5.6",
+        "ext-zip": "*"
     },
     "platform-dev": [],
     "platform-overrides": {


### PR DESCRIPTION
Fixes `[INTERNAL] /var/www/html/var/cache/prod/classes.php line 9103 - Cannot redeclare class Psr\Log\LoggerInterface` while upgrading to PS 1.7.6.0