### PR TITLE
Update logs around zip upgrade

### DIFF
--- a/classes/TaskRunner/Upgrade/UpgradeModules.php
+++ b/classes/TaskRunner/Upgrade/UpgradeModules.php
@@ -62,6 +62,7 @@ class UpgradeModules extends AbstractTask
             do {
                 $module_info = array_shift($listModules);
                 try {
+                    $this->logger->debug($this->translator->trans('Upgrading module %module%...', ['%module%' => $module_info['name']], 'Modules.Autoupgrade.Admin'));
                     $this->container->getModuleAdapter()->upgradeModule($module_info['id'], $module_info['name']);
                     $this->logger->debug($this->translator->trans('The files of module %s have been upgraded.', array($module_info['name']), 'Modules.Autoupgrade.Admin'));
                 } catch (UpgradeException $e) {

--- a/classes/ZipAction.php
+++ b/classes/ZipAction.php
@@ -166,7 +166,7 @@ class ZipAction
         }
 
         $zip->close();
-        $this->logger->debug($this->translator->trans('Archive extracted', array(), 'Modules.Autoupgrade.Admin'));
+        $this->logger->debug($this->translator->trans('Content of archive %zip% is extracted', ['%zip%' => $from_file], 'Modules.Autoupgrade.Admin'));
 
         return true;
     }
@@ -246,7 +246,6 @@ class ZipAction
      */
     private function open($zipFile, $flags = null)
     {
-        $this->logger->debug($this->translator->trans('Using class ZipArchive...', array(), 'Modules.Autoupgrade.Admin'));
         $zip = new \ZipArchive();
         if ($zip->open($zipFile, $flags) !== true || empty($zip->filename)) {
             $this->logger->error($this->translator->trans('Unable to open zipFile %s', array($zipFile), 'Modules.Autoupgrade.Admin'));


### PR DESCRIPTION
This PR removes the log "Extract using ZipArchive", which is now always true, and add details the path to the zipfile being modified to the logs. This provides additional details to the user about how the module works.

![image](https://user-images.githubusercontent.com/6768917/60532063-53990000-9cf4-11e9-8bb5-25f05618e171.png)
