### PR TITLE
Fix PHP 8.1 deprecated notice

### DIFF
--- a/classes/Twig/Block/UpgradeButtonBlock.php
+++ b/classes/Twig/Block/UpgradeButtonBlock.php
@@ -116,7 +116,10 @@ class UpgradeButtonBlock
     {
         $translator = $this->translator;
 
-        $versionCompare = version_compare(_PS_VERSION_, $this->upgrader->version_num);
+        $versionCompare = $this->upgrader->version_num !== null
+            ? version_compare(_PS_VERSION_, $this->upgrader->version_num)
+            : 0
+        ;
         $channel = $this->config->get('channel');
 
         if (!in_array($channel, ['archive', 'directory']) && !empty($this->upgrader->version_num)) {

--- a/classes/Upgrader.php
+++ b/classes/Upgrader.php
@@ -195,7 +195,7 @@ class Upgrader
                         && version_compare($branch_name, $this->branch, '>='))
                     ) {
                         // skip if $branch->num is inferior to a previous one, skip it
-                        if (version_compare((string) $branch->num, $this->version_num, '<')) {
+                        if ($this->version_num !== null && version_compare((string) $branch->num, $this->version_num, '<')) {
                             continue;
                         }
                         // also skip if previous loop found an available upgrade and current is not
@@ -225,7 +225,7 @@ class Upgrader
         // retro-compatibility :
         // return array(name,link) if you don't use the last version
         // false otherwise
-        if (version_compare($this->currentPsVersion, $this->version_num, '<')) {
+        if ($this->version_num !== null && version_compare($this->currentPsVersion, $this->version_num, '<')) {
             $this->need_upgrade = true;
 
             return ['name' => $this->version_name, 'link' => $this->link];


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Since PHP 8.1, `version_compare()` cannot accept `null` as an argument. This PR fixes it by checking that the argument `version_num` is not null before using it in the `version_compare()` function.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/PrestaShop#28631
| How to test?      | Please see PrestaShop/PrestaShop#28631
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
