### PR TITLE
Fix calling unexisting method

### DIFF
--- a/classes/UpgradeTools/SymfonyAdapter.php
+++ b/classes/UpgradeTools/SymfonyAdapter.php
@@ -70,7 +70,9 @@ class SymfonyAdapter
             require_once _PS_ROOT_DIR_ . '/app/AppKernel.php';
             $env = (true == _PS_MODE_DEV_) ? 'dev' : 'prod';
             $kernel = new \AppKernel($env, _PS_MODE_DEV_);
-            $kernel->loadClassCache();
+            if (method_exists($kernel, 'loadClassCache')) { // This method has been deleted in Symfony 4.x
+                $kernel->loadClassCache();
+            }
             $kernel->boot();
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Since Symfony has been updated to version 4.4 on develop, the method `AppKernel::loadClassCache()` has been deleted. This PR aims to check if the method exists before calling it.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/PrestaShop#25276
| How to test?      | Please see PrestaShop/PrestaShop#25276
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
