### PR TITLE
Update 1.7.8.0.sql

### DIFF
--- a/upgrade/sql/1.7.8.0.sql
+++ b/upgrade/sql/1.7.8.0.sql
@@ -198,4 +198,4 @@ CREATE TABLE IF NOT EXISTS `PREFIX_feature_flag` (
 
 INSERT INTO `PREFIX_feature_flag` (`name`, `state`, `label_wording`, `label_domain`, `description_wording`, `description_domain`)
 VALUES
-	('product_page_v2', 0, 'Experimental product page', 'Admin.Advparameters.Feature', 'This page benefits from increased performance and includes new features such as a new combination management system. Please note this is a work in progress and some features are not available yet.', 'Admin.Advparameters.Help');
+	('product_page_v2', 0, 'Experimental product page', 'Admin.Advparameters.Feature', 'This page benefits from increased performance and includes new features such as a new combination management system. Please note this is a work in progress and some features are not available.', 'Admin.Advparameters.Help');

--- a/upgrade/sql/1.7.8.0.sql
+++ b/upgrade/sql/1.7.8.0.sql
@@ -198,4 +198,4 @@ CREATE TABLE IF NOT EXISTS `PREFIX_feature_flag` (
 
 INSERT INTO `PREFIX_feature_flag` (`name`, `state`, `label_wording`, `label_domain`, `description_wording`, `description_domain`)
 VALUES
-	('product_page_v2', 0, 'Experimental product page', 'Admin.Advparameters.Feature', 'This page benefits from increased performance and includes new features such as a new combination management system. Please note this is a work in progress and some features are not available.', 'Admin.Advparameters.Help');
+	('product_page_v2', 0, 'Experimental product page', 'Admin.Advparameters.Feature', 'This page benefits from increased performance and includes new features such as a new combination management system. Please note this is a work in progress and some features are not available', 'Admin.Advparameters.Help');


### PR DESCRIPTION
description_wording value inserted exeeded 191 chars

Cause an error while upgrading from 1.6.1.24 to 1.7.8.0
ERROR     [console] Error thrown while running command "prestashop:schema:update-without-foreign --env=prod". Message: "SQLSTATE[HY000]: General error: 2006 MySQL server has gone away"

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Please be specific when describing the PR. Every detail helps: What are you changing? Why?
| Type?             | bug fix / improvement / new feature / refacto / critical
| BC breaks?        | yes / no
| Deprecations?     | yes / no
| Fixed ticket?     | Fixes {paste the issue here}.
| How to test?      | Please indicate how to best verify that this PR is correct.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
