### PR TITLE
Fix v4.9.0 upgrade filename

### DIFF
--- a/upgrade/install-4.9.0.php
+++ b/upgrade/install-4.9.0.php
@@ -17,6 +17,10 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
 function upgrade_module_4_9_0($module)
 {
     return $module->registerHookAndSetToTop('dashboardZoneOne');


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | v4.9.0 upgrade filename was wrong, so it was probably ignored 🤔
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |  
| How to test?  | Please check that, following an upgrade from a version < 4.9.0 to a version > 4.9.0 autoupgrade module is correctly registered on hook `dashboardZoneOne` and set to top
