### PR TITLE
Uninstall incompatible modules

### DIFF
--- a/classes/TaskRunner/Upgrade/BackupDb.php
+++ b/classes/TaskRunner/Upgrade/BackupDb.php
@@ -39,8 +39,8 @@ class BackupDb extends AbstractTask
         if (!$this->container->getUpgradeConfiguration()->get('PS_AUTOUP_BACKUP')) {
             $this->stepDone = true;
             $this->container->getState()->setDbStep(0);
-            $this->logger->info($this->translator->trans('Database backup skipped. Now upgrading files...', array(), 'Modules.Autoupgrade.Admin'));
-            $this->next = 'upgradeFiles';
+            $this->logger->info($this->translator->trans('Database backup skipped. Now uninstalling incompatible modules...', array(), 'Modules.Autoupgrade.Admin'));
+            $this->next = 'uninstallIncompatibleModules';
 
             return true;
         }
@@ -289,8 +289,8 @@ class BackupDb extends AbstractTask
             // reset dbStep at the end of this step
             $this->container->getState()->setDbStep(0);
 
-            $this->logger->info($this->translator->trans('Database backup done in filename %s. Now upgrading files...', array($this->container->getState()->getBackupName()), 'Modules.Autoupgrade.Admin'));
-            $this->next = 'upgradeFiles';
+            $this->logger->info($this->translator->trans('Database backup done in filename %s. Now uninstalling incompatible modules...', array($this->container->getState()->getBackupName()), 'Modules.Autoupgrade.Admin'));
+            $this->next = 'uninstallIncompatibleModules';
 
             return true;
         }

--- a/classes/TaskRunner/Upgrade/RemoveSamples.php
+++ b/classes/TaskRunner/Upgrade/RemoveSamples.php
@@ -128,10 +128,10 @@ class RemoveSamples extends AbstractTask
             ));
 
             if ($this->container->getUpgradeConfiguration()->get('skip_backup')) {
-                $this->next = 'upgradeFiles';
+                $this->next = 'uninstallIncompatibleModules';
                 $this->logger->info(
                     $this->translator->trans(
-                        'All sample files removed. Backup process skipped. Now upgrading files.',
+                        'All sample files removed. Backup process skipped. Now uninstalling incompatible modules.',
                         array(),
                         'Modules.Autoupgrade.Admin'
                 ));

--- a/classes/TaskRunner/Upgrade/UninstallIncompatibleModules.php
+++ b/classes/TaskRunner/Upgrade/UninstallIncompatibleModules.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+namespace PrestaShop\Module\AutoUpgrade\TaskRunner\Upgrade;
+
+use PrestaShop\Module\AutoUpgrade\TaskRunner\AbstractTask;
+use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
+use PrestaShop\Module\AutoUpgrade\UpgradeException;
+use PrestaShop\Module\AutoUpgrade\UpgradeTools\SettingsFileWriter;
+
+/**
+ * Uninstall modules that are not compatible with the version of PrestaShop being installed
+ */
+class UninstallIncompatibleModules extends AbstractTask
+{
+    // Modules incompatible with 1.7.x
+    private static $incompatibleModules = [
+        'bankwire',
+        'blockbanner',
+        'blockcart',
+        'blockcategories',
+        'blockcms',
+        'blockcmsinfo',
+        'blockcontact',
+        'blockcurrencies',
+        'blocklanguages',
+        'blocklayered',
+        'blockmyaccount',
+        'blocknewsletter',
+        'blocksearch',
+        'blocksocial',
+        'blocktopmenu',
+        'blockuserinfo',
+        'cheque',
+        'homefeatured',
+        'homeslider',
+        'onboarding',
+        'socialsharing',
+        'vatnumber',
+        'blockadvertising',
+        'blockbestsellers',
+        'blockcustomerprivacy',
+        'blocklink',
+        'blockmanufacturer',
+        'blocknewproducts',
+        'blockpermanentlinks',
+        'blockrss',
+        'blocksharefb',
+        'blockspecials',
+        'blocksupplier',
+        'blockviewed',
+        'crossselling',
+        'followup',
+        'productscategory',
+        'producttooltip',
+        'mailalert',
+        'blockcontactinfos',
+        'blockfacebook',
+        'blockmyaccountfooter',
+        'blockpaymentlogo',
+        'blockstore',
+        'blocktags',
+        'blockwishlist',
+        'productpaymentlogos',
+        'sendtoafriend',
+        'themeconfigurator',
+    ];
+
+    public function run()
+    {
+        $this->next = 'upgradeDb';
+        if (version_compare($this->container->getState()->getInstallVersion(), '1.7.0.0', '<')) {
+            $this->logger->info(
+                $this->translator->trans(
+                    'No incompatible module to uninstall. Now upgrading database...',
+                    array(),
+                    'Modules.Autoupgrade.Admin'
+                )
+            );
+
+            return true;
+        }
+        $modulePath = $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH)
+            . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR;
+
+        if (!is_dir($modulePath)) {
+            throw (new UpgradeException(
+                $this->translator->trans(
+                    '[ERROR] %dir% does not exist or is not a directory.',
+                    array('%dir%' => $modulePath),
+                    'Modules.Autoupgrade.Admin'
+                )
+            ))
+                ->addQuickInfo(
+                    $this->translator->trans(
+                        '[ERROR] %s does not exist or is not a directory.',
+                        array($modulePath),
+                        'Modules.Autoupgrade.Admin'
+                    )
+                )
+                ->setSeverity(UpgradeException::SEVERITY_ERROR);
+        }
+
+        foreach (scandir($modulePath) as $moduleName) {
+            if (
+                in_array($moduleName, static::$incompatibleModules)
+                && file_exists($modulePath . $moduleName . DIRECTORY_SEPARATOR . $moduleName . '.php')
+            ) {
+                $this->logger->info('Uninstalling module ' . $moduleName);
+                \Module::getInstanceByName($moduleName)->uninstall();
+            }
+        }
+
+        $this->logger->info(
+            $this->translator->trans(
+                'Incompatible modules uninstalled. Now upgrading database...',
+                array(),
+                'Modules.Autoupgrade.Admin'
+            )
+        );
+
+        return true;
+    }
+
+    public function init()
+    {
+        $this->container->getCacheCleaner()->cleanFolders();
+
+        // Migrating settings file
+        $this->container->initPrestaShopAutoloader();
+        (new SettingsFileWriter($this->translator))->migrateSettingsFile($this->logger);
+        parent::init();
+    }
+}

--- a/classes/TaskRunner/Upgrade/UpgradeDb.php
+++ b/classes/TaskRunner/Upgrade/UpgradeDb.php
@@ -64,4 +64,14 @@ class UpgradeDb extends AbstractTask
 
         return new CoreUpgrader17($this->container, $this->logger);
     }
+
+    public function init()
+    {
+        $this->container->getCacheCleaner()->cleanFolders();
+
+        // Migrating settings file
+        $this->container->initPrestaShopAutoloader();
+        (new SettingsFileWriter($this->translator))->migrateSettingsFile($this->logger);
+        parent::init();
+    }
 }

--- a/classes/TaskRunner/Upgrade/UpgradeDb.php
+++ b/classes/TaskRunner/Upgrade/UpgradeDb.php
@@ -64,14 +64,4 @@ class UpgradeDb extends AbstractTask
 
         return new CoreUpgrader17($this->container, $this->logger);
     }
-
-    public function init()
-    {
-        $this->container->getCacheCleaner()->cleanFolders();
-
-        // Migrating settings file
-        $this->container->initPrestaShopAutoloader();
-        (new SettingsFileWriter($this->translator))->migrateSettingsFile($this->logger);
-        parent::init();
-    }
 }

--- a/classes/TaskRunner/Upgrade/UpgradeFiles.php
+++ b/classes/TaskRunner/Upgrade/UpgradeFiles.php
@@ -58,11 +58,11 @@ class UpgradeFiles extends AbstractTask
         // @TODO : does not upgrade files in modules, translations if they have not a correct md5 (or crc32, or whatever) from previous version
         for ($i = 0; $i < $this->container->getUpgradeConfiguration()->getNumberOfFilesPerCall(); ++$i) {
             if (count($filesToUpgrade) <= 0) {
-                $this->next = 'upgradeDb';
+                $this->next = 'uninstallIncompatibleModules';
                 if (file_exists(UpgradeFileNames::FILES_TO_UPGRADE_LIST)) {
                     unlink(UpgradeFileNames::FILES_TO_UPGRADE_LIST);
                 }
-                $this->logger->info($this->translator->trans('All files upgraded. Now upgrading database...', array(), 'Modules.Autoupgrade.Admin'));
+                $this->logger->info($this->translator->trans('All files upgraded. Now uninstalling incompatible modules...', array(), 'Modules.Autoupgrade.Admin'));
                 $this->stepDone = true;
                 break;
             }
@@ -205,8 +205,8 @@ class UpgradeFiles extends AbstractTask
         } elseif (is_dir($dest)) {
             if (strpos($dest, DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR) === false) {
                 FilesystemAdapter::deleteDirectory($dest, true);
+                $this->logger->debug(sprintf('removed dir %1$s.', $file));
             }
-            $this->logger->debug(sprintf('removed dir %1$s.', $file));
 
             return true;
         } else {

--- a/classes/TaskRunner/Upgrade/UpgradeFiles.php
+++ b/classes/TaskRunner/Upgrade/UpgradeFiles.php
@@ -58,11 +58,11 @@ class UpgradeFiles extends AbstractTask
         // @TODO : does not upgrade files in modules, translations if they have not a correct md5 (or crc32, or whatever) from previous version
         for ($i = 0; $i < $this->container->getUpgradeConfiguration()->getNumberOfFilesPerCall(); ++$i) {
             if (count($filesToUpgrade) <= 0) {
-                $this->next = 'uninstallIncompatibleModules';
+                $this->next = 'upgradeDb';
                 if (file_exists(UpgradeFileNames::FILES_TO_UPGRADE_LIST)) {
                     unlink(UpgradeFileNames::FILES_TO_UPGRADE_LIST);
                 }
-                $this->logger->info($this->translator->trans('All files upgraded. Now uninstalling incompatible modules...', array(), 'Modules.Autoupgrade.Admin'));
+                $this->logger->info($this->translator->trans('All files upgraded. Now upgrading database...', array(), 'Modules.Autoupgrade.Admin'));
                 $this->stepDone = true;
                 break;
             }

--- a/classes/UpgradeTools/TaskRepository.php
+++ b/classes/UpgradeTools/TaskRepository.php
@@ -71,6 +71,8 @@ class TaskRepository
                 return new \PrestaShop\Module\AutoUpgrade\TaskRunner\Upgrade\UpgradeComplete($container);
             case 'upgradeDb':
                 return new \PrestaShop\Module\AutoUpgrade\TaskRunner\Upgrade\UpgradeDb($container);
+            case 'uninstallIncompatibleModules':
+                return new \PrestaShop\Module\AutoUpgrade\TaskRunner\Upgrade\UninstallIncompatibleModules($container);
             case 'upgradeFiles':
                 return new \PrestaShop\Module\AutoUpgrade\TaskRunner\Upgrade\UpgradeFiles($container);
             case 'upgradeModules':


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When upgrading from ps < 1.7.0.0 to >= 1.7.0.0, some core modules should be uninstall because they are not compatible with the new version. This PR handles that.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/22668
| How to test?      | Upgrade from 1.6.1.24 to 1.7.7.1, the upgrade process should work without any issue<br>As the CI is not working properly, we should try an update from 1.7.2.2 to 1.7.7.1 too.
| Possible impacts? | /

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
