### PR TITLE
SQL upgrade files can use DB_NAME placeholder

### DIFF
--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -328,8 +328,8 @@ abstract class CoreUpgrader
      */
     protected function applySqlParams(array $sqlFiles)
     {
-        $search = array('PREFIX_', 'ENGINE_TYPE');
-        $replace = array(_DB_PREFIX_, (defined('_MYSQL_ENGINE_') ? _MYSQL_ENGINE_ : 'MyISAM'));
+        $search = array('PREFIX_', 'ENGINE_TYPE', 'DB_NAME');
+        $replace = array(_DB_PREFIX_, (defined('_MYSQL_ENGINE_') ? _MYSQL_ENGINE_ : 'MyISAM'), _DB_NAME_);
 
         $sqlRequests = array();
 


### PR DESCRIPTION
SQL upgrade files can use DB_NAME placeholder

Which will be useful for 1.7.7.0 version (see SQL upgrade file)

Test: to validate this modification you will need to create a build based on this PR https://github.com/PrestaShop/PrestaShop/pull/16465 which uses the new feature (so you can validate 2 PRs at once, amazing!)