### PR TITLE
Added stock_mvt tables upgrade

### DIFF
--- a/upgrade/sql/8.0.0.sql
+++ b/upgrade/sql/8.0.0.sql
@@ -91,3 +91,5 @@ UPDATE `PREFIX_tab` SET wording = 'New & Experimental Features' WHERE `class_nam
 /* PHP:ps_update_tab_lang('Admin.Navigation.Menu', 'AdminFeatureFlag'); */;
 
 UPDATE `PREFIX_quick_access` SET `link` = 'index.php/sell/orders' WHERE `link` = 'index.php?controller=AdminOrders';
+
+ALTER TABLE  `PREFIX_stock_mvt` CHANGE `physical_quantity` `physical_quantity` INT(11) UNSIGNED  NOT NULL;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Changing the stock_mvt tables quantity input to unsigned. It is always positive number and by doing this we can insert twice as big int and after this [PR](https://github.com/PrestaShop/PrestaShop/pull/29081) we need that.
| Type?             | improvement 
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | Fixes [27313](https://github.com/PrestaShop/PrestaShop/issues/27313).
| How to test?      | Run upgrade and check if table stock_mvt had the column physical_quantity changed to UNSIGNED.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
