### PR TITLE
Add optional xml field for archive channel

### DIFF
--- a/classes/TaskRunner/Miscellaneous/UpdateConfig.php
+++ b/classes/TaskRunner/Miscellaneous/UpdateConfig.php
@@ -81,9 +81,17 @@ class UpdateConfig extends AbstractTask
 
                 return false;
             }
+            $xmlFile = $configurationData['archive_xml'];
+            if (!empty($xmlFile) && !file_exists($this->container->getProperty(UpgradeContainer::DOWNLOAD_PATH) . DIRECTORY_SEPARATOR . $xmlFile)) {
+                $this->error = true;
+                $this->logger->info($this->translator->trans('File %s does not exist. Unable to select that channel', array($xmlFile), 'Modules.Autoupgrade.Admin'));
+
+                return false;
+            }
             $config['channel'] = 'archive';
             $config['archive.filename'] = $configurationData['archive_prestashop'];
             $config['archive.version_num'] = $configurationData['archive_num'];
+            $config['archive.xml'] = $configurationData['archive_xml'];
             // $config['archive_name'] = $request['archive_name'];
             $this->logger->info($this->translator->trans('Upgrade process will use archive.', array(), 'Modules.Autoupgrade.Admin'));
         }

--- a/classes/Twig/Block/UpgradeButtonBlock.php
+++ b/classes/Twig/Block/UpgradeButtonBlock.php
@@ -153,6 +153,7 @@ class UpgradeButtonBlock
         }
 
         $dir = glob($this->downloadPath . DIRECTORY_SEPARATOR . '*.zip');
+        $xml = glob($this->downloadPath . DIRECTORY_SEPARATOR . '*.xml');
 
         $data = array(
             'versionCompare' => $versionCompare,
@@ -174,7 +175,9 @@ class UpgradeButtonBlock
                 'allowMajor' => $this->config->get('private_allow_major'),
             ),
             'archiveFiles' => $dir,
+            'xmlFiles' => $xml,
             'archiveFileName' => $this->config->get('archive.filename'),
+            'xmlFileName' => $this->config->get('archive.xml'),
             'archiveVersionNumber' => $this->config->get('archive.version_num'),
             'downloadPath' => $this->downloadPath . DIRECTORY_SEPARATOR,
             'directoryVersionNumber' => $this->config->get('directory.version_num'),

--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -301,6 +301,10 @@ class UpgradeContainer
             case 'archive':
                 $upgrader->channel = 'archive';
                 $upgrader->version_num = $upgradeConfiguration->get('archive.version_num');
+                $archiveXml = $upgradeConfiguration->get('archive.xml');
+                if (!empty($archiveXml)) {
+                    $upgrader->version_md5[$upgrader->version_num] = $this->getProperty(self::DOWNLOAD_PATH) . DIRECTORY_SEPARATOR . $archiveXml;
+                }
                 $upgrader->checkPSVersion(true, array('archive'));
                 break;
             case 'directory':

--- a/classes/Upgrader.php
+++ b/classes/Upgrader.php
@@ -51,6 +51,7 @@ class Upgrader
     public $version_name;
     public $version_num;
     public $version_is_modified;
+    public $version_md5 = array();
     /**
      * @var string contains hte url where to download the file
      */
@@ -344,7 +345,11 @@ class Upgrader
      */
     public function getXmlMd5File($version, $refresh = false)
     {
-        return $this->getXmlFIle(_PS_ROOT_DIR_ . '/config/xml/' . $version . '.xml', $this->rss_md5file_link_dir . $version . '.xml', $refresh);
+        if (isset($this->version_md5[$version])) {
+            return @simplexml_load_file($this->version_md5[$version]);
+        }
+
+        return $this->getXmlFile(_PS_ROOT_DIR_ . '/config/xml/' . $version . '.xml', $this->rss_md5file_link_dir . $version . '.xml', $refresh);
     }
 
     /**

--- a/js/upgrade.js
+++ b/js/upgrade.js
@@ -800,6 +800,7 @@ $(document).ready(function() {
       } else if ($newChannel === "archive") {
         var archive_prestashop = $("select[name=archive_prestashop]").val();
         var archive_num = $("input[name=archive_num]").val();
+        var archive_xml = $("select[name=archive_xml]").val();
         if (archive_num == "") {
           showConfigResult(input.translation.needToEnterArchiveVersionNumber, "error");
           return false;
@@ -811,6 +812,7 @@ $(document).ready(function() {
         params.channel = "archive";
         params.archive_prestashop = archive_prestashop;
         params.archive_num = archive_num;
+        params.archive_xml = archive_xml;
       } else if ($newChannel === "directory") {
         params.channel = "directory";
         params.directory_prestashop = $("select[name=directory_prestashop] option:selected").val();

--- a/tests/phpstan/Dockerfile
+++ b/tests/phpstan/Dockerfile
@@ -13,7 +13,7 @@ RUN echo "memory_limit=-1" > $PHP_CONF_DIR/99_memory-limit.ini \
     && apk add git \
     && rm -rf /var/cache/apk/* /var/tmp/* /tmp/*
 
-RUN composer global require phpstan/phpstan \
+RUN composer global require phpstan/phpstan:0.12.99 \
 	&& rm -rf /composer/vendor/phpstan/phpstan/.git \
 	&& composer clear-cache
 

--- a/views/templates/block/upgradeButtonBlock.twig
+++ b/views/templates/block/upgradeButtonBlock.twig
@@ -116,12 +116,21 @@
                                 <br>
                                 <label for="archive_num">{{ 'Number of the version you want to upgrade to:'|trans }} * </label>
                                 <input type="text" size="10" id="archive_num" name="archive_num" value="{{ archiveVersionNumber }}" placeholder="1.7.0.1" />
+                                <br>
+                                <label for="archive_xml">{{ 'XML file to use:'|trans }}</label>
+                                <select id="archive_xml" name="archive_xml">
+                                    <option value="">{{ 'Choose an XML file'|trans }}</option>
+                                    {% for file in xmlFiles %}
+                                        {% set fileName = file|replace({(downloadPath): ''}) %}
+                                        <option {% if xmlFileName == fileName %} selected{% endif %} value="{{ fileName }}">{{ fileName }}</option>
+                                    {% endfor %}
+                                </select>
                             </div>
                         {% else %}
                             <div class="alert alert-warning">{{ 'No archive found in your admin/autoupgrade/download directory'|trans }}</div>
                         {% endif %}
                         <div class="margin-form">
-                            {{ 'Save in the following directory the archive file of the version you want to upgrade to: %s'|trans(['<b>/admin/autoupgrade/download/</b>'])|raw }}<br>
+                            {{ 'Save in the following directory the archive file and XML file of the version you want to upgrade to: %s'|trans(['<b>/admin/autoupgrade/download/</b>'])|raw }}<br>
                             {{ 'Click to save once the archive is there.'|trans }}<br>
                             {{ 'This option will skip the download step.'|trans }}
                         </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR aims to provide a way to use a local xml file containing the md5 sum of every files of the zip. This xml file is usually provided by an online API but when we use a local archive of a PrestaShop version that is not released yet, there was no easy way to do it.
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | Try an upgrade from 1.6.1.24 to build of PrestaShop that is not released yet using the new "XML file to use:" field (xml files should be put in the same folder as the zip): <img width="559" alt="Capture d’écran 2021-12-06 à 17 10 51" src="https://user-images.githubusercontent.com/2168836/144881266-c660f46c-7cf5-4d63-80c1-32cfa59a185f.png">
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
