### PR TITLE
Unescape special chars on translate chain

### DIFF
--- a/views/templates/block/upgradeButtonBlock.twig
+++ b/views/templates/block/upgradeButtonBlock.twig
@@ -122,7 +122,7 @@
                         {% endif %}
                         <div class="margin-form">
                             {{ 'Save in the following directory the archive file of the version you want to upgrade to: %s'|trans(['<b>/admin/autoupgrade/download/</b>'])|raw }}<br>
-                            {{ 'Click "Save" once the archive is there.'|trans }}<br>
+                            {{ 'Click "Save" once the archive is there.'|trans|raw }}<br>
                             {{ 'This option will skip the download step.'|trans }}
                         </div>
                     </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | There was encoded html chars on the configuration page
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/23147.
| How to test?      | See issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
