### PR TITLE
Remove PS_SMARTY_CACHING_TYPE configuration in 1.7.8.8

### DIFF
--- a/upgrade/sql/1.7.8.8.sql
+++ b/upgrade/sql/1.7.8.8.sql
@@ -1,0 +1,4 @@
+SET SESSION sql_mode='';
+SET NAMES 'utf8';
+
+DELETE FROM `PREFIX_configuration` WHERE `name` = 'PS_SMARTY_CACHING_TYPE';


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Please be specific when describing the PR. Every detail helps: What are you changing? Why?
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | After the update to 1.7.8.8, the table `ps_configuration` should not contain an entry with the name `PS_SMARTY_CACHING_TYPE`.
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
