### PR TITLE
Replace usage of deprecated method

### DIFF
--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader17.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader17.php
@@ -87,7 +87,7 @@ class CoreUpgrader17 extends CoreUpgrader
         \Language::installSfLanguagePack($lang_pack['locale'], $errorsLanguage);
 
         if (!$this->container->getUpgradeConfiguration()->shouldKeepMails()) {
-            \Language::installEmailsLanguagePack($lang_pack, $errorsLanguage);
+            \Language::generateEmailsLanguagePack($lang_pack, $errorsLanguage, true);
         }
 
         if (!empty($errorsLanguage)) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | As the installEmailsLanguagePack() method of Language is deprecated and could be removed into next major version of PrestaShop, we update this method. (Cfr. https://github.com/PrestaShop/PrestaShop/pull/26309)
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Nothing really to test.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
