### PR TITLE
Fix dirname call for PHP <7.0

### DIFF
--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -192,7 +192,7 @@ abstract class CoreUpgrader
             define('_PS_MODULE_DIR_', $this->pathToInstallFolder . '/../modules/');
         }
 
-        $this->pathToUpgradeScripts = dirname(__DIR__, 3) . '/upgrade/';
+        $this->pathToUpgradeScripts = dirname(dirname(dirname(__DIR__))) . '/upgrade/';
         define('_PS_INSTALLER_PHP_UPGRADE_DIR_', $this->pathToUpgradeScripts . 'php/');
 
         if (!defined('__PS_BASE_URI__')) {


### PR DESCRIPTION
`dirname(..., 3)` in PHP 7.0+ is equivalent to `dirname(dirname(dirname(...)))` in PHP <7.0.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Changing a `dirname()` call to avoid using the second argument which is only supported by PHP 7.0+
| Type?             | bug fix / improvement
| BC breaks?        | I don’t know. What’s BC?
| Deprecations?     | I don’t know
| Fixed ticket?     | _none_
| How to test?      | Run the autoupgrade script using PHP 5.6
| Possible impacts? |

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
