### PR TITLE
Delete table before delete view

### DIFF
--- a/classes/TaskRunner/Upgrade/BackupDb.php
+++ b/classes/TaskRunner/Upgrade/BackupDb.php
@@ -180,8 +180,8 @@ class BackupDb extends AbstractTask
                 if (isset($schema[0]['View'])) {
                     $views .= '/* Scheme for view' . $schema[0]['View'] . " */\n";
                     // If some *upgrade* transform a table in a view, drop both just in case
-                    $views .= 'DROP VIEW IF EXISTS `' . $schema[0]['View'] . '`;' . "\n";
                     $views .= 'DROP TABLE IF EXISTS `' . $schema[0]['View'] . '`;' . "\n";
+                    $views .= 'DROP VIEW IF EXISTS `' . $schema[0]['View'] . '`;' . "\n";
                     $views .= preg_replace('#DEFINER=[^\s]+\s#', 'DEFINER=CURRENT_USER ', $schema[0]['Create View']) . ";\n\n";
                     $written += fwrite($fp, "\n" . $views);
                     $ignore_stats_table[] = $schema[0]['View'];
@@ -192,8 +192,8 @@ class BackupDb extends AbstractTask
                     $written += fwrite($fp, '/* Scheme for table ' . $schema[0]['Table'] . " */\n");
                     if (!in_array($schema[0]['Table'], $ignore_stats_table)) {
                         // If some *upgrade* transform a table in a view, drop both just in case
-                        $written += fwrite($fp, 'DROP VIEW IF EXISTS `' . $schema[0]['Table'] . '`;' . "\n");
                         $written += fwrite($fp, 'DROP TABLE IF EXISTS `' . $schema[0]['Table'] . '`;' . "\n");
+                        $written += fwrite($fp, 'DROP VIEW IF EXISTS `' . $schema[0]['Table'] . '`;' . "\n");
                         // CREATE TABLE
                         $written += fwrite($fp, $schema[0]['Create Table'] . ";\n\n");
                     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Since MySQL 8.0, if there is a table with the name of the view you want to drop, you'll get an error. This PR fixes it by deleting the table before trying to delete the view.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/24872
| How to test?      | Please see https://github.com/PrestaShop/PrestaShop/issues/24872
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
