### PR TITLE
Use GenerateThemeMailTemplatesCommand during upgrade

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,7 +12,7 @@ jobs:
       - name: PHP syntax checker 5.6
         uses: prestashop/github-action-php-lint/5.6@master
         with:
-          folder-to-exclude: "! -path \"./.github/*\""
+          folder-to-exclude: "! -path \"./.github/*\" ! -path \"./classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php\""
 
       - name: PHP syntax checker 7.2
         uses: prestashop/github-action-php-lint/7.2@master

--- a/classes/TaskRunner/Upgrade/UpgradeDb.php
+++ b/classes/TaskRunner/Upgrade/UpgradeDb.php
@@ -64,7 +64,7 @@ class UpgradeDb extends AbstractTask
             return new CoreUpgrader16($this->container, $this->logger);
         }
 
-        if (version_compare($this->container->getState()->getInstallVersion(), '8.0.0.0', '<')) {
+        if (version_compare($this->container->getState()->getInstallVersion(), '8.0.0', '<')) {
             return new CoreUpgrader17($this->container, $this->logger);
         }
 

--- a/classes/TaskRunner/Upgrade/UpgradeDb.php
+++ b/classes/TaskRunner/Upgrade/UpgradeDb.php
@@ -31,6 +31,7 @@ use PrestaShop\Module\AutoUpgrade\TaskRunner\AbstractTask;
 use PrestaShop\Module\AutoUpgrade\UpgradeException;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreUpgrader16;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreUpgrader17;
+use PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreUpgrader80;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\SettingsFileWriter;
 
 class UpgradeDb extends AbstractTask
@@ -59,11 +60,15 @@ class UpgradeDb extends AbstractTask
 
     public function getCoreUpgrader()
     {
-        if (version_compare($this->container->getState()->getInstallVersion(), '1.7.0.0', '<=')) {
+        if (version_compare($this->container->getState()->getInstallVersion(), '1.7.0.0', '<')) {
             return new CoreUpgrader16($this->container, $this->logger);
         }
 
-        return new CoreUpgrader17($this->container, $this->logger);
+        if (version_compare($this->container->getState()->getInstallVersion(), '8.0.0.0', '<')) {
+            return new CoreUpgrader17($this->container, $this->logger);
+        }
+
+        return new CoreUpgrader80($this->container, $this->logger);
     }
 
     public function init()

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader17.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader17.php
@@ -30,7 +30,6 @@ namespace PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader;
 use PrestaShop\Module\AutoUpgrade\UpgradeException;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\ThemeAdapter;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
-use PrestaShop\PrestaShop\Core\Domain\MailTemplate\Command\GenerateThemeMailTemplatesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Theme\Command\AdaptThemeToRTLLanguagesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Theme\ValueObject\ThemeName;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
@@ -84,33 +83,7 @@ class CoreUpgrader17 extends CoreUpgrader
         \Language::installSfLanguagePack($lang_pack['locale'], $errorsLanguage);
 
         if (!$this->container->getUpgradeConfiguration()->shouldKeepMails()) {
-            $mailTheme = \Configuration::get('PS_MAIL_THEME', null, null, null, 'modern');
-
-            $frontTheme = _THEME_NAME_;
-            $frontThemeMailsFolder = _PS_ALL_THEMES_DIR_ . $frontTheme . '/mails';
-            $frontThemeModulesFolder = _PS_ALL_THEMES_DIR_ . $frontTheme . '/modules';
-
-            $generateCommand = new GenerateThemeMailTemplatesCommand(
-                $mailTheme,
-                $lang_pack['locale'],
-                true,
-                $frontThemeMailsFolder,
-                $frontThemeModulesFolder
-            );
-            /** @var CommandBusInterface $commandBus */
-            $commandBus = $this->container->get('prestashop.core.command_bus');
-
-            try {
-                $commandBus->handle($generateCommand);
-            } catch (CoreException $e) {
-                throw new UpgradeException(
-                    $this->container->getTranslator()->trans(
-                        'Cannot generate email templates: %s.',
-                        [$e->getMessage()],
-                        'Modules.Autoupgrade.Admin'
-                    )
-                );
-            }
+            \Language::installEmailsLanguagePack($lang_pack, $errorsLanguage);
         }
 
         if (!empty($errorsLanguage)) {

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader17.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader17.php
@@ -30,6 +30,7 @@ namespace PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader;
 use PrestaShop\Module\AutoUpgrade\UpgradeException;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\ThemeAdapter;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\MailTemplate\Command\GenerateThemeMailTemplatesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Theme\Command\AdaptThemeToRTLLanguagesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Theme\ValueObject\ThemeName;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
@@ -83,7 +84,33 @@ class CoreUpgrader17 extends CoreUpgrader
         \Language::installSfLanguagePack($lang_pack['locale'], $errorsLanguage);
 
         if (!$this->container->getUpgradeConfiguration()->shouldKeepMails()) {
-            \Language::installEmailsLanguagePack($lang_pack, $errorsLanguage);
+            $mailTheme = \Configuration::get('PS_MAIL_THEME', null, null, null, 'modern');
+
+            $frontTheme = _THEME_NAME_;
+            $frontThemeMailsFolder = _PS_ALL_THEMES_DIR_ . $frontTheme . '/mails';
+            $frontThemeModulesFolder = _PS_ALL_THEMES_DIR_ . $frontTheme . '/modules';
+
+            $generateCommand = new GenerateThemeMailTemplatesCommand(
+                $mailTheme,
+                $lang_pack['locale'],
+                true,
+                $frontThemeMailsFolder,
+                $frontThemeModulesFolder
+            );
+            /** @var CommandBusInterface $commandBus */
+            $commandBus = $this->container->get('prestashop.core.command_bus');
+
+            try {
+                $commandBus->handle($generateCommand);
+            } catch (CoreException $e) {
+                throw new UpgradeException(
+                    $this->container->getTranslator()->trans(
+                        'Cannot generate email templates: %s.',
+                        [$e->getMessage()],
+                        'Modules.Autoupgrade.Admin'
+                    )
+                );
+            }
         }
 
         if (!empty($errorsLanguage)) {

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
@@ -39,13 +39,6 @@ class CoreUpgrader80 extends CoreUpgrader
     {
         parent::initConstants();
 
-        /*if (!file_exists(SETTINGS_FILE_PHP)) {
-            throw new UpgradeException($this->container->getTranslator()->trans('The app/config/parameters.php file was not found.', array(), 'Modules.Autoupgrade.Admin'));
-        }
-        if (!file_exists(SETTINGS_FILE_YML)) {
-            throw new UpgradeException($this->container->getTranslator()->trans('The app/config/parameters.yml file was not found.', array(), 'Modules.Autoupgrade.Admin'));
-        }*/
-
         // Container may be needed to run upgrade scripts
         $this->container->getSymfonyAdapter()->initAppKernel();
     }

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
@@ -94,7 +94,7 @@ class CoreUpgrader80 extends CoreUpgrader
                 $frontThemeModulesFolder
             );
             /** @var CommandBusInterface $commandBus */
-            $commandBus = $this->container->get('prestashop.core.command_bus');
+            $commandBus = $this->container->getModuleAdapter()->getCommandBus();
 
             try {
                 $commandBus->handle($generateCommand);

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
@@ -49,8 +49,7 @@ class CoreUpgrader80 extends CoreUpgrader
 
         $commandResult = $this->container->getSymfonyAdapter()->runSchemaUpgradeCommand();
         if (0 !== $commandResult['exitCode']) {
-            throw (new UpgradeException($this->container->getTranslator()->trans('Error upgrading Doctrine schema', array(), 'Modules.Autoupgrade.Admin')))
-                ->setQuickInfos(explode("\n", $commandResult['output']));
+            throw (new UpgradeException($this->container->getTranslator()->trans('Error upgrading Doctrine schema', [], 'Modules.Autoupgrade.Admin')))->setQuickInfos(explode("\n", $commandResult['output']));
         }
     }
 
@@ -61,19 +60,10 @@ class CoreUpgrader80 extends CoreUpgrader
         if (!\Validate::isLangIsoCode($isoCode)) {
             return;
         }
-        $errorsLanguage = array();
+        $errorsLanguage = [];
 
         if (!\Language::downloadLanguagePack($isoCode, _PS_VERSION_, $errorsLanguage)) {
-            throw new UpgradeException(
-                $this->container->getTranslator()->trans(
-                    'Download of the language pack %lang% failed. %details%',
-                    [
-                        '%lang%' => $isoCode,
-                        '%details%' => implode('; ', $errorsLanguage),
-                    ],
-                    'Modules.Autoupgrade.Admin'
-                )
-            );
+            throw new UpgradeException($this->container->getTranslator()->trans('Download of the language pack %lang% failed. %details%', ['%lang%' => $isoCode, '%details%' => implode('; ', $errorsLanguage)], 'Modules.Autoupgrade.Admin'));
         }
 
         $lang_pack = \Language::getLangDetails($isoCode);
@@ -99,27 +89,12 @@ class CoreUpgrader80 extends CoreUpgrader
             try {
                 $commandBus->handle($generateCommand);
             } catch (CoreException $e) {
-                throw new UpgradeException(
-                    $this->container->getTranslator()->trans(
-                        'Cannot generate email templates: %s.',
-                        [$e->getMessage()],
-                        'Modules.Autoupgrade.Admin'
-                    )
-                );
+                throw new UpgradeException($this->container->getTranslator()->trans('Cannot generate email templates: %s.', [$e->getMessage()], 'Modules.Autoupgrade.Admin'));
             }
         }
 
         if (!empty($errorsLanguage)) {
-            throw new UpgradeException(
-                $this->container->getTranslator()->trans(
-                    'Error while updating translations for lang %lang%. %details%',
-                    [
-                        '%lang%' => $isoCode,
-                        '%details%' => implode('; ', $errorsLanguage),
-                    ],
-                    'Modules.Autoupgrade.Admin'
-                )
-            );
+            throw new UpgradeException($this->container->getTranslator()->trans('Error while updating translations for lang %lang%. %details%', ['%lang%' => $isoCode, '%details%' => implode('; ', $errorsLanguage)], 'Modules.Autoupgrade.Admin'));
         }
         \Language::loadLanguages();
 

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
@@ -90,8 +90,8 @@ class CoreUpgrader80 extends CoreUpgrader
                 $mailTheme,
                 $lang_pack['locale'],
                 true,
-                $frontThemeMailsFolder,
-                $frontThemeModulesFolder
+                is_dir($frontThemeMailsFolder) ? $frontThemeMailsFolder : '',
+                is_dir($frontThemeModulesFolder) ? $frontThemeModulesFolder : ''
             );
             /** @var CommandBusInterface $commandBus */
             $commandBus = $this->container->getModuleAdapter()->getCommandBus();

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader;
+
+use PrestaShop\Module\AutoUpgrade\UpgradeException;
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\MailTemplate\Command\GenerateThemeMailTemplatesCommand;
+use PrestaShop\PrestaShop\Core\Exception\CoreException;
+
+class CoreUpgrader80 extends CoreUpgrader
+{
+    protected function initConstants()
+    {
+        parent::initConstants();
+
+        /*if (!file_exists(SETTINGS_FILE_PHP)) {
+            throw new UpgradeException($this->container->getTranslator()->trans('The app/config/parameters.php file was not found.', array(), 'Modules.Autoupgrade.Admin'));
+        }
+        if (!file_exists(SETTINGS_FILE_YML)) {
+            throw new UpgradeException($this->container->getTranslator()->trans('The app/config/parameters.yml file was not found.', array(), 'Modules.Autoupgrade.Admin'));
+        }*/
+
+        // Container may be needed to run upgrade scripts
+        $this->container->getSymfonyAdapter()->initAppKernel();
+    }
+
+    protected function upgradeDb($oldversion)
+    {
+        parent::upgradeDb($oldversion);
+
+        $commandResult = $this->container->getSymfonyAdapter()->runSchemaUpgradeCommand();
+        if (0 !== $commandResult['exitCode']) {
+            throw (new UpgradeException($this->container->getTranslator()->trans('Error upgrading Doctrine schema', array(), 'Modules.Autoupgrade.Admin')))
+                ->setQuickInfos(explode("\n", $commandResult['output']));
+        }
+    }
+
+    protected function upgradeLanguage($lang)
+    {
+        $isoCode = $lang['iso_code'];
+
+        if (!\Validate::isLangIsoCode($isoCode)) {
+            return;
+        }
+        $errorsLanguage = array();
+
+        if (!\Language::downloadLanguagePack($isoCode, _PS_VERSION_, $errorsLanguage)) {
+            throw new UpgradeException(
+                $this->container->getTranslator()->trans(
+                    'Download of the language pack %lang% failed. %details%',
+                    [
+                        '%lang%' => $isoCode,
+                        '%details%' => implode('; ', $errorsLanguage),
+                    ],
+                    'Modules.Autoupgrade.Admin'
+                )
+            );
+        }
+
+        $lang_pack = \Language::getLangDetails($isoCode);
+        \Language::installSfLanguagePack($lang_pack['locale'], $errorsLanguage);
+
+        if (!$this->container->getUpgradeConfiguration()->shouldKeepMails()) {
+            $mailTheme = \Configuration::get('PS_MAIL_THEME', null, null, null, 'modern');
+
+            $frontTheme = _THEME_NAME_;
+            $frontThemeMailsFolder = _PS_ALL_THEMES_DIR_ . $frontTheme . '/mails';
+            $frontThemeModulesFolder = _PS_ALL_THEMES_DIR_ . $frontTheme . '/modules';
+
+            $generateCommand = new GenerateThemeMailTemplatesCommand(
+                $mailTheme,
+                $lang_pack['locale'],
+                true,
+                $frontThemeMailsFolder,
+                $frontThemeModulesFolder
+            );
+            /** @var CommandBusInterface $commandBus */
+            $commandBus = $this->container->get('prestashop.core.command_bus');
+
+            try {
+                $commandBus->handle($generateCommand);
+            } catch (CoreException $e) {
+                throw new UpgradeException(
+                    $this->container->getTranslator()->trans(
+                        'Cannot generate email templates: %s.',
+                        [$e->getMessage()],
+                        'Modules.Autoupgrade.Admin'
+                    )
+                );
+            }
+        }
+
+        if (!empty($errorsLanguage)) {
+            throw new UpgradeException(
+                $this->container->getTranslator()->trans(
+                    'Error while updating translations for lang %lang%. %details%',
+                    [
+                        '%lang%' => $isoCode,
+                        '%details%' => implode('; ', $errorsLanguage),
+                    ],
+                    'Modules.Autoupgrade.Admin'
+                )
+            );
+        }
+        \Language::loadLanguages();
+
+        // TODO: Update AdminTranslationsController::addNewTabs to install tabs translated
+    }
+}

--- a/tests/phpstan/phpstan-1.6.1.18.neon
+++ b/tests/phpstan/phpstan-1.6.1.18.neon
@@ -7,6 +7,7 @@ parameters:
 		- ./../../classes/pclzip.lib.php
 		- ./../../functions.php
 		- ./../../classes/UpgradeTools/CoreUpgrader/CoreUpgrader17.php
+		- ./../../classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
 		- ./../../classes/UpgradeTools/SymfonyAdapter.php
 	ignoreErrors:
 		- '#Access to an undefined property Autoupgrade::\$bootstrap.#'

--- a/tests/phpstan/phpstan-1.7.2.5.neon
+++ b/tests/phpstan/phpstan-1.7.2.5.neon
@@ -2,6 +2,8 @@ includes:
 	- %currentWorkingDirectory%/tests/phpstan/phpstan.neon
 
 parameters:
+	excludes_analyse:
+		- ./../../classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
 	ignoreErrors:
 		- '#Access to an undefined property Autoupgrade::\$bootstrap.#'
 		- '#Access to an undefined property Module::\$installed.#'

--- a/tests/phpstan/phpstan-1.7.3.4.neon
+++ b/tests/phpstan/phpstan-1.7.3.4.neon
@@ -2,6 +2,8 @@ includes:
 	- %currentWorkingDirectory%/tests/phpstan/phpstan.neon
 
 parameters:
+	excludes_analyse:
+		- ./../../classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
 	ignoreErrors:
 		- '#Access to an undefined property Autoupgrade::\$bootstrap.#'
 		- '#Access to an undefined property Module::\$installed.#'

--- a/tests/phpstan/phpstan-1.7.4.4.neon
+++ b/tests/phpstan/phpstan-1.7.4.4.neon
@@ -2,6 +2,8 @@ includes:
 	- %currentWorkingDirectory%/tests/phpstan/phpstan.neon
 
 parameters:
+	excludes_analyse:
+		- ./../../classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
 	ignoreErrors:
 		- '#Access to an undefined property Autoupgrade::\$bootstrap.#'
 		- '#Access to an undefined property Module::\$installed.#'

--- a/tests/phpstan/phpstan-1.7.5.1.neon
+++ b/tests/phpstan/phpstan-1.7.5.1.neon
@@ -2,6 +2,8 @@ includes:
 	- %currentWorkingDirectory%/tests/phpstan/phpstan.neon
 
 parameters:
+	excludes_analyse:
+		- ./../../classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
 	ignoreErrors:
 		- '#Access to an undefined property Autoupgrade::\$bootstrap.#'
 		- '#Access to an undefined property Module::\$installed.#'

--- a/tests/phpstan/phpstan-1.7.6.neon
+++ b/tests/phpstan/phpstan-1.7.6.neon
@@ -2,6 +2,8 @@ includes:
 	- %currentWorkingDirectory%/tests/phpstan/phpstan.neon
 
 parameters:
+	excludes_analyse:
+		- ./../../classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
 	ignoreErrors:
 		- '#Access to an undefined property Autoupgrade::\$bootstrap.#'
 		- '#Access to an undefined property Module::\$installed.#'

--- a/tests/phpstan/phpstan-1.7.7.neon
+++ b/tests/phpstan/phpstan-1.7.7.neon
@@ -2,6 +2,8 @@ includes:
 	- %currentWorkingDirectory%/tests/phpstan/phpstan.neon
 
 parameters:
+	excludes_analyse:
+		- ./../../classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
 	ignoreErrors:
 		- '#Access to an undefined property Module::\$installed.#'
 		- '#Call to method fetchLocale\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Cldr\\Update.#'

--- a/tests/phpstan/phpstan-1.7.8.neon
+++ b/tests/phpstan/phpstan-1.7.8.neon
@@ -2,6 +2,8 @@ includes:
 	- %currentWorkingDirectory%/tests/phpstan/phpstan.neon
 
 parameters:
+	excludes_analyse:
+		- ./../../classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
 	ignoreErrors:
 		- '#Access to an undefined property Module::\$installed.#'
 		- '#Call to method fetchLocale\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Cldr\\Update.#'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Use GenerateThemeMailTemplatesCommand during upgrade instead of legacy removed Language::installEmailsLanguagePack function
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/26503
| How to test?      | PrestaShop/PrestaShop#27276 must be merged before. Build the module based on this branch Install it and try to upgrade to 8.0.0 (you will probably need to create a release from the most recent develop branch). You shouldn't have anymore error related to mail generation (there might be other errors down on the road but it's not the purpose of this PR)
| Possible impacts? | The module now relies on `GenerateThemeMailTemplatesCommand` which was introduced in PrestaShop 1.7.6 which means the module would now be only compatible with target versions above 1.7.6 I don't know if we should handle retrocompatibility with older versions? If so then we might need to extract this new code in a dedicated class or service to handle the switch more cleanly

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
