### PR TITLE
Split upgrade & backup process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,10 @@ script:
     fi
   - docker run --rm --volumes-from prestashop_autoupgrade -v $PWD:/web/module -e _PS_ROOT_DIR_=/var/www/html quetzacoalt/phpstan analyse --configuration=/web/module/tests/phpstan/$PHPSTAN_FILE;
 
+  # Backup
+  - docker exec -u www-data -ti prestashop_autoupgrade php modules/autoupgrade/tests/testCliProcess.php admin-dev/autoupgrade/cli-backup.php --dir="admin-dev"
   # Upgrade
-  - docker exec -u www-data -ti prestashop_autoupgrade php modules/autoupgrade/tests/testCliProcess.php admin-dev/autoupgrade/cli-upgrade.php  --dir="admin-dev" --channel="$CHANNEL"
+  - docker exec -u www-data -ti prestashop_autoupgrade php modules/autoupgrade/tests/testCliProcess.php admin-dev/autoupgrade/cli-upgrade.php --dir="admin-dev" --channel="$CHANNEL"
   # Front office -> HTTP code 200 expected (no maintenance)
   - bash -c '[ "$(curl -L -s -o /dev/null -w %{http_code} http://localhost:8001/index.php)" == "200" ]'
   # Back office -> HTTP code 200 expected
@@ -47,7 +49,7 @@ script:
 
   # Rollback (only when expect a completed upgrade)
   - if [ $VERSION != "latest" ]; then
-      docker exec -u www-data -ti prestashop_autoupgrade php modules/autoupgrade/tests/testCliProcess.php admin-dev/autoupgrade/cli-rollback.php  --dir="admin-dev" --backup=`docker exec -ti prestashop_autoupgrade bash -c "ls -td -- /var/www/html/admin-dev/autoupgrade/backup/*/ | head -n 1 | cut -d'/' -f8 | tr -d '\n'"`;
+      docker exec -u www-data -ti prestashop_autoupgrade php modules/autoupgrade/tests/testCliProcess.php admin-dev/autoupgrade/cli-rollback.php --dir="admin-dev" --backup=`docker exec -ti prestashop_autoupgrade bash -c "ls -td -- /var/www/html/admin-dev/autoupgrade/backup/*/ | head -n 1 | cut -d'/' -f8 | tr -d '\n'"`;
     fi
   # Front office -> HTTP code 200 expected (no maintenance)
   - bash -c '[ "$(curl -L -s -o /dev/null -w %{http_code} http://localhost:8001/index.php)" == "200" ]'

--- a/AdminSelfUpgrade.php
+++ b/AdminSelfUpgrade.php
@@ -145,10 +145,6 @@ class AdminSelfUpgrade extends AdminController
     private function _setFields()
     {
         $this->_fieldsBackupOptions = array(
-            'PS_AUTOUP_BACKUP' => array(
-                'title' => $this->trans('Back up my files and database', array(), 'Modules.Autoupgrade.Admin'), 'cast' => 'intval', 'validation' => 'isBool', 'defaultValue' => '1',
-                'type' => 'bool', 'desc' => $this->trans('Automatically back up your database and files in order to restore your shop if needed. This is experimental: you should still perform your own manual backup for safety.', array(), 'Modules.Autoupgrade.Admin'),
-            ),
             'PS_AUTOUP_KEEP_IMAGES' => array(
                 'title' => $this->trans('Back up my images', array(), 'Modules.Autoupgrade.Admin'), 'cast' => 'intval', 'validation' => 'isBool', 'defaultValue' => '1',
                 'type' => 'bool', 'desc' => $this->trans('To save time, you can decide not to back your images up. In any case, always make sure you did back them up manually.', array(), 'Modules.Autoupgrade.Admin'),

--- a/Readme.md
+++ b/Readme.md
@@ -23,6 +23,20 @@ All versions can be found in the [releases list](https://github.com/PrestaShop/a
 * Create a new zip file of **autoupgrade** folder
 * Now you can upload into your module pages
 
+# Backup a shop
+
+**When planning to upgrade, it is strongly recommended to backup your shop first!**
+The module makes an entrypoint available to run its own backup process, which can be then reused if case of error during 
+or after the upgrade process. 
+
+## Command line parameters
+
+Backup can be automated by calling *cli-backup.php*.
+
+The following parameter is mandatory:
+
+* **--dir**: Tells where the admin directory is.
+
 # Running an upgrade on PrestaShop
 
 Upgrading a shop can be done via:

--- a/classes/Parameters/UpgradeConfigurationStorage.php
+++ b/classes/Parameters/UpgradeConfigurationStorage.php
@@ -71,7 +71,6 @@ class UpgradeConfigurationStorage extends FileConfigurationStorage
             'PS_AUTOUP_UPDATE_DEFAULT_THEME' => 1,
             'PS_AUTOUP_CHANGE_DEFAULT_THEME' => 0,
             'PS_AUTOUP_KEEP_MAILS' => 0,
-            'PS_AUTOUP_BACKUP' => 1,
             'PS_AUTOUP_KEEP_IMAGES' => 1,
             'channel' => Upgrader::DEFAULT_CHANNEL,
             'archive.filename' => Upgrader::DEFAULT_FILENAME,

--- a/classes/State.php
+++ b/classes/State.php
@@ -146,13 +146,6 @@ class State
             \Language::getIsoIds(false)
         );
         $this->setInstalledLanguagesIso($installedLanguagesIso);
-
-        $rand = dechex(mt_rand(0, min(0xffffffff, mt_getrandmax())));
-        $date = date('Ymd-His');
-        $backupName = 'V' . $version . '_' . $date . '-' . $rand;
-        // Todo: To be moved in state class? We could only require the backup name here
-        // I.e = $this->upgradeContainer->getState()->setBackupName($backupName);, which triggers 2 other setters internally
-        $this->setBackupName($backupName);
     }
 
     // GETTERS

--- a/classes/TaskRunner/Backup/AllBackupTasks.php
+++ b/classes/TaskRunner/Backup/AllBackupTasks.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author PrestaShop SA <contact@prestashop.com>
+ *  @copyright  2007-2018 PrestaShop SA
+ *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\Module\AutoUpgrade\TaskRunner\Backup;
+
+use PrestaShop\Module\AutoUpgrade\TaskRunner\ChainedTasks;
+
+/**
+ * Execute the whole upgrade process in a single request.
+ */
+class AllBackupTasks extends ChainedTasks
+{
+    const initialTask = 'backup';
+
+    protected $step = self::initialTask;
+
+    /**
+     * Customize the execution context with several options
+     *
+     * @param array $options
+     */
+    public function setOptions(array $options)
+    {
+    }
+
+    /**
+     * Set default config on first run.
+     */
+    public function init()
+    {
+        // Do nothing
+    }
+}

--- a/classes/TaskRunner/Backup/Backup.php
+++ b/classes/TaskRunner/Backup/Backup.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author PrestaShop SA <contact@prestashop.com>
+ *  @copyright  2007-2018 PrestaShop SA
+ *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\Module\AutoUpgrade\TaskRunner\Backup;
+
+use PrestaShop\Module\AutoUpgrade\TaskRunner\AbstractTask;
+use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
+
+/**
+ * Ends the backup process and displays the success message.
+ */
+class Backup extends AbstractTask
+{
+    public function run()
+    {
+        // Example: V1.6.1.23_20190703-164600-1d09134a
+        $backupName = sprintf(
+            'V%s_%s-%s',
+            $this->container->getProperty(UpgradeContainer::PS_VERSION),
+            date('Ymd-His'),
+            dechex(mt_rand(0, min(0xffffffff, mt_getrandmax())))
+        );
+        $this->container->getState()->setBackupName($backupName);
+
+        $this->next = 'backupFiles';
+        $this->logger->info(
+            $this->translator->trans(
+                'Starting backup process. Now backing up files...',
+                [],
+                'Modules.Autoupgrade.Admin'
+        ));
+    }
+}

--- a/classes/TaskRunner/Backup/BackupComplete.php
+++ b/classes/TaskRunner/Backup/BackupComplete.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author PrestaShop SA <contact@prestashop.com>
+ *  @copyright  2007-2018 PrestaShop SA
+ *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\Module\AutoUpgrade\TaskRunner\Backup;
+
+use PrestaShop\Module\AutoUpgrade\TaskRunner\AbstractTask;
+
+/**
+ * Ends the backup process and displays the success message.
+ */
+class BackupComplete extends AbstractTask
+{
+    public function run()
+    {
+        $this->logger->info($this->translator->trans('Backup completed!', array(), 'Modules.Autoupgrade.Admin'));
+        $this->next = '';
+    }
+}

--- a/classes/TaskRunner/Backup/BackupDb.php
+++ b/classes/TaskRunner/Backup/BackupDb.php
@@ -25,7 +25,7 @@
  *  International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace PrestaShop\Module\AutoUpgrade\TaskRunner\Upgrade;
+namespace PrestaShop\Module\AutoUpgrade\TaskRunner\Backup;
 
 use PrestaShop\Module\AutoUpgrade\Tools14;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeFileNames;
@@ -36,15 +36,6 @@ class BackupDb extends AbstractTask
 {
     public function run()
     {
-        if (!$this->container->getUpgradeConfiguration()->get('PS_AUTOUP_BACKUP')) {
-            $this->stepDone = true;
-            $this->container->getState()->setDbStep(0);
-            $this->logger->info($this->translator->trans('Database backup skipped. Now upgrading files...', array(), 'Modules.Autoupgrade.Admin'));
-            $this->next = 'upgradeFiles';
-
-            return true;
-        }
-
         $timeAllowed = $this->container->getUpgradeConfiguration()->getNumberOfFilesPerCall();
         $relative_backup_path = str_replace(_PS_ROOT_DIR_, '', $this->container->getProperty(UpgradeContainer::BACKUP_PATH));
         $report = '';
@@ -289,7 +280,7 @@ class BackupDb extends AbstractTask
             $this->container->getState()->setDbStep(0);
 
             $this->logger->info($this->translator->trans('Database backup done in filename %s. Now upgrading files...', array($this->container->getState()->getBackupName()), 'Modules.Autoupgrade.Admin'));
-            $this->next = 'upgradeFiles';
+            $this->next = 'backupComplete';
 
             return true;
         }

--- a/classes/TaskRunner/Backup/BackupFiles.php
+++ b/classes/TaskRunner/Backup/BackupFiles.php
@@ -25,7 +25,7 @@
  *  International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace PrestaShop\Module\AutoUpgrade\TaskRunner\Upgrade;
+namespace PrestaShop\Module\AutoUpgrade\TaskRunner\Backup;
 
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeFileNames;
 use PrestaShop\Module\AutoUpgrade\TaskRunner\AbstractTask;
@@ -35,14 +35,6 @@ class BackupFiles extends AbstractTask
 {
     public function run()
     {
-        if (!$this->container->getUpgradeConfiguration()->get('PS_AUTOUP_BACKUP')) {
-            $this->stepDone = true;
-            $this->next = 'backupDb';
-            $this->logger->info('File backup skipped.');
-
-            return true;
-        }
-
         $this->stepDone = false;
         $backupFilesFilename = $this->container->getState()->getBackupFilesFilename();
         if (empty($backupFilesFilename)) {

--- a/classes/TaskRunner/Miscellaneous/UpdateConfig.php
+++ b/classes/TaskRunner/Miscellaneous/UpdateConfig.php
@@ -91,9 +91,6 @@ class UpdateConfig extends AbstractTask
 
             $config['directory.version_num'] = $request['directory_num'];
         }
-        if (isset($request['skip_backup'])) {
-            $config['skip_backup'] = $request['skip_backup'];
-        }
 
         if (!$this->writeConfig($config)) {
             $this->error = true;

--- a/classes/TaskRunner/Upgrade/RemoveSamples.php
+++ b/classes/TaskRunner/Upgrade/RemoveSamples.php
@@ -117,23 +117,13 @@ class RemoveSamples extends AbstractTask
 
         if (0 >= count($removeList)) {
             $this->stepDone = true;
-            $this->next = 'backupFiles';
+            $this->next = 'upgradeFiles';
             $this->logger->info(
                 $this->translator->trans(
-                    'All sample files removed. Now backing up files.',
+                    'All sample files removed. Backup process skipped. Now upgrading files.',
                     array(),
                     'Modules.Autoupgrade.Admin'
             ));
-
-            if ($this->container->getUpgradeConfiguration()->get('skip_backup')) {
-                $this->next = 'upgradeFiles';
-                $this->logger->info(
-                    $this->translator->trans(
-                        'All sample files removed. Backup process skipped. Now upgrading files.',
-                        array(),
-                        'Modules.Autoupgrade.Admin'
-                ));
-            }
         }
 
         return true;

--- a/classes/Twig/Form/BackupOptionsForm.php
+++ b/classes/Twig/Form/BackupOptionsForm.php
@@ -54,22 +54,6 @@ class BackupOptionsForm
         $translationDomain = 'Modules.Autoupgrade.Admin';
 
         $this->fields = array(
-            'PS_AUTOUP_BACKUP' => array(
-                'title' => $this->translator->trans(
-                    'Back up my files and database',
-                    array(),
-                    $translationDomain
-                ),
-                'cast' => 'intval',
-                'validation' => 'isBool',
-                'defaultValue' => '1',
-                'type' => 'bool',
-                'desc' => $this->translator->trans(
-                    'Automatically back up your database and files in order to restore your shop if needed. This is experimental: you should still perform your own manual backup for safety.',
-                    array(),
-                    $translationDomain
-                ),
-            ),
             'PS_AUTOUP_KEEP_IMAGES' => array(
                 'title' => $this->translator->trans(
                     'Back up my images',

--- a/classes/UpgradePage.php
+++ b/classes/UpgradePage.php
@@ -304,7 +304,6 @@ class UpgradePage
         $jsParams = array(
             'manualMode' => (bool) $this->manualMode,
             '_PS_MODE_DEV_' => (defined('_PS_MODE_DEV_') && true == _PS_MODE_DEV_),
-            'PS_AUTOUP_BACKUP' => (bool) $this->config->get('PS_AUTOUP_BACKUP'),
             'adminDir' => $adminDir,
             'adminUrl' => __PS_BASE_URI__ . $adminDir,
             'token' => $this->token,

--- a/classes/UpgradeTools/TaskRepository.php
+++ b/classes/UpgradeTools/TaskRepository.php
@@ -56,11 +56,17 @@ class TaskRepository
             case 'rollbackComplete':
                 return new \PrestaShop\Module\AutoUpgrade\TaskRunner\Rollback\RollbackComplete($container);
 
-            // UPGRADE
+            // BACKUP
+            case 'backup':
+                return new \PrestaShop\Module\AutoUpgrade\TaskRunner\Backup\Backup($container);
             case 'backupDb':
-                return new \PrestaShop\Module\AutoUpgrade\TaskRunner\Upgrade\BackupDb($container);
+                return new \PrestaShop\Module\AutoUpgrade\TaskRunner\Backup\BackupDb($container);
             case 'backupFiles':
-                return new \PrestaShop\Module\AutoUpgrade\TaskRunner\Upgrade\BackupFiles($container);
+                return new \PrestaShop\Module\AutoUpgrade\TaskRunner\Backup\BackupFiles($container);
+            case 'backupComplete':
+                return new \PrestaShop\Module\AutoUpgrade\TaskRunner\Backup\BackupComplete($container);
+
+            // UPGRADE
             case 'cleanDatabase':
                 return new \PrestaShop\Module\AutoUpgrade\TaskRunner\Upgrade\CleanDatabase($container);
             case 'download':

--- a/cli-backup.php
+++ b/cli-backup.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author PrestaShop SA <contact@prestashop.com>
+ *  @copyright  2007-2018 PrestaShop SA
+ *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+if (PHP_SAPI !== 'cli') {
+    echo 'This script must be called from CLI';
+    exit(1);
+}
+
+require_once realpath(dirname(__FILE__) . '/../../modules/autoupgrade') . '/ajax-upgradetabconfig.php';
+$container = autoupgrade_init_container(dirname(__FILE__));
+
+$container->setLogger(new PrestaShop\Module\AutoUpgrade\Log\StreamedLogger());
+$controller = new \PrestaShop\Module\AutoUpgrade\TaskRunner\Backup\AllBackupTasks($container);
+$controller->init();
+exit($controller->run());

--- a/js/upgrade.js
+++ b/js/upgrade.js
@@ -2,7 +2,6 @@ if (typeof input === 'undefined') {
   var input = {
     manualMode: "",
     _PS_MODE_DEV_: true,
-    PS_AUTOUP_BACKUP: true,
     adminUrl: "http://test.com/admin",
     adminDir: "/admin",
     token: "asdadsasdasdasd",
@@ -190,6 +189,7 @@ $(document).ready(function(){
 
   // prepare available button here, without params ?
   prepareNextButton("#upgradeNow",firstTimeParams);
+  prepareNextButton("#backup", {});
 
   /**
    * reset rollbackParams js array (used to init rollback button)
@@ -375,6 +375,10 @@ function afterError(res) {
   addQuickInfo(["unbind :) "]);
 }
 
+function afterBackup(res) {
+  startProcess("backup");
+}
+
 function afterRollback(res) {
   startProcess("rollback");
 }
@@ -408,7 +412,7 @@ function afterBackupFiles(res) {
 function afterBackupDb(res) {
   var params = res.nextParams;
 
-  if (res.stepDone && input.PS_AUTOUP_BACKUP === true) {
+  if (res.stepDone) {
     $("#restoreBackupContainer").show();
     $("select[name=restoreName]")
       .append("<option selected=\"selected\" value=\"" + params.backupName + "\">" + params.backupName + "</option>")
@@ -828,16 +832,6 @@ $(document).ready(function() {
           return false;
         }
         params.directory_num = $("input[name=directory_num]").val();
-      }
-    }
-    // note: skipBackup is currently not used
-    if ($(this).attr("name") == "submitConf-skipBackup") {
-      var skipBackup = $("input[name=submitConf-skipBackup]:checked").length;
-      if (skipBackup == 0 || confirm(input.translation.confirmSkipBackup)) {
-        params.skip_backup = $("input[name=submitConf-skipBackup]:checked").length;
-      } else {
-        $("input[name=submitConf-skipBackup]:checked").removeAttr("checked");
-        return false;
       }
     }
 

--- a/views/templates/block/checklist.twig
+++ b/views/templates/block/checklist.twig
@@ -168,7 +168,10 @@
                 </tr>
             </table>
             <br>
-            <p class="alert alert-info">{{ 'Please also make sure you make a full manual backup of your files and database.'|trans }}</p>
+            <p class="alert alert-info">
+                {{ 'Please also make sure you make a full manual backup of your files and database.'|trans }}
+                <a href="#" id="backup" class="upgradestep btn btn-primary">{{ 'Backup your shop'|trans }}</a>
+            </p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Backup tasks have been removed from the upgrade process, as it can take a long time. Each backup must be triggered manually.

The current web interface does not allow to trigger the backup, because it is supposed to be completely reworked.