### PR TITLE
Reverse arrays and use array_pop instead of array_shift

### DIFF
--- a/classes/TaskRunner/Upgrade/BackupDb.php
+++ b/classes/TaskRunner/Upgrade/BackupDb.php
@@ -74,6 +74,7 @@ class BackupDb extends AbstractTask
             }
             $this->container->getState()->setDbStep(0);
             $tablesToBackup = $this->container->getDb()->executeS('SHOW TABLES LIKE "' . _DB_PREFIX_ . '%"', true, false);
+            $tablesToBackup = array_reverse($tablesToBackup);
             $this->container->getFileConfigurationStorage()->save($tablesToBackup, UpgradeFileNames::DB_TABLES_TO_BACKUP_LIST);
         }
 
@@ -96,7 +97,7 @@ class BackupDb extends AbstractTask
                 if (count($tablesToBackup) == 0) {
                     break;
                 }
-                $table = current(array_shift($tablesToBackup));
+                $table = current(array_pop($tablesToBackup));
                 $this->container->getState()->setBackupLoopLimit(0);
             }
 

--- a/classes/TaskRunner/Upgrade/BackupFiles.php
+++ b/classes/TaskRunner/Upgrade/BackupFiles.php
@@ -57,6 +57,7 @@ class BackupFiles extends AbstractTask
         if (!$this->container->getFileConfigurationStorage()->exists(UpgradeFileNames::FILES_TO_BACKUP_LIST)) {
             /** @todo : only add files and dir listed in "originalPrestashopVersion" list */
             $filesToBackup = $this->container->getFilesystemAdapter()->listFilesInDir($this->container->getProperty(UpgradeContainer::PS_ROOT_PATH), 'backup', false);
+            $filesToBackup = array_reverse($filesToBackup);
             $this->container->getFileConfigurationStorage()->save($filesToBackup, UpgradeFileNames::FILES_TO_BACKUP_LIST);
             if (count($filesToBackup)) {
                 $this->logger->debug($this->translator->trans('%s Files to backup.', array(count($filesToBackup)), 'Modules.Autoupgrade.Admin'));

--- a/classes/TaskRunner/Upgrade/RemoveSamples.php
+++ b/classes/TaskRunner/Upgrade/RemoveSamples.php
@@ -74,7 +74,9 @@ class RemoveSamples extends AbstractTask
                 array('path' => $latestPath . '/override', 'filter' => '.php'),
             ));
 
-            $this->container->getState()->setRemoveList($removeList);
+            $this->container->getState()->setRemoveList(
+                array_reverse($removeList)
+            );
 
             if (count($removeList)) {
                 $this->logger->debug(
@@ -85,7 +87,7 @@ class RemoveSamples extends AbstractTask
 
         $filesystem = new Filesystem();
         for ($i = 0; $i < $this->container->getUpgradeConfiguration()->getNumberOfFilesPerCall() && 0 < count($removeList); ++$i) {
-            $file = array_shift($removeList);
+            $file = array_pop($removeList);
             try {
                 $filesystem->remove($file);
             } catch (\Exception $e) {

--- a/classes/TaskRunner/Upgrade/UpgradeFiles.php
+++ b/classes/TaskRunner/Upgrade/UpgradeFiles.php
@@ -67,7 +67,7 @@ class UpgradeFiles extends AbstractTask
                 break;
             }
 
-            $file = array_shift($filesToUpgrade);
+            $file = array_pop($filesToUpgrade);
             if (!$this->upgradeThisFile($file)) {
                 // put the file back to the begin of the list
                 $this->next = 'error';
@@ -264,9 +264,9 @@ class UpgradeFiles extends AbstractTask
         }
 
         // also add files to remove
-        $list_files_to_upgrade = array_merge($list_files_diff, $list_files_to_upgrade);
+        $list_files_to_upgrade = array_reverse(array_merge($list_files_diff, $list_files_to_upgrade));
 
-        $filesToMoveToTheBeginning = array(
+        $filesToMoveToTheEnd = array(
             DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php',
             DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'composer' . DIRECTORY_SEPARATOR . 'ClassLoader.php',
             DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'composer' . DIRECTORY_SEPARATOR . 'autoload_classmap.php',
@@ -280,10 +280,10 @@ class UpgradeFiles extends AbstractTask
             DIRECTORY_SEPARATOR . 'vendor',
         );
 
-        foreach ($filesToMoveToTheBeginning as $file) {
+        foreach ($filesToMoveToTheEnd as $file) {
             if ($key = array_search($file, $list_files_to_upgrade)) {
                 unset($list_files_to_upgrade[$key]);
-                $list_files_to_upgrade = array_merge(array($file), $list_files_to_upgrade);
+                $list_files_to_upgrade[] = $file;
             }
         }
 

--- a/classes/TaskRunner/Upgrade/UpgradeModules.php
+++ b/classes/TaskRunner/Upgrade/UpgradeModules.php
@@ -60,7 +60,7 @@ class UpgradeModules extends AbstractTask
         // module list
         if (count($listModules) > 0) {
             do {
-                $module_info = array_shift($listModules);
+                $module_info = array_pop($listModules);
                 try {
                     $this->logger->debug($this->translator->trans('Upgrading module %module%...', ['%module%' => $module_info['name']], 'Modules.Autoupgrade.Admin'));
                     $this->container->getModuleAdapter()->upgradeModule($module_info['id'], $module_info['name']);
@@ -142,6 +142,7 @@ class UpgradeModules extends AbstractTask
     {
         try {
             $modulesToUpgrade = $this->container->getModuleAdapter()->listModulesToUpgrade($this->container->getState()->getModules_addons());
+            $modulesToUpgrade = array_reverse($modulesToUpgrade);
             $this->container->getFileConfigurationStorage()->save($modulesToUpgrade, UpgradeFileNames::MODULES_TO_UPGRADE_LIST);
         } catch (UpgradeException $e) {
             $this->handleException($e);

--- a/classes/UpgradeTools/Database.php
+++ b/classes/UpgradeTools/Database.php
@@ -44,7 +44,7 @@ class Database
 
         $all_tables = array();
         foreach ($tables as $v) {
-            $table = array_shift($v);
+            $table = reset($v);
             $all_tables[$table] = $table;
         }
 

--- a/classes/ZipAction.php
+++ b/classes/ZipAction.php
@@ -75,7 +75,7 @@ class ZipAction
         }
 
         for ($i = 0; $i < $this->configMaxNbFilesCompressedInARow && count($filesList); ++$i) {
-            $file = array_shift($filesList);
+            $file = array_pop($filesList);
 
             $archiveFilename = $this->getFilepathInArchive($file);
             if (!$this->isFileWithinFileSizeLimit($file)) {


### PR DESCRIPTION
In some configuration (especially on PHP 5.6), calling `array_shift` reduce significantly the server performance. This PR removes this method when possible and replaces it with `array_reverse` / `array_pop`.

![image](https://user-images.githubusercontent.com/6768917/60819248-26869a80-a197-11e9-9c51-a18cf8a91e5f.png)
