### PR TITLE
Add more nightly tests and re-enable 1.6 migration test

### DIFF
--- a/.github/action.yml
+++ b/.github/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - name: Build docker compose stack
       env:
-        VERSION: ${{ matrix.ps-versions.from }}
+        VERSION: ${{ matrix.from }}
       shell: bash
       run: |
         docker-compose -f docker-compose.yml up -d

--- a/.github/action.yml
+++ b/.github/action.yml
@@ -18,6 +18,7 @@ runs:
         CHANNEL: ${{ matrix.ps-versions.channel }}
         ARCHIVE_URL: ${{ matrix.ps-versions.file }}
         VERSION: ${{ matrix.ps-versions.version }}
+        FROM: ${{ matrix.from }}
       shell: bash
       run: ${{ github.action_path }}/action_upgrade.sh
     - name: Check endpoints response

--- a/.github/action_upgrade.sh
+++ b/.github/action_upgrade.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 
 if [[ $CHANNEL == "archive" ]]; then
+  if [[ $FROM == 1.6* ]] && [[ $VERSION == 1.7* ]]; then
+    UPDATE_THEME=1
+  else
+    UPDATE_THEME=0
+  fi
   docker exec -u www-data prestashop_autoupgrade mkdir admin-dev/autoupgrade/download
   docker exec -u www-data prestashop_autoupgrade curl $ARCHIVE_URL -o admin-dev/autoupgrade/download/prestashop.zip
-  echo "{\"channel\":\"archive\",\"archive_prestashop\":\"prestashop.zip\",\"archive_num\":\"${VERSION}\"}" > config.json
+  echo "{\"channel\":\"archive\",\"archive_prestashop\":\"prestashop.zip\",\"archive_num\":\"${VERSION}\", \"PS_AUTOUP_CHANGE_DEFAULT_THEME\":${UPDATE_THEME}}" > config.json
   docker exec -u www-data prestashop_autoupgrade php admin-dev/autoupgrade/cli-updateconfig.php --from=modules/autoupgrade/config.json --dir=admin-dev
 fi
 
-docker exec -u www-data prestashop_autoupgrade php modules/autoupgrade/tests/testCliProcess.php admin-dev/autoupgrade/cli-upgrade.php  --dir="admin-dev" --channel="$CHANNEL"
+docker exec -u www-data prestashop_autoupgrade php modules/autoupgrade/tests/testCliProcess.php admin-dev/autoupgrade/cli-upgrade.php  --dir="admin-dev"

--- a/.github/action_upgrade.sh
+++ b/.github/action_upgrade.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
 if [[ $CHANNEL == "archive" ]]; then
-  if [[ $FROM == 1.6* ]] && [[ $VERSION == 1.7* ]]; then
+  if [[ "${FROM}" == 1.6* ]] && [[ "${VERSION}" == 1.7* ]]; then
     UPDATE_THEME=1
   else
     UPDATE_THEME=0
   fi
+
   docker exec -u www-data prestashop_autoupgrade mkdir admin-dev/autoupgrade/download
   docker exec -u www-data prestashop_autoupgrade curl $ARCHIVE_URL -o admin-dev/autoupgrade/download/prestashop.zip
   echo "{\"channel\":\"archive\",\"archive_prestashop\":\"prestashop.zip\",\"archive_num\":\"${VERSION}\", \"PS_AUTOUP_CHANGE_DEFAULT_THEME\":${UPDATE_THEME}}" > config.json

--- a/.github/get_matrix.php
+++ b/.github/get_matrix.php
@@ -20,7 +20,6 @@ foreach ($reports as $report) {
     if ($date === $currentDate) {
         $zipFiles[] = $report['download'];
         $matrix[] = [
-            "from" => "1.7.6.9",
             "channel" => "archive",
             "branch" => $report['version'],
             "version" => getVersionFromFilename($report['download']),

--- a/.github/get_results.php
+++ b/.github/get_results.php
@@ -72,6 +72,7 @@ function getResultFiles(string $branch): array
         if ($file->isDir() || strpos($file->getPathname(), $branch . '.txt') === false) {
             continue;
         }
+
         $files[] = $file->getPathname();
     }
 

--- a/.github/workflows/nigthly_upgrade.yml
+++ b/.github/workflows/nigthly_upgrade.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        from: ['1.7.6.9', '1.7.7.0']
+        from: ['1.7.6.9', '1.7.7.0', '1.6.1.24']
         ps-versions: ${{ fromJson(needs.get_matrix.outputs.matrix) }}
     runs-on: ubuntu-latest
     name: Upgrade

--- a/.github/workflows/nigthly_upgrade.yml
+++ b/.github/workflows/nigthly_upgrade.yml
@@ -21,6 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        from: ['1.7.6.9', '1.7.7.0']
         ps-versions: ${{ fromJson(needs.get_matrix.outputs.matrix) }}
     runs-on: ubuntu-latest
     name: Upgrade
@@ -35,21 +36,41 @@ jobs:
       - name: Upgrade & Rollback
         id: upgrade-rollback
         uses: ./.github/
-      - name: Format result
+      - name: Save result
         if: ${{ always() }}
         run: |
           export END_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
-          echo "${{matrix.ps-versions.branch}}|${{matrix.ps-versions.version}}|$START_DATE|$END_DATE|${{steps.upgrade-rollback.outcome}}" > result.txt
-          php ./.github/get_results.php
-      - name: Set up Cloud SDK
+          echo "${{matrix.from}}|${{matrix.ps-versions.branch}}|${{matrix.ps-versions.version}}|$START_DATE|$END_DATE|${{steps.upgrade-rollback.outcome}}" > ${{matrix.from}}_${{matrix.ps-versions.branch}}.txt
+      - name: Upload artifact
         if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{matrix.from}}_${{matrix.ps-versions.branch}}
+          path: ${{matrix.from}}_${{matrix.ps-versions.branch}}.txt
+  results:
+    name: Results
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    needs:
+      - get_matrix
+      - upgrade
+    strategy:
+      matrix:
+        ps-versions: ${{ fromJson(needs.get_matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          path: ./artifacts/
+      - name: Format results
+        run: php ./.github/get_results.php ${{matrix.ps-versions.branch}}
+      - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@master
         with:
           project_id: ${{ secrets.GC_PROJECT_ID }}
           service_account_key: ${{ secrets.GC_SERVICE_KEY }}
           export_default_credentials: true
       - name: Push results to the nightly board
-        if: ${{ always() }}
         run: |
           export TODAY=`date -u +"%Y-%m-%d"`
           export FILENAME=autoupgrade_$TODAY-${{matrix.ps-versions.branch}}.json

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -4,18 +4,10 @@ jobs:
   upgrade:
     strategy:
       matrix:
+        from: ['1.6.1.11', '1.7.6.9', '1.7.6.1', '1.7.7.0']
         ps-versions:
-          - from: 1.6.1.11
-            channel: minor
-          # Failing for now
-          #- from: 1.6.1.24
-          #  channel: major
-          - from: 1.7.6.9
-            channel: major
-          - from: 1.7.6.1
-            channel: minor
-          - from: 1.7.7.0
-            channel: minor
+          - channel: minor
+          - channel: major
     runs-on: ubuntu-latest
     name: Upgrade
     steps:

--- a/classes/TaskRunner/Miscellaneous/UpdateConfig.php
+++ b/classes/TaskRunner/Miscellaneous/UpdateConfig.php
@@ -101,6 +101,9 @@ class UpdateConfig extends AbstractTask
         if (isset($configurationData['skip_backup'])) {
             $config['skip_backup'] = $configurationData['skip_backup'];
         }
+        if (isset($configurationData['PS_AUTOUP_CHANGE_DEFAULT_THEME'])) {
+            $config['PS_AUTOUP_CHANGE_DEFAULT_THEME'] = $configurationData['PS_AUTOUP_CHANGE_DEFAULT_THEME'];
+        }
 
         if (!$this->writeConfig($config)) {
             $this->error = true;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR aims to add nightly migration tests by adding 1.6.1.24 & 1.7.7.0 to the list of versions to migrate from. It also re-enable migration from 1.6.1.11 in the "classic" tests.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     |
| How to test?      | CI should be green
| Possible impacts? |

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
