### PR TITLE
Add second parameter for fopen in Tools14::copy

### DIFF
--- a/classes/Tools14.php
+++ b/classes/Tools14.php
@@ -2410,7 +2410,7 @@ AddOutputFilterByType DEFLATE application/x-javascript
         }
 
         if (self::shouldUseFopen($source)) {
-            $sourceFile = fopen($source);
+            $sourceFile = fopen($source, 'rb');
             // If something else than false, the data was stored
             $result = (file_put_contents($destination, $sourceFile) !== false);
             fclose($sourceFile);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fopen requires secong parameter for open mode
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| How to test?      | CI green<br>If `allow_url_fopen` is set to false or 0 or Off in php.ini, curl will be used to download the PS binary, otherwise, fopen will be used. <br>To test this PR, use fopen
| Possible impacts? | -

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
