### PR TITLE
Don't hide expert mode when major chanel selected

### DIFF
--- a/js/upgrade.js
+++ b/js/upgrade.js
@@ -765,14 +765,6 @@ $("input[name=btn_adv]").click(function(e) {
   }
 });
 
-$(document).ready(function(){
-  if (input.channel === 'major') {
-    switch_to_normal();
-  } else {
-    switch_to_advanced();
-  }
-});
-
 $(document).ready(function() {
   $("input[name|=submitConf]").bind("click", function(e) {
     var params = {};


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | After discussion with Marion, You should not hide the default expert mode when chanel major is selected. The merchant will be able to see the compatibility.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/26034
| How to test?      | Selected Major chanel, click to save see if the expert mode is hidden
| Possible impacts? | Only good

This is the opposite of: https://github.com/PrestaShop/PrestaShop/issues/26003

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
