### PR TITLE
Add logs email receivers in configuration table

### DIFF
--- a/upgrade/sql/1.7.8.0.sql
+++ b/upgrade/sql/1.7.8.0.sql
@@ -199,3 +199,5 @@ CREATE TABLE IF NOT EXISTS `PREFIX_feature_flag` (
 INSERT INTO `PREFIX_feature_flag` (`name`, `state`, `label_wording`, `label_domain`, `description_wording`, `description_domain`)
 VALUES
 	('product_page_v2', 0, 'Experimental product page', 'Admin.Advparameters.Feature', 'This page benefits from increased performance and includes new features such as a new combination management system. Please note this is a work in progress and some features are not available yet.', 'Admin.Advparameters.Help');
+
+INSERT IGNORE INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES ('PS_LOGS_EMAIL_RECEIVERS', (SELECT `value` FROM `PREFIX_configuration` WHERE `name` = 'PS_SHOP_EMAIL'), NOW(), NOW());

--- a/upgrade/sql/1.7.8.0.sql
+++ b/upgrade/sql/1.7.8.0.sql
@@ -199,5 +199,3 @@ CREATE TABLE IF NOT EXISTS `PREFIX_feature_flag` (
 INSERT INTO `PREFIX_feature_flag` (`name`, `state`, `label_wording`, `label_domain`, `description_wording`, `description_domain`)
 VALUES
 	('product_page_v2', 0, 'Experimental product page', 'Admin.Advparameters.Feature', 'This page benefits from increased performance and includes new features such as a new combination management system. Please note this is a work in progress and some features are not available yet.', 'Admin.Advparameters.Help');
-
-INSERT IGNORE INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES ('PS_LOGS_EMAIL_RECEIVERS', (SELECT `value` FROM `PREFIX_configuration` WHERE `name` = 'PS_SHOP_EMAIL'), NOW(), NOW());

--- a/upgrade/sql/1.7.8.3.sql
+++ b/upgrade/sql/1.7.8.3.sql
@@ -125,4 +125,4 @@ UPDATE `PREFIX_tab` SET `wording`='Link List', `wording_domain`='Modules.Linklis
 UPDATE `PREFIX_tab` SET `wording`='Theme & Logo', `wording_domain`='Admin.Navigation.Menu' WHERE `class_name`='AdminThemesParent' AND COALESCE(`wording`, '') = '' AND COALESCE(`wording_domain`, '') = '';
 
 INSERT IGNORE INTO `PREFIX_configuration` (`id_shop_group`, `id_shop`, `name`, `value`, `date_add`, `date_upd`)
-SELECT `id_shop_group`, `id_shop`, 'PS_LOGS_EMAIL_RECEIVERS', `value`, `date_add`, `date_upd` FROM `PREFIX_configuration` WHERE `name` = 'PS_SHOP_EMAIL'
+SELECT `id_shop_group`, `id_shop`, 'PS_LOGS_EMAIL_RECEIVERS', `value`, `date_add`, `date_upd` FROM `PREFIX_configuration` WHERE `name` = 'PS_SHOP_EMAIL';

--- a/upgrade/sql/1.7.8.3.sql
+++ b/upgrade/sql/1.7.8.3.sql
@@ -123,3 +123,5 @@ UPDATE `PREFIX_tab` SET `wording`='Quick Access', `wording_domain`='Admin.Naviga
 UPDATE `PREFIX_tab` SET `wording`='More', `wording_domain`='Admin.Navigation.Menu' WHERE `class_name`='DEFAULT' AND COALESCE(`wording`, '') = '' AND COALESCE(`wording_domain`, '') = '';
 UPDATE `PREFIX_tab` SET `wording`='Link List', `wording_domain`='Modules.Linklist.Admin' WHERE `class_name`='AdminLinkWidget' AND COALESCE(`wording`, '') = '' AND COALESCE(`wording_domain`, '') = '';
 UPDATE `PREFIX_tab` SET `wording`='Theme & Logo', `wording_domain`='Admin.Navigation.Menu' WHERE `class_name`='AdminThemesParent' AND COALESCE(`wording`, '') = '' AND COALESCE(`wording_domain`, '') = '';
+
+INSERT IGNORE INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES ('PS_LOGS_EMAIL_RECEIVERS', (SELECT `value` FROM `PREFIX_configuration` WHERE `name` = 'PS_SHOP_EMAIL'), NOW(), NOW());

--- a/upgrade/sql/1.7.8.3.sql
+++ b/upgrade/sql/1.7.8.3.sql
@@ -124,5 +124,5 @@ UPDATE `PREFIX_tab` SET `wording`='More', `wording_domain`='Admin.Navigation.Men
 UPDATE `PREFIX_tab` SET `wording`='Link List', `wording_domain`='Modules.Linklist.Admin' WHERE `class_name`='AdminLinkWidget' AND COALESCE(`wording`, '') = '' AND COALESCE(`wording_domain`, '') = '';
 UPDATE `PREFIX_tab` SET `wording`='Theme & Logo', `wording_domain`='Admin.Navigation.Menu' WHERE `class_name`='AdminThemesParent' AND COALESCE(`wording`, '') = '' AND COALESCE(`wording_domain`, '') = '';
 
-SET @ps_logs_email_receivers = (SELECT `value` FROM `PREFIX_configuration` WHERE `name` = 'PS_SHOP_EMAIL');
-INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES ('PS_LOGS_EMAIL_RECEIVERS', @ps_logs_email_receivers, NOW(), NOW());
+INSERT IGNORE INTO `PREFIX_configuration` (`id_shop_group`, `id_shop`, `name`, `value`, `date_add`, `date_upd`)
+SELECT `id_shop_group`, `id_shop`, 'PS_LOGS_EMAIL_RECEIVERS', `value`, `date_add`, `date_upd` FROM `PREFIX_configuration` WHERE `name` = 'PS_SHOP_EMAIL'

--- a/upgrade/sql/1.7.8.3.sql
+++ b/upgrade/sql/1.7.8.3.sql
@@ -124,4 +124,5 @@ UPDATE `PREFIX_tab` SET `wording`='More', `wording_domain`='Admin.Navigation.Men
 UPDATE `PREFIX_tab` SET `wording`='Link List', `wording_domain`='Modules.Linklist.Admin' WHERE `class_name`='AdminLinkWidget' AND COALESCE(`wording`, '') = '' AND COALESCE(`wording_domain`, '') = '';
 UPDATE `PREFIX_tab` SET `wording`='Theme & Logo', `wording_domain`='Admin.Navigation.Menu' WHERE `class_name`='AdminThemesParent' AND COALESCE(`wording`, '') = '' AND COALESCE(`wording_domain`, '') = '';
 
-INSERT IGNORE INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES ('PS_LOGS_EMAIL_RECEIVERS', (SELECT `value` FROM `PREFIX_configuration` WHERE `name` = 'PS_SHOP_EMAIL'), NOW(), NOW());
+SET @ps_logs_email_receivers = (SELECT `value` FROM `PREFIX_configuration` WHERE `name` = 'PS_SHOP_EMAIL');
+INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES ('PS_LOGS_EMAIL_RECEIVERS', @ps_logs_email_receivers, NOW(), NOW());


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | "Error: invalid e-mail address" when opening modules page in debug mode after upgrade to 1.7.8
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/PrestaShop#26680
| How to test?      | Upgrade PrestaShop to 1.7.8 in debug mode and go to the module page
| Possible impacts? | no

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
