### PR TITLE
Clear cache before enabling theme

### DIFF
--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -27,6 +27,7 @@
 
 namespace PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader;
 
+use Cache;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 use PrestaShop\Module\AutoUpgrade\UpgradeException;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\ThemeAdapter;
@@ -679,6 +680,8 @@ abstract class CoreUpgrader
         }
         $this->logger->info($this->container->getTranslator()->trans('Switching to default theme.', array(), 'Modules.Autoupgrade.Admin'));
         $themeAdapter = new ThemeAdapter($this->db, $this->destinationUpgradeVersion);
+
+        Cache::clean('*');
 
         $themeErrors = $themeAdapter->enableTheme(
             $themeAdapter->getDefaultTheme()


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Please be specific when describing the PR. Every detail helps: What are you changing? Why?
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Partially PrestaShop/PrestaShop#22668
| How to test?      | Once https://github.com/PrestaShop/PrestaShop/pull/22682 is merged, try migrating from 1.6.1.24 to a build of PrestaShop containing #22682 **with `Use default theme` option selected** in the 1-click upgrade module. The process should complete without any error.
| Possible impacts? | /

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
