### PR TITLE
Add hooks to retrieve module on install/upgrade from external source

### DIFF
--- a/upgrade/sql/8.0.0.sql
+++ b/upgrade/sql/8.0.0.sql
@@ -23,8 +23,8 @@ INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `po
   (NULL, 'actionPresentPaymentOptions', 'Payment options Presenter', 'This hook is called before payment options are presented', '1'),
   (NULL, 'actionCustomerLogoutBefore', 'Before customer logout', 'This hook allows you to execute code before customer logout', '1'),
   (NULL, 'actionCustomerLogoutAfter', 'After customer logout', 'This hook allows you to execute code after customer logout', '1'),
-  (NULL, 'displayCheckoutSummaryTop', 'Cart summary top', 'This hook allows you to display new elements in top of cart summary', '1')
-  (NULL, 'actionAdminModuleInstallRetrieveSource', 'Module Install - Get source from other module', 'This hook retrieves a module zip on install process in the BackOffice', '1')
+  (NULL, 'displayCheckoutSummaryTop', 'Cart summary top', 'This hook allows you to display new elements in top of cart summary', '1'),
+  (NULL, 'actionAdminModuleInstallRetrieveSource', 'Module Install - Get source from other module', 'This hook retrieves a module zip on install process in the BackOffice', '1'),
   (NULL, 'actionAdminModuleUpgradeRetrieveSource', 'Module Upgrade - Get source from other module', 'This hook retrieves a module zip on upgrade process in the BackOffice', '1')
 ;
 

--- a/upgrade/sql/8.0.0.sql
+++ b/upgrade/sql/8.0.0.sql
@@ -24,6 +24,8 @@ INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `po
   (NULL, 'actionCustomerLogoutBefore', 'Before customer logout', 'This hook allows you to execute code before customer logout', '1'),
   (NULL, 'actionCustomerLogoutAfter', 'After customer logout', 'This hook allows you to execute code after customer logout', '1'),
   (NULL, 'displayCheckoutSummaryTop', 'Cart summary top', 'This hook allows you to display new elements in top of cart summary', '1')
+  (NULL, 'actionAdminModuleInstallRetrieveSource', 'Module Install - Get source from other module', 'This hook retrieves a module zip on install process in the BackOffice', '1')
+  (NULL, 'actionAdminModuleUpgradeRetrieveSource', 'Module Upgrade - Get source from other module', 'This hook retrieves a module zip on upgrade process in the BackOffice', '1')
 ;
 
 ALTER TABLE `PREFIX_employee_session` ADD `date_upd` DATETIME NOT NULL AFTER `token`;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add hooks actionAdminModuleInstallRetrieveSource and actionAdminModuleUpgradeRetrieveSource for autoupgrade of 8.0.0
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | See https://github.com/PrestaShop/PrestaShop/pull/27703
| How to test?      | -
| Possible impacts? | -

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
