### PR TITLE
Fix error with private method and upgrade

### DIFF
--- a/autoupgrade.php
+++ b/autoupgrade.php
@@ -162,7 +162,7 @@ class Autoupgrade extends Module
      *
      * @return bool
      */
-    private function registerHookAndSetToTop($hookName)
+    public function registerHookAndSetToTop($hookName)
     {
         return $this->registerHook($hookName) && $this->updatePosition((int) Hook::getIdByName($hookName), 0);
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The method registerHookAndSetToTop must be public
| Type?         | bug fix 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/22399
| How to test?  | Try to upgrade module from v4.8 to v4.9 (see ticket details)


## Insights

When upgrading the module from version 4.8.0 through command line you should not have an error  In install-4.9.0.php line 32: Call to private method Autoupgrade::registerHookAndSetToTop() from context    ![image](https://user-images.githubusercontent.com/7163132/102023224-34791b80-3d8c-11eb-96fa-f1ec74e5133d.png) As the function is called in upgrade file it can not be private.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
