### PR TITLE
Prepend and optimize autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,9 @@
     "preferred-install": "dist",
     "platform": {
         "php": "5.6"
-    }
+    },
+    "prepend-autoloader": false,
+    "optimize-autoloader": true
   },
   "type": "prestashop-module",
   "autoload": {


### PR DESCRIPTION
Disabling the option `prepend-autoloader` will allow the PrestaShop autoloader to go first. Although it seems dangerous as the core is unstable during the upgrade, it seems to fix some issues like https://github.com/PrestaShop/PrestaShop/issues/13633

:warning: Run `composer install` after applying this PR