### PR TITLE
Enable upgrades from 1.6 to develop

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,4 +1,4 @@
-FROM prestashop/base:7.3-apache
+FROM prestashop/base:7.2-apache
 LABEL maintainer="PrestaShop Core Team <coreteam@prestashop.com>"
 
 ARG VERSION

--- a/.github/action.yml
+++ b/.github/action.yml
@@ -13,14 +13,29 @@ runs:
     - name: Copy autoupgrade module
       shell: bash
       run: docker exec -u www-data prestashop_autoupgrade cp modules/autoupgrade/ -R admin-dev
-    - name: Upgrade (major)
+    - name: Upgrade (intermediate)
+      env:
+        CHANNEL: 'archive'
+        ARCHIVE_URL: 'https://github.com/PrestaShop/PrestaShop/releases/download/1.7.7.8/prestashop_1.7.7.8.zip'
+        VERSION: '1.7.7.8'
+        FROM: ${{ matrix.from }}
+        SKIP: ${{ matrix.ps-versions.channel != 'archive' || !startsWith(matrix.from, '1.6') || startsWith(matrix.ps-versions.version, '1.7.7') }}
+      shell: bash
+      run: |
+        [[ "$SKIP" == true ]] || ${{ github.action_path }}action_upgrade.sh
+        [[ "$SKIP" == true ]] || docker exec prestashop_autoupgrade rm admin-dev/autoupgrade/modulesToUpgrade.list
+        [[ "$SKIP" == true ]] || docker stop prestashop_autoupgrade
+        [[ "$SKIP" == true ]] || docker rm prestashop_autoupgrade
+        [[ "$SKIP" == true ]] || docker run --name prestashop_autoupgrade -p 8001:80 -v autoupgrade_temp-ps:/var/www/html -v "$(pwd):/var/www/html/modules/autoupgrade" --network autoupgrade_default -d prestashop/base:7.2-apache
+        [[ "$SKIP" == true ]] || bash -c 'while [[ "$(curl -L -s -o /dev/null -w %{http_code} http://localhost:8001/index.php)" == "000" ]]; do sleep 5; done'
+    - name: Upgrade
       env:
         CHANNEL: ${{ matrix.ps-versions.channel }}
         ARCHIVE_URL: ${{ matrix.ps-versions.file }}
         VERSION: ${{ matrix.ps-versions.version }}
         FROM: ${{ matrix.from }}
       shell: bash
-      run: ${{ github.action_path }}/action_upgrade.sh
+      run: ${{ github.action_path }}action_upgrade.sh
     - name: Check endpoints response
       shell: bash
       run: |

--- a/.github/action_upgrade.sh
+++ b/.github/action_upgrade.sh
@@ -1,15 +1,30 @@
 #!/bin/bash
 
 if [[ $CHANNEL == "archive" ]]; then
-  if [[ "${FROM}" == 1.6* ]] && [[ "${VERSION}" == 1.7* ]]; then
-    UPDATE_THEME=1
+  if [[ "${FROM:0:1}" == 1 ]] && [[ "${VERSION:0:1}" == 1 ]]; then
+    if [[ "${FROM:2:1}" == "${VERSION:2:1}" ]]; then
+      UPDATE_THEME=0
+    else
+      UPDATE_THEME=1
+    fi
   else
-    UPDATE_THEME=0
+    if [[ "${FROM:0:1}" == "${VERSION:0:1}" ]]; then
+      UPDATE_THEME=0
+    else
+      UPDATE_THEME=1
+    fi
+  fi
+
+  SKIP_BACKUP=$(docker exec -u www-data prestashop_autoupgrade ls admin-dev/autoupgrade/backup/ | wc -l)
+  if [[ "$SKIP_BACKUP" > 1 ]]; then
+    SKIP_BACKUP=1
+  else
+    SKIP_BACKUP=0
   fi
 
   docker exec -u www-data prestashop_autoupgrade mkdir admin-dev/autoupgrade/download
-  docker exec -u www-data prestashop_autoupgrade curl $ARCHIVE_URL -o admin-dev/autoupgrade/download/prestashop.zip
-  echo "{\"channel\":\"archive\",\"archive_prestashop\":\"prestashop.zip\",\"archive_num\":\"${VERSION}\", \"PS_AUTOUP_CHANGE_DEFAULT_THEME\":${UPDATE_THEME}}" > config.json
+  docker exec -u www-data prestashop_autoupgrade curl -L $ARCHIVE_URL -o admin-dev/autoupgrade/download/prestashop.zip
+  echo "{\"channel\":\"archive\",\"archive_prestashop\":\"prestashop.zip\",\"archive_num\":\"${VERSION}\", \"PS_AUTOUP_CHANGE_DEFAULT_THEME\":${UPDATE_THEME}, \"skip_backup\": ${SKIP_BACKUP}}" > config.json
   docker exec -u www-data prestashop_autoupgrade php admin-dev/autoupgrade/cli-updateconfig.php --from=modules/autoupgrade/config.json --dir=admin-dev
 fi
 

--- a/.github/workflows/nigthly_upgrade.yml
+++ b/.github/workflows/nigthly_upgrade.yml
@@ -26,8 +26,6 @@ jobs:
         branch: ['dev', 'master']
         exclude:
           - from: '1.6.1.24'
-            ps-versions: {branch: 'develop'}
-          - from: '1.6.1.24'
             branch: 'master'
           - from: '1.7.6.9'
             ps-versions: {branch: 'develop'}

--- a/classes/TaskRunner/Upgrade/UpgradeModules.php
+++ b/classes/TaskRunner/Upgrade/UpgradeModules.php
@@ -155,11 +155,6 @@ class UpgradeModules extends AbstractTask
             $this->logger->info($this->translator->trans('%s modules will be upgraded.', array($total_modules_to_upgrade), 'Modules.Autoupgrade.Admin'));
         }
 
-        // WamUp core side
-        if (method_exists('\Module', 'getModulesOnDisk')) {
-            \Module::getModulesOnDisk();
-        }
-
         $this->stepDone = false;
         $this->next = 'upgradeModules';
 

--- a/tests/phpstan/phpstan-PS-16.neon
+++ b/tests/phpstan/phpstan-PS-16.neon
@@ -19,6 +19,7 @@ parameters:
 		- '#Function deactivate_custom_modules not found.#'
 		- '#Constant MCRYPT_[A-Z0-9_]+ not found.#'
 		- "#Call to function method_exists#"
+		- '#Access to an undefined property Module::\$installed\.#'
 		# CLDR related check
 		- '#[cC]lass PrestaShop\\PrestaShop\\Core\\Cldr\\Update#'
 		# AppKernel wasn't properly listed in autoloader

--- a/tests/phpstan/phpstan.neon
+++ b/tests/phpstan/phpstan.neon
@@ -13,6 +13,7 @@ parameters:
 		- '#Function deactivate_custom_modules not found.#'
 		- '#Constant MCRYPT_[A-Z0-9_]+ not found.#'
 		- "#Call to function method_exists#"
+		- '#.* property (Module::)?\$installed.*#'
 		# CLDR related check
 		- '#[cC]lass PrestaShop\\PrestaShop\\Core\\Cldr\\Update#'
 		# AppKernel wasn't properly listed in autoloader


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | As there is no common compatible php version between PS 1.6 and develop, this PR aims to perform the upgrade in 2 steps (1.6 -> 1.7 with php 7.1 then 1.7 -> develop with php 7.2) so there is always a common compatible php version. 
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | CI should be green
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
