### PR TITLE
Add missing Security tab entries

### DIFF
--- a/upgrade/php/ps_800_add_security_tab.php
+++ b/upgrade/php/ps_800_add_security_tab.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+function ps_800_add_security_tab()
+{
+    include_once __DIR__ . '/add_new_tab.php';
+    $tabs = [
+        ['AdminParentSecurity', 'en:Security', 0, false, 'AdminAdvancedParameters'],
+        ['AdminSecurity', 'en:Security', 0, false, 'AdminParentSecurity'],
+        ['AdminSecuritySessionEmployee', 'en:Employee Sessions', 0, false, 'AdminParentSecurity'],
+        ['AdminSecuritySessionCustomer', 'en:Customer Sessions', 0, false, 'AdminParentSecurity'],
+    ];
+    $tabsData = [
+        'AdminParentSecurity' => [
+            'active' => 1,
+            'enabled' => 1,
+            'wording' => '\'Security\'',
+            'wording_domain' => '\'Admin.Navigation.Menu\'',
+        ],
+        'AdminSecurity' => [
+            'active' => 1,
+            'enabled' => 1,
+            'wording' => '\'Security\'',
+            'wording_domain' => '\'Admin.Navigation.Menu\'',
+            'route_name' => '\'admin_security\'',
+        ],
+        'AdminSecuritySessionEmployee' => [
+            'active' => 1,
+            'enabled' => 1,
+            'wording' => '\'Employee Sessions\'',
+            'wording_domain' => '\'Admin.Navigation.Menu\'',
+            'route_name' => '\'admin_security_sessions_employee_list\'',
+        ],
+        'AdminSecuritySessionCustomer' => [
+            'active' => 1,
+            'enabled' => 1,
+            'wording' => '\'Customer Sessions\'',
+            'wording_domain' => '\'Admin.Navigation.Menu\'',
+            'route_name' => '\'admin_security_sessions_customer_list\'',
+        ],
+    ];
+
+    foreach ($tabs as $tab) {
+        add_new_tab_17(...$tab);
+        $data = [];
+        foreach ($tabsData[$tab[0]] as $key => $value) {
+            $data[] = '`' . $key . '` = ' . $value;
+        }
+        Db::getInstance()->execute(
+            'UPDATE `' . _DB_PREFIX_ . 'tab` SET ' . implode(', ', $data) . ' WHERE `class_name` = \'' . $tab[0] . '\''
+        );
+    }
+}

--- a/upgrade/sql/8.0.0.sql
+++ b/upgrade/sql/8.0.0.sql
@@ -10,7 +10,8 @@ INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VAL
     ('PS_MAIL_DKIM_DOMAIN', '', NOW(), NOW()),
     ('PS_MAIL_DKIM_SELECTOR', '', NOW(), NOW()),
     ('PS_MAIL_DKIM_KEY', '', NOW(), NOW()),
-    ('PS_WEBP_QUALITY', '80', NOW(), NOW())
+    ('PS_WEBP_QUALITY', '80', NOW(), NOW()),
+    ('PS_SECURITY_TOKEN', '1', NOW(), NOW())
 ;
 
 INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES
@@ -38,3 +39,5 @@ ALTER TABLE `PREFIX_product` MODIFY COLUMN `redirect_type` ENUM(
 ALTER TABLE `PREFIX_product_shop` MODIFY COLUMN `redirect_type` ENUM(
     '404', '410', '301-product', '302-product', '301-category', '302-category'
 ) NOT NULL DEFAULT '404';
+
+/* PHP:ps_800_add_security_tab(); */;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Since the new Security page has been added in the develop branch, it was not available after an upgrade from previous versions. This PR fixes it by adding the missing tab entries in the DB during the upgrade.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/PrestaShop#27735.
| How to test?      | Try to upgrade from 1.7.8.3 to develop, the menu security should be available in the menu.
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
