### PR TITLE
Fix warning in 1.7 when settings file does not exist

### DIFF
--- a/classes/PrestashopConfiguration.php
+++ b/classes/PrestashopConfiguration.php
@@ -78,7 +78,10 @@ class PrestashopConfiguration
             $this->psRootDir . '/app/AppKernel.php',
         );
         foreach ($files as $file) {
-            $version = $this->findPrestaShopVersionInFile(@file_get_contents($file));
+            if (!file_exists($file)) {
+                continue;
+            }
+            $version = $this->findPrestaShopVersionInFile(file_get_contents($file));
             if ($version) {
                 return $version;
             }

--- a/classes/PrestashopConfiguration.php
+++ b/classes/PrestashopConfiguration.php
@@ -78,7 +78,7 @@ class PrestashopConfiguration
             $this->psRootDir . '/app/AppKernel.php',
         );
         foreach ($files as $file) {
-            $version = $this->findPrestaShopVersionInFile(file_get_contents($file));
+            $version = $this->findPrestaShopVersionInFile(@file_get_contents($file));
             if ($version) {
                 return $version;
             }


### PR DESCRIPTION
settings.inc.php is still searched in 1.7 upgrade
cf https://github.com/PrestaShop/autoupgrade/issues/321