### PR TITLE
Revert "Test upgrades for PS1.7 with php7.1"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ services: docker
 
 php:
   - '5.6'
-  - '7.1'
 
 env:
   - VERSION=1.7.2.2
@@ -15,13 +14,6 @@ env:
   # Check how the upgrade behaves with the latest PrestaShop
   - VERSION=latest
     CHANNEL=minor
-
-jobs:
-  exclude:
-  - php: '7.1'
-    env: VERSION=1.6 CHANNEL=major
-  - php: '7.1'
-    env: VERSION=1.6.1.10 CHANNEL=minor
 
 cache:
   directories:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Just realized https://github.com/PrestaShop/autoupgrade/pull/361 is probably useless. Because phpunit tests will be moved in GitHub Actions and phpstan tests and integration tests are run in a docker image so the PHP version used by Travis does not matter.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
