### PR TITLE
Check for version instead of if file exists

### DIFF
--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader17.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader17.php
@@ -101,7 +101,7 @@ class CoreUpgrader17 extends CoreUpgrader
         // TODO: Update AdminTranslationsController::addNewTabs to install tabs translated
 
         // CLDR has been updated on PS 1.7.6.0. From this version, updates are not needed anymore.
-        if (method_exists('\PrestaShop\PrestaShop\Core\Cldr\Update', 'fetchLocale')) {
+        if (version_compare($this->container->getState()->getInstallVersion(), '1.7.6.0', '<')) {
             $cldrUpdate = new \PrestaShop\PrestaShop\Core\Cldr\Update(_PS_TRANSLATIONS_DIR_);
             $cldrUpdate->fetchLocale(\Language::getLocaleByIso($isoCode));
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Because this module was checking the presence of a file instead of checking the version of PrestaShop, if that file was present, the module was calling a function from it that throw a exception in recent version of PrestaShop leading in a upgrade error. This PR fixes it by checking the PrestaShop version.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Upgrade from PS < 1.7.6.0 to 1.7.7.0, no error should be displayed.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
