### PR TITLE
New option for displaying copyright in the footer

### DIFF
--- a/upgrade/sql/8.0.0.sql
+++ b/upgrade/sql/8.0.0.sql
@@ -11,6 +11,7 @@ INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VAL
     ('PS_MAIL_DKIM_SELECTOR', '', NOW(), NOW()),
     ('PS_MAIL_DKIM_KEY', '', NOW(), NOW()),
     ('PS_WEBP_QUALITY', '80', NOW(), NOW()),
+    ('PS_DISPLAY_FOOTER_COPYRIGHT', '1', NOW(), NOW()),
     ('PS_SECURITY_TOKEN', '1', NOW(), NOW())
 ;
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | To be merged after https://github.com/PrestaShop/PrestaShop/pull/27963
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to https://github.com/PrestaShop/PrestaShop/issues/9674
| How to test?      | After update from 1.7 to v8 you should have "Display PrestaShop copyright in the footer" set to "yes" in Preferences -> General
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
