### PR TITLE
Add SQL upgrade queries for new unit price column

### DIFF
--- a/upgrade/sql/8.0.0.sql
+++ b/upgrade/sql/8.0.0.sql
@@ -50,6 +50,13 @@ ALTER TABLE `PREFIX_product_shop` MODIFY COLUMN `redirect_type` ENUM(
 
 ALTER TABLE `PREFIX_order_detail` MODIFY COLUMN `product_name` TEXT NOT NULL;
 
+ALTER TABLE `PREFIX_product` ADD `unit_price` decimal(20, 6) NOT NULL DEFAULT '0.000000' AFTER `unity`;
+ALTER TABLE `PREFIX_product_shop` ADD `unit_price` decimal(20, 6) NOT NULL DEFAULT '0.000000' AFTER `unity`;
+
+UPDATE `PREFIX_product` SET `unit_price` = IF (`unit_price_ratio` != 0, `price` / `unit_price_ratio`, 0);
+UPDATE `PREFIX_product_shop` SET `unit_price` = IF (`unit_price_ratio` != 0, `price` / `unit_price_ratio`, 0);
+
+
 ALTER TABLE `PREFIX_feature_flag` ADD `stability` VARCHAR(64) DEFAULT 'beta' NOT NULL;
 UPDATE `PREFIX_feature_flag` SET `state` = '0', `stability` = 'stable', `label_wording` = 'New product page - Single store', `description_wording` = 'This page benefits from increased performance and includes new features such as a new combination management system.' WHERE `name` = 'product_page_V2';
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | These upgrade queries are related to this PR https://github.com/PrestaShop/PrestaShop/pull/26762 which adds a new column in product tables<br>In 178 the product table used the `unit_price_ratio` to save the unit price, so the actual value was not saved only the ratio instead. In 8.0.0 we now have a `unit_price` column which persists the actual value specified in the BO and used in the FO. But we kept the `unit_price_ratio` for backward compatibility for now.<br><br>This upgrade PR does to things:<br>- it adds the new column `unit_price` in the database<br>- it computes its value based on existing `unit_price_ratio` and `price` column
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| How to test?      | You should create (or edit) some products with defined prices AND unit prices. After the upgrade check that the `unit_price` column has been created in the `product` table and `product_shop` table, the `unit_price` values should be prefilled based on previous values. The formula to compute it is the following `unit_price = price / unit_price_ratio`, when you go back to the product edition the value for the unit price should be the same even if it is now based on a different column.
| Possible impacts? | ~

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
