### PR TITLE
Add suppliers sql upgrade

### DIFF
--- a/upgrade/sql/1.7.8.1.sql
+++ b/upgrade/sql/1.7.8.1.sql
@@ -1,0 +1,7 @@
+SET SESSION sql_mode='';
+SET NAMES 'utf8mb4';
+
+INSERT INTO `PREFIX_product_supplier` (id_product, id_supplier, product_supplier_reference, product_supplier_price_te, id_currency)
+SELECT ps.id_product, ps.id_supplier, ps.product_supplier_reference, ps.product_supplier_price_te, ps.id_currency
+FROM `PREFIX_product_supplier` as ps
+ON DUPLICATE KEY UPDATE `PREFIX_product_supplier`.id_product = ps.id_product;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR fixes the issue #25593 by during the uprade process to PS >= 1.7.8.1 by adding missing `product_supplier` entries.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Partially Fixes #25593
| How to test?      | Install 1.7.8.0, try to upgrade to 1.7.8.1, suppliers should be viewable
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
