### PR TITLE
Fix get_matrix returning the same value twice

### DIFF
--- a/.github/get_matrix.php
+++ b/.github/get_matrix.php
@@ -12,9 +12,11 @@ foreach ($reports as $report) {
     if ("" === $currentDate) {
         $currentDate = $date;
     }
+
     if (null === $report['download'] || in_array($report['download'], $zipFiles)) {
         continue;
     }
+
     if ($date === $currentDate) {
         $zipFiles[] = $report['download'];
         $matrix[] = [

--- a/.github/get_matrix.php
+++ b/.github/get_matrix.php
@@ -6,12 +6,17 @@ $nightlyEndpoint = "https://api-nightly.prestashop.com/reports";
 
 $reports = json_decode(file_get_contents($nightlyEndpoint), true);
 $currentDate = "";
+$zipFiles = [];
 foreach ($reports as $report) {
     $date = strtotime($report['date']);
     if ("" === $currentDate) {
         $currentDate = $date;
     }
+    if (null === $report['download'] || in_array($report['download'], $zipFiles)) {
+        continue;
+    }
     if ($date === $currentDate) {
+        $zipFiles[] = $report['download'];
         $matrix[] = [
             "from" => "1.7.6.9",
             "channel" => "archive",


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Now that autoupgrade results are pushed on the nightlyboard, these results were used in the get_matrix function leading to duplicate jobs. This PR fixes it
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | `php .github/get_matrix.php` should return a json table with only 2 objects.
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
