### PR TITLE
Add pages to enable maintenance mode before upgrade

### DIFF
--- a/.github/workflows/e2e_nightly_upgrade.yml
+++ b/.github/workflows/e2e_nightly_upgrade.yml
@@ -1,6 +1,7 @@
 name: Nightly upgrades with user inferfaces
 
 on:
+  push:
   schedule:
     - cron: "0 6 * * *" # Every day at 06:00Am
 

--- a/.github/workflows/e2e_nightly_upgrade.yml
+++ b/.github/workflows/e2e_nightly_upgrade.yml
@@ -1,7 +1,6 @@
 name: Nightly upgrades with user inferfaces
 
 on:
-  push:
   schedule:
     - cron: "0 6 * * *" # Every day at 06:00Am
 

--- a/tests/e2e/.gitignore
+++ b/tests/e2e/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 */node_modules
+mochawesome-report
 .idea

--- a/tests/e2e/configClassMap.js
+++ b/tests/e2e/configClassMap.js
@@ -12,4 +12,22 @@ module.exports = [
       '1.7.7': `${basePath}/pages/BO/modules/autoupgrade/index.js`,
     },
   },
+  {
+    file: 'BO/shopParameters/general/index.js',
+    versions: {
+      '1.7.4': `${basePath}/pages/BO/shopParameters/general/index.js`,
+      '1.7.5': `${basePath}/pages/BO/shopParameters/general/index.js`,
+      '1.7.6': `${basePath}/pages/BO/shopParameters/general/index.js`,
+      '1.7.7': `${basePath}/pages/BO/shopParameters/general/index.js`,
+    },
+  },
+  {
+    file: 'BO/shopParameters/general/maintenance/index.js',
+    versions: {
+      '1.7.4': `${basePath}/pages/BO/shopParameters/general/maintenance/index.js`,
+      '1.7.5': `${basePath}/pages/BO/shopParameters/general/maintenance/index.js`,
+      '1.7.6': `${basePath}/pages/BO/shopParameters/general/maintenance/index.js`,
+      '1.7.7': `${basePath}/pages/BO/shopParameters/general/maintenance/index.js`,
+    },
+  },
 ];

--- a/tests/e2e/globals.js
+++ b/tests/e2e/globals.js
@@ -1,5 +1,5 @@
 global.PS_VERSION_UPGRADE_FROM = global.PS_VERSION;
-global.PS_VERSION_UPGRADE_TO = process.env.PS_VERSION_UPGRADE_TO || '1.7.8';
+global.PS_VERSION_UPGRADE_TO = process.env.PS_VERSION_UPGRADE_TO || '1.7.8.5';
 global.PS_RESOLVER_VERSION = {
   FROM: global.PS_VERSION.substr(0, global.PS_VERSION.lastIndexOf('.')),
   TO: global.PS_VERSION_UPGRADE_TO.substr(0, global.PS_VERSION_UPGRADE_TO.lastIndexOf('.')),

--- a/tests/e2e/pages/BO/shopParameters/general/index.js
+++ b/tests/e2e/pages/BO/shopParameters/general/index.js
@@ -1,0 +1,31 @@
+// Get resolver
+const VersionSelectResolver = require('prestashop_test_lib/kernel/resolvers/versionSelectResolver');
+
+const configClassMap = require('@root/configClassMap.js');
+
+const versionSelectResolver = new VersionSelectResolver(global.PS_RESOLVER_VERSION.FROM, configClassMap);
+
+// Import BOBasePage
+const BoBasePage = versionSelectResolver.require('BO/BObasePage.js');
+
+class General extends BoBasePage {
+  constructor() {
+    super();
+
+    this.pageTitle = 'Preferences';
+
+    this.maintenanceSubTabLink = '#subtab-AdminMaintenance';
+  }
+
+  // Methods
+  /**
+   * Go to maintenance tab
+   * @param page {Page} Browser tab
+   * @returns {Promise<void>}
+   */
+  async goToMaintenanceTab(page) {
+    await this.clickAndWaitForNavigation(page, this.maintenanceSubTabLink);
+  }
+}
+
+module.exports = new General();

--- a/tests/e2e/pages/BO/shopParameters/general/maintenance/index.js
+++ b/tests/e2e/pages/BO/shopParameters/general/maintenance/index.js
@@ -14,6 +14,7 @@ class Maintenance extends BoBasePage {
 
     this.pageTitle = 'Maintenance';
     this.storeStatusRadio = status => `#form_general_enable_shop_${status}, #form_enable_shop_${status}`;
+    this.addIpButton = '.add_ip_button';
     this.saveButton = '.card-footer button';
   }
 
@@ -29,7 +30,16 @@ class Maintenance extends BoBasePage {
     // eslint-disable-next-line no-return-assign,no-param-reassign
     await page.$eval(this.storeStatusRadio(status ? '1' : '0'), el => el.checked = true);
     await this.clickAndWaitForNavigation(page, this.saveButton);
-    await page.screenshot({path: 'page.png', fullPage: true});
+  }
+
+  /**
+   * Add my ip to shop
+   * @param page {Page} Browser tab
+   * @returns {Promise<void>}
+   */
+  async addMyIp(page) {
+    await page.click(this.addIpButton);
+    await this.clickAndWaitForNavigation(page, this.saveButton);
   }
 }
 

--- a/tests/e2e/pages/BO/shopParameters/general/maintenance/index.js
+++ b/tests/e2e/pages/BO/shopParameters/general/maintenance/index.js
@@ -1,0 +1,36 @@
+// Get resolver
+const VersionSelectResolver = require('prestashop_test_lib/kernel/resolvers/versionSelectResolver');
+
+const configClassMap = require('@root/configClassMap.js');
+
+const versionSelectResolver = new VersionSelectResolver(global.PS_RESOLVER_VERSION.FROM, configClassMap);
+
+// Import BOBasePage
+const BoBasePage = versionSelectResolver.require('BO/BObasePage.js');
+
+class Maintenance extends BoBasePage {
+  constructor() {
+    super();
+
+    this.pageTitle = 'Maintenance';
+    this.storeStatusRadio = status => `#form_general_enable_shop_${status}, #form_enable_shop_${status}`;
+    this.saveButton = '.card-footer button';
+  }
+
+  // Methods
+
+  /**
+   * Set shop status
+   * @param page {Page} Browser tab
+   * @param status {boolean} Status for the shop
+   * @returns {Promise<void>}
+   */
+  async setShopStatus(page, status = true) {
+    // eslint-disable-next-line no-return-assign,no-param-reassign
+    await page.$eval(this.storeStatusRadio(status ? '1' : '0'), el => el.checked = true);
+    await this.clickAndWaitForNavigation(page, this.saveButton);
+    await page.screenshot({path: 'page.png', fullPage: true});
+  }
+}
+
+module.exports = new Maintenance();

--- a/tests/e2e/scenarios/02_upgrade.js
+++ b/tests/e2e/scenarios/02_upgrade.js
@@ -15,6 +15,8 @@ const newVersionSelectResolver = new VersionSelectResolver(global.PS_RESOLVER_VE
 // Import pages
 const loginPage = versionSelectResolver.require('BO/login/index.js');
 const dashboardPage = versionSelectResolver.require('BO/dashboard/index.js');
+const shopParamGeneralPage = versionSelectResolver.require('BO/shopParameters/general/index.js');
+const shopParamMaintenancePage = versionSelectResolver.require('BO/shopParameters/general/maintenance/index.js');
 const moduleManagerPage = versionSelectResolver.require('BO/modules/moduleManager/index.js');
 const upgradeModulePage = versionSelectResolver.require('BO/modules/autoupgrade/index.js');
 const newLoginPage = newVersionSelectResolver.require('BO/login/index.js');
@@ -78,11 +80,30 @@ describe(`[${global.AUTOUPGRADE_VERSION}] Upgrade PrestaShop from '${global.PS_V
     await expect(pageTitle).to.contains(dashboardPage.pageTitle);
   });
 
-  it('should go to modules manager page', async () => {
+  it('should go to shop parameter page', async () => {
     await dashboardPage.goToSubMenu(
       page,
-      dashboardPage.modulesParentLink,
-      dashboardPage.moduleManagerLink,
+      dashboardPage.shopParametersParentLink,
+      dashboardPage.shopParametersGeneralLink,
+    );
+
+    const pageTitle = await shopParamGeneralPage.getPageTitle(page);
+    await expect(pageTitle).to.contains(shopParamGeneralPage.pageTitle);
+  });
+
+  it('should go to maintenance page and disable the shop', async () => {
+    await shopParamGeneralPage.goToMaintenanceTab(page);
+
+    const pageTitle = await shopParamMaintenancePage.getPageTitle(page);
+    await expect(pageTitle).to.contains(shopParamMaintenancePage.pageTitle);
+    await shopParamMaintenancePage.setShopStatus(page, false);
+  });
+
+  it('should go to modules manager page', async () => {
+    await shopParamMaintenancePage.goToSubMenu(
+      page,
+      shopParamMaintenancePage.modulesParentLink,
+      shopParamMaintenancePage.moduleManagerLink,
     );
 
     const pageTitle = await moduleManagerPage.getPageTitle(page);

--- a/tests/e2e/scenarios/02_upgrade.js
+++ b/tests/e2e/scenarios/02_upgrade.js
@@ -97,6 +97,7 @@ describe(`[${global.AUTOUPGRADE_VERSION}] Upgrade PrestaShop from '${global.PS_V
     const pageTitle = await shopParamMaintenancePage.getPageTitle(page);
     await expect(pageTitle).to.contains(shopParamMaintenancePage.pageTitle);
     await shopParamMaintenancePage.setShopStatus(page, false);
+    await shopParamMaintenancePage.addMyIp(page);
   });
 
   it('should go to modules manager page', async () => {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add pages to enable maintenance mode before upgrade
| Type?             | refacto
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | no
| How to test?      | Tested with workflow
| Possible impacts? | none

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
