### PR TITLE
Update stock movement DB employee fields

### DIFF
--- a/upgrade/sql/8.1.0.sql
+++ b/upgrade/sql/8.1.0.sql
@@ -46,3 +46,5 @@ UPDATE `PREFIX_product_shop` SET `redirect_type` = 'default' WHERE `redirect_typ
 /* Update product v2 toggle and delete product_page_v2_multi_shop */
 UPDATE `PREFIX_feature_flag` SET `label_wording` = 'New product page', `stability` = 'stable' WHERE `name` = 'product_page_v2';
 DELETE FROM `PREFIX_feature_flag` WHERE name = 'product_page_v2_multi_shop';
+
+ALTER TABLE `PREFIX_stock_mvt` CHANGE `employee_lastname` `employee_lastname` VARCHAR(255) DEFAULT NULL, CHANGE `employee_firstname` `employee_firstname` VARCHAR(255) DEFAULT NULL;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | In the PR https://github.com/PrestaShop/PrestaShop/pull/28640 a bug was detected related to employee with long name or firstname, it cause a bug while creating a stock movement because the `stock_mvt` structure can't handle such long values
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| How to test?      | When upgrading from version prior ao 8.0.0 check the DB structure, in the `stock_mvt` table the columns `employee_lastname` and `employee_lastname` used to be `VARCHAR(32)` now they should be `VARCHAR(255)` to match the length from the employee table
| Possible impacts? | ~

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
