### PR TITLE
Update E2E tests to run on 1.7.7.8

### DIFF
--- a/.github/workflows/e2e_nightly_upgrade.yml
+++ b/.github/workflows/e2e_nightly_upgrade.yml
@@ -49,7 +49,7 @@ jobs:
     # Testing upgrade from '1.7.4.4', '1.7.5.2', '1.7.6.9', '1.7.7.1' to the last '1.7.7.x' and '1.7.8.x'(develop)
     strategy:
       matrix:
-        ps_start_version: ['1.7.4.4', '1.7.5.2', '1.7.6.9', '1.7.7.1']
+        ps_start_version: ['1.7.4.4', '1.7.5.2', '1.7.6.9', '1.7.7.8']
 
         ps_target_version: ${{ fromJson(needs.get_ps_target_versions.outputs.target_versions) }}
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Update E2E tests to run on 1.7.7.8
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | no
| How to test?      | Nightly should test upgrade from 1.7.7.8
| Possible impacts? | none
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
