### PR TITLE
Handle PrestaShop versions before 1.7.5.1 + CI fix

### DIFF
--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -422,7 +422,7 @@ class UpgradeSelfCheck
 
         // if multistore is not active, just check if shop is enabled and has a maintenance IP
         if (!Shop::isFeatureActive()) {
-            return !(Configuration::get('PS_SHOP_ENABLE') && Configuration::get('PS_MAINTENANCE_IP'));
+            return !(Configuration::get('PS_SHOP_ENABLE') || !Configuration::get('PS_MAINTENANCE_IP'));
         }
 
         // multistore is active: all shops must be deactivated and have a maintenance IP, otherwise return false
@@ -515,7 +515,8 @@ class UpgradeSelfCheck
         foreach ([
             'curl', 'dom', 'fileinfo', 'gd', 'intl', 'json', 'mbstring', 'openssl', 'pdo_mysql', 'simplexml', 'zip',
         ] as $extension) {
-            if (!ConfigurationTest::{'test_' . $extension}()) {
+            $method = 'test_' . $extension;
+            if (method_exists(ConfigurationTest::class, $method) && !ConfigurationTest::$method()) {
                 $extensions[] = $extension;
             }
         }

--- a/tests/e2e/scenarios/02_upgrade.js
+++ b/tests/e2e/scenarios/02_upgrade.js
@@ -108,10 +108,10 @@ describe(`[${global.AUTOUPGRADE_VERSION}] Upgrade PrestaShop from '${global.PS_V
     await expect(textResult).to.contain(upgradeModulePage.configResultValidationMessage);
   });
 
-  it('should put the shop under maintenance and check if the checklist is all green', async () => {
+  it('Check if the checklist is all green', async () => {
     await upgradeModulePage.putShopUnderMaintenance(page);
 
-    for (let i = 1; i <= 10; i++) {
+    for (let i = 1; i <= 8; i++) {
       const textResult = await upgradeModulePage.getRowImageContent(page, i);
       await expect(textResult).to.equal('ok');
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Since #440 has been merged, `ConfigurationTest::test_intl()` is called but this method was introduced in PrestaShop in 1.7.5.1 only. This PR aims to check if functions exists before calling them. It also fixes the nightly CI configuration check that is now 8 items long instead of 10. There's no need to put the store into maintenance mode as localhost is considered safe to upgrade. [This last configuration error](https://github.com/PrestaShop/autoupgrade/pull/445#issuecomment-1079197168) is also fixed.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | 1. From a PrestaShop 1.7.4.4, install this module<br>2. Try to configure it: no exception should be thrown<br><br>Also see https://github.com/PrestaShop/autoupgrade/pull/445#issuecomment-1079197168
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
