### PR TITLE
Update php to 7.3 on e2e nightly upgrade

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,4 +1,4 @@
-FROM prestashop/base:7.1-apache
+FROM prestashop/base:7.3-apache
 LABEL maintainer="PrestaShop Core Team <coreteam@prestashop.com>"
 
 ARG VERSION

--- a/.github/workflows/e2e_nightly_upgrade.yml
+++ b/.github/workflows/e2e_nightly_upgrade.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         name: Setup PHP
         with:
-          php-version: '7.4'
+          php-version: '7.3'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
 
       - name: Install Module dependencies

--- a/.github/workflows/e2e_nightly_upgrade.yml
+++ b/.github/workflows/e2e_nightly_upgrade.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         name: Setup PHP
         with:
-          php-version: '7.1'
+          php-version: '7.4'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
 
       - name: Install Module dependencies


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Update PHP to 7. on e2e nightly upgrade
| Type?             | refacto
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | no
| How to test?      | Should fix upgrades for develop branch
| Possible impacts? | none

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
