### PR TITLE
Added support of Twig 3

### DIFF
--- a/classes/Twig/Block/ChannelInfoBlock.php
+++ b/classes/Twig/Block/ChannelInfoBlock.php
@@ -44,7 +44,7 @@ class ChannelInfoBlock
     private $channelInfo;
 
     /**
-     * @var \Twig_Environment
+     * @var Twig_Environment|\Twig\Environment
      */
     private $twig;
 
@@ -53,9 +53,9 @@ class ChannelInfoBlock
      *
      * @param UpgradeConfiguration $config
      * @param ChannelInfo $channelInfo
-     * @param Twig_Environment $twig
+     * @param Twig_Environment|\Twig\Environment $twig
      */
-    public function __construct(UpgradeConfiguration $config, ChannelInfo $channelInfo, Twig_Environment $twig)
+    public function __construct(UpgradeConfiguration $config, ChannelInfo $channelInfo, $twig)
     {
         $this->config = $config;
         $this->channelInfo = $channelInfo;

--- a/classes/Twig/Block/UpgradeButtonBlock.php
+++ b/classes/Twig/Block/UpgradeButtonBlock.php
@@ -39,7 +39,7 @@ use PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator;
 class UpgradeButtonBlock
 {
     /**
-     * @var \Twig_Environment
+     * @var Twig_Environment|\Twig\Environment
      */
     private $twig;
 
@@ -81,14 +81,14 @@ class UpgradeButtonBlock
     /**
      * UpgradeButtonBlock constructor.
      *
-     * @param Twig_Environment $twig
+     * @param Twig_Environment|\Twig\Environment $twig
      * @param Translator $translator
      * @param UpgradeConfiguration $config
      * @param Upgrader $upgrader
      * @param UpgradeSelfCheck $selfCheck
      */
     public function __construct(
-        Twig_Environment $twig,
+        $twig,
         Translator $translator,
         UpgradeConfiguration $config,
         Upgrader $upgrader,

--- a/classes/Twig/Block/UpgradeChecklist.php
+++ b/classes/Twig/Block/UpgradeChecklist.php
@@ -38,7 +38,7 @@ use Twig_Environment;
 class UpgradeChecklist
 {
     /**
-     * @var Twig_Environment
+     * @var Twig_Environment|\Twig\Environment
      */
     private $twig;
 
@@ -75,7 +75,7 @@ class UpgradeChecklist
     /**
      * UpgradeChecklistBlock constructor.
      *
-     * @param Twig_Environment $twig
+     * @param Twig_Environment|\Twig\Environment $twig
      * @param UpgradeSelfCheck $upgradeSelfCheck
      * @param string $prodRootPath
      * @param string $adminPath
@@ -84,7 +84,7 @@ class UpgradeChecklist
      * @param string $token
      */
     public function __construct(
-        Twig_Environment $twig,
+        $twig,
         UpgradeSelfCheck $upgradeSelfCheck,
         $prodRootPath,
         $adminPath,

--- a/classes/Twig/Form/FormRenderer.php
+++ b/classes/Twig/Form/FormRenderer.php
@@ -69,10 +69,10 @@ class FormRenderer
             $required = !empty($field['required']);
             $disabled = !empty($field['disabled']);
 
-            $val = $this->config->get(
-                $key,
-                isset($field['defaultValue']) ? $field['defaultValue'] : false
-            );
+            $val = $this->config->get($key);
+            if ($val === null) {
+                $val = isset($field['defaultValue']) ? $field['defaultValue'] : false;
+            }
 
             if (!in_array($field['type'], array('image', 'radio', 'select', 'container', 'bool', 'container_end')) || isset($field['show'])) {
                 $html .= '<div style="clear: both; padding-top:15px">'

--- a/classes/Twig/Form/FormRenderer.php
+++ b/classes/Twig/Form/FormRenderer.php
@@ -33,15 +33,24 @@ use Twig_Environment;
 
 class FormRenderer
 {
+    /**
+     * @var UpgradeConfiguration
+     */
     private $config;
 
+    /**
+     * @var Translator
+     */
     private $translator;
 
+    /**
+     * @var Twig_Environment|\Twig\Environment
+     */
     private $twig;
 
     public function __construct(
         UpgradeConfiguration $configuration,
-        Twig_Environment $twig,
+        $twig,
         Translator $translator
     ) {
         $this->config = $configuration;

--- a/classes/Twig/TransFilterExtension.php
+++ b/classes/Twig/TransFilterExtension.php
@@ -27,13 +27,20 @@
 
 namespace PrestaShop\Module\AutoUpgrade\Twig;
 
+use PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator;
 use Twig_Extension;
 use Twig_SimpleFilter;
 
+/**
+ * Filter (Support for Twig 1)
+ */
 class TransFilterExtension extends Twig_Extension
 {
     const DOMAIN = 'Modules.Autoupgrade.Admin';
 
+    /**
+     * @var Translator
+     */
     private $translator;
 
     public function __construct($translator)

--- a/classes/Twig/TransFilterExtension3.php
+++ b/classes/Twig/TransFilterExtension3.php
@@ -25,36 +25,38 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
 
-namespace PrestaShop\Module\AutoUpgrade\Twig\Block;
+namespace PrestaShop\Module\AutoUpgrade\Twig;
 
-use PrestaShop\Module\AutoUpgrade\BackupFinder;
-use Twig_Environment;
+use PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
 
-class RollbackForm
+/**
+ * Filter (Support for Twig 3)
+ */
+class TransFilterExtension3 extends AbstractExtension
 {
-    /**
-     * @var Twig_Environment|\Twig\Environment
-     */
-    private $twig;
+    const DOMAIN = 'Modules.Autoupgrade.Admin';
 
     /**
-     * @var BackupFinder
+     * @var Translator
      */
-    private $backupFinder;
+    private $translator;
 
-    public function __construct($twig, BackupFinder $backupFinder)
+    public function __construct($translator)
     {
-        $this->twig = $twig;
-        $this->backupFinder = $backupFinder;
+        $this->translator = $translator;
     }
 
-    public function render()
+    public function getFilters()
     {
-        return $this->twig->render(
-            '@ModuleAutoUpgrade/block/rollbackForm.twig',
-            array(
-                'availableBackups' => $this->backupFinder->getAvailableBackups(),
-            )
+        return array(
+            new TwigFilter('trans', array($this, 'trans')),
         );
+    }
+
+    public function trans($string, $params = array())
+    {
+        return $this->translator->trans($string, $params, self::DOMAIN);
     }
 }

--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -424,19 +424,19 @@ class UpgradeContainer
             return $this->twig;
         }
 
-        if (class_exists(\Twig\Environment::class)) {
-            // We use Twig 3
-            $loader = new \Twig\Loader\FilesystemLoader();
-            $loader->addPath(realpath(__DIR__ . '/..') . '/views/templates', 'ModuleAutoUpgrade');
-            $twig = new \Twig\Environment($loader);
-            $twig->addExtension(new TransFilterExtension3($this->getTranslator()));
-        } else {
+        if (class_exists(Twig_Environment::class)) {
             // We use Twig 1
             // Using independant template engine for 1.6 & 1.7 compatibility
             $loader = new Twig_Loader_Filesystem();
             $loader->addPath(realpath(__DIR__ . '/..') . '/views/templates', 'ModuleAutoUpgrade');
             $twig = new Twig_Environment($loader);
             $twig->addExtension(new TransFilterExtension($this->getTranslator()));
+        } else {
+            // We use Twig 3
+            $loader = new \Twig\Loader\FilesystemLoader();
+            $loader->addPath(realpath(__DIR__ . '/..') . '/views/templates', 'ModuleAutoUpgrade');
+            $twig = new \Twig\Environment($loader);
+            $twig->addExtension(new TransFilterExtension3($this->getTranslator()));
         }
 
         $this->twig = $twig;

--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -29,6 +29,7 @@ namespace PrestaShop\Module\AutoUpgrade;
 
 use PrestaShop\Module\AutoUpgrade\Log\LegacyLogger;
 use PrestaShop\Module\AutoUpgrade\Log\Logger;
+use PrestaShop\Module\AutoUpgrade\Twig\TransFilterExtension3;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\CacheCleaner;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\FileFilter;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\FilesystemAdapter;
@@ -114,7 +115,7 @@ class UpgradeContainer
     private $moduleAdapter;
 
     /**
-     * @var Twig_Environment
+     * @var Twig_Environment|\Twig\Environment
      */
     private $twig;
 
@@ -415,7 +416,7 @@ class UpgradeContainer
     }
 
     /**
-     * @return Twig_Environment
+     * @return Twig_Environment|\Twig\Environment
      */
     public function getTwig()
     {
@@ -423,11 +424,20 @@ class UpgradeContainer
             return $this->twig;
         }
 
-        // Using independant template engine for 1.6 & 1.7 compatibility
-        $loader = new Twig_Loader_Filesystem();
-        $loader->addPath(realpath(__DIR__ . '/..') . '/views/templates', 'ModuleAutoUpgrade');
-        $twig = new Twig_Environment($loader);
-        $twig->addExtension(new TransFilterExtension($this->getTranslator()));
+        if (class_exists(\Twig\Environment::class)) {
+            // We use Twig 3
+            $loader = new \Twig\Loader\FilesystemLoader();
+            $loader->addPath(realpath(__DIR__ . '/..') . '/views/templates', 'ModuleAutoUpgrade');
+            $twig = new \Twig\Environment($loader);
+            $twig->addExtension(new TransFilterExtension3($this->getTranslator()));
+        } else {
+            // We use Twig 1
+            // Using independant template engine for 1.6 & 1.7 compatibility
+            $loader = new Twig_Loader_Filesystem();
+            $loader->addPath(realpath(__DIR__ . '/..') . '/views/templates', 'ModuleAutoUpgrade');
+            $twig = new Twig_Environment($loader);
+            $twig->addExtension(new TransFilterExtension($this->getTranslator()));
+        }
 
         $this->twig = $twig;
 

--- a/classes/UpgradePage.php
+++ b/classes/UpgradePage.php
@@ -55,7 +55,7 @@ class UpgradePage
     private $templatesDir = '/views/templates';
 
     /**
-     * @var Twig_Environment
+     * @var Twig_Environment|\Twig\Environment
      */
     private $twig;
 
@@ -131,7 +131,7 @@ class UpgradePage
 
     public function __construct(
         UpgradeConfiguration $config,
-        Twig_Environment $twig,
+        $twig,
         Translator $translator,
         UpgradeSelfCheck $upgradeSelfCheck,
         Upgrader $upgrader,

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-zip": "*",
         "symfony/filesystem": "~2.8",
         "doctrine/collections": "~1.3.0",
-        "twig/twig": "^1.35"
+        "twig/twig": "^1.35|^3"
     },
     "config": {
         "preferred-install": "dist",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "07d914ad01aee16ebb0b3e4e846fa9e2",
+    "content-hash": "ca1acf1a9e487acb126daf64e42a64c5",
     "packages": [
         {
             "name": "doctrine/collections",
@@ -122,31 +122,110 @@
             "time": "2018-01-03T07:36:31+00:00"
         },
         {
-            "name": "twig/twig",
-            "version": "v1.35.0",
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.19.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/twigphp/Twig.git",
-                "reference": "daa657073e55b0a78cce8fdd22682fddecc6385f"
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "aed596913b70fae57be53d86faa2e9ef85a2297b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/daa657073e55b0a78cce8fdd22682fddecc6385f",
-                "reference": "daa657073e55b0a78cce8fdd22682fddecc6385f",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/aed596913b70fae57be53d86faa2e9ef85a2297b",
+                "reference": "aed596913b70fae57be53d86faa2e9ef85a2297b",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
-            "require-dev": {
-                "psr/container": "^1.0",
-                "symfony/debug": "~2.7",
-                "symfony/phpunit-bridge": "~3.3@dev"
+            "suggest": {
+                "ext-ctype": "For best performance"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.35-dev"
+                    "dev-main": "1.19-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.19.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T09:01:57+00:00"
+        },
+        {
+            "name": "twig/twig",
+            "version": "v1.42.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twigphp/Twig.git",
+                "reference": "87b2ea9d8f6fd014d0621ca089bb1b3769ea3f8e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/87b2ea9d8f6fd014d0621ca089bb1b3769ea3f8e",
+                "reference": "87b2ea9d8f6fd014d0621ca089bb1b3769ea3f8e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "require-dev": {
+                "psr/container": "^1.0",
+                "symfony/phpunit-bridge": "^4.4|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.42-dev"
                 }
             },
             "autoload": {
@@ -169,22 +248,25 @@
                     "role": "Lead Developer"
                 },
                 {
+                    "name": "Twig Team",
+                    "role": "Contributors"
+                },
+                {
                     "name": "Armin Ronacher",
                     "email": "armin.ronacher@active-4.com",
                     "role": "Project Founder"
-                },
-                {
-                    "name": "Twig Team",
-                    "homepage": "http://twig.sensiolabs.org/contributors",
-                    "role": "Contributors"
                 }
             ],
             "description": "Twig, the flexible, fast, and secure template language for PHP",
-            "homepage": "http://twig.sensiolabs.org",
+            "homepage": "https://twig.symfony.com",
             "keywords": [
                 "templating"
             ],
-            "time": "2017-09-27T18:06:46+00:00"
+            "support": {
+                "issues": "https://github.com/twigphp/Twig/issues",
+                "source": "https://github.com/twigphp/Twig/tree/1.x"
+            },
+            "time": "2020-02-11T05:59:23+00:00"
         }
     ],
     "packages-dev": [

--- a/tests/UpgradeContainerTest.php
+++ b/tests/UpgradeContainerTest.php
@@ -63,7 +63,7 @@ class UpgradeContainerTest extends TestCase
             array('getSymfonyAdapter', PrestaShop\Module\AutoUpgrade\UpgradeTools\SymfonyAdapter::class),
             array('getTranslationAdapter', \PrestaShop\Module\AutoUpgrade\UpgradeTools\Translation::class),
             array('getTranslator', \PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator::class),
-            array('getTwig', Twig_Environment::class),
+            array('getTwig', \Twig\Environment::class),
             array('getPrestaShopConfiguration', PrestaShop\Module\AutoUpgrade\PrestashopConfiguration::class),
             array('getUpgradeConfiguration', PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration::class),
             array('getWorkspace', PrestaShop\Module\AutoUpgrade\Workspace::class),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fixed support of Twig 3 : Like `develop` is now based on Twig 3 (Thanks @atomiix), autoload load firstly the dependency of the core and after the dependency of the module. It's why I detect if Twig 3 class is here or not.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/PrestaShop#25624
| How to test?      | Cf PrestaShop/PrestaShop#25624 : check on PS 1.6/1.7/develop the display of the module
| Possible impacts? | N/A

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
