### PR TITLE
File modulesToUpgrade.list doesn't need to be manually deleted anymore

### DIFF
--- a/.github/action.yml
+++ b/.github/action.yml
@@ -24,7 +24,6 @@ runs:
       shell: bash
       run: |
         [[ "$SKIP" == true ]] || ${{ github.action_path }}action_upgrade.sh
-        [[ "$SKIP" == true ]] || docker exec prestashop_autoupgrade rm admin-dev/autoupgrade/modulesToUpgrade.list
         [[ "$SKIP" == true ]] || docker stop prestashop_autoupgrade
         [[ "$SKIP" == true ]] || docker rm prestashop_autoupgrade
         [[ "$SKIP" == true ]] || docker run --name prestashop_autoupgrade -p 8001:80 -v autoupgrade_temp-ps:/var/www/html -v "$(pwd):/var/www/html/modules/autoupgrade" --network autoupgrade_default -d prestashop/base:7.2-apache

--- a/.github/workflows/nigthly_upgrade.yml
+++ b/.github/workflows/nigthly_upgrade.yml
@@ -1,5 +1,6 @@
 name: Nightly Upgrades
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
 jobs:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Since #450 the file `modulesToUpgrade.list` is deleted at the end of the upgrade process, there is then no need to manually delete it manually during the upgrade tests.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | Error before this PR: https://github.com/PrestaShop/autoupgrade/runs/6150038767?check_suite_focus=true#step:5:438<br>Error after this PR: https://github.com/atomiix/autoupgrade/runs/6155485959?check_suite_focus=true#step:5:941<br>The error left will be fixed in another PR
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
