### PR TITLE
Updated PREFIX_state.name field to 80 chars.

### DIFF
--- a/upgrade/sql/1.7.8.4.sql
+++ b/upgrade/sql/1.7.8.4.sql
@@ -1,0 +1,4 @@
+SET SESSION sql_mode='';
+SET NAMES 'utf8mb4';
+
+ALTER TABLE `PREFIX_state` MODIFY COLUMN `name` VARCHAR(80) NOT NULL;


### PR DESCRIPTION
Fixes https://github.com/PrestaShop/PrestaShop/issues/27156 updating size to 80 chars for PREFIX_state.name field.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Updating PREFIX_State.name field to 80 chars according to PR https://github.com/PrestaShop/PrestaShop/pull/27162
| Type?             | improvement
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/27156.
| How to test?      | This PR should be approved at the same time as PR https://github.com/PrestaShop/PrestaShop/pull/27162 which changes the field size to 80 chars.
| Possible impacts? | None that I know of.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
