### PR TITLE
Fix version compare check to use CoreUpgrader 8 with 8.0 version

### DIFF
--- a/classes/TaskRunner/Upgrade/UpgradeDb.php
+++ b/classes/TaskRunner/Upgrade/UpgradeDb.php
@@ -60,11 +60,11 @@ class UpgradeDb extends AbstractTask
 
     public function getCoreUpgrader()
     {
-        if (version_compare($this->container->getState()->getInstallVersion(), '1.7.0.0', '<')) {
+        if (version_compare($this->container->getState()->getInstallVersion(), '1.7', '<')) {
             return new CoreUpgrader16($this->container, $this->logger);
         }
 
-        if (version_compare($this->container->getState()->getInstallVersion(), '8.0.0', '<')) {
+        if (version_compare($this->container->getState()->getInstallVersion(), '8', '<')) {
             return new CoreUpgrader17($this->container, $this->logger);
         }
 

--- a/js/upgrade.js
+++ b/js/upgrade.js
@@ -804,7 +804,7 @@ $(document).ready(function() {
         var archive_prestashop = $("select[name=archive_prestashop]").val();
         var archive_num = $("input[name=archive_num]").val();
         var archive_xml = $("select[name=archive_xml]").val();
-        if (archive_num == "" || !archive_num.match(versionNumberRegex)) {
+        if (archive_num == "" || (archive_num !== undefined && !archive_num.match(versionNumberRegex))) {
           showConfigResult(input.translation.needToEnterArchiveVersionNumber, "error");
           return false;
         }
@@ -820,7 +820,7 @@ $(document).ready(function() {
         params.channel = "directory";
         params.directory_prestashop = $("select[name=directory_prestashop] option:selected").val();
         let directory_num = $("input[name=directory_num]").val();
-        if (directory_num == "" || !directory_num.match(versionNumberRegex)) {
+        if (directory_num == "" || (directory_num !== undefined && !directory_num.match(versionNumberRegex))) {
           showConfigResult(input.translation.needToEnterDirectoryVersionNumber, "error");
           return false;
         }

--- a/js/upgrade.js
+++ b/js/upgrade.js
@@ -820,7 +820,7 @@ $(document).ready(function() {
         params.channel = "directory";
         params.directory_prestashop = $("select[name=directory_prestashop] option:selected").val();
         let directory_num = $("input[name=directory_num]").val();
-        if (directory_num !== undefined && (directory_num == "" || !directory_num.match(versionNumberRegex))) {
+        if (directory_num == "" || !directory_num.match(versionNumberRegex)) {
           showConfigResult(input.translation.needToEnterDirectoryVersionNumber, "error");
           return false;
         }

--- a/js/upgrade.js
+++ b/js/upgrade.js
@@ -11,7 +11,7 @@ if (typeof input === 'undefined') {
     ajaxUpgradeTabExists: true,
     currentIndex: 'page.php',
     tab: input.tab,
-    versionNumberRegex: '^(1\\.(6|7)\\.(\\d)\\.(\\d+)$)|^(8\\.(\\d).(\\d)$)',
+    versionNumberRegex: /^(1\\.(6|7)\\.(\\d)\\.(\\d+)$)|^(8\\.(\\d).(\\d)$)/,
     channel: 'major',
     translation: {
       confirmDeleteBackup: "Are you sure you want to delete this backup?",

--- a/js/upgrade.js
+++ b/js/upgrade.js
@@ -11,6 +11,7 @@ if (typeof input === 'undefined') {
     ajaxUpgradeTabExists: true,
     currentIndex: 'page.php',
     tab: input.tab,
+    versionNumberRegex: '^(1\\.(6|7)\\.(\\d)\\.(\\d+)$)|^(8\\.(\\d).(\\d)$)',
     channel: 'major',
     translation: {
       confirmDeleteBackup: "Are you sure you want to delete this backup?",
@@ -47,7 +48,7 @@ if (typeof input === 'undefined') {
       linkAndMd5CannotBeEmpty: "Link and MD5 hash cannot be empty",
       needToEnterArchiveVersionNumber: "You need to enter the version number associated with the archive.",
       noArchiveSelected: "No archive has been selected.",
-      needToEnterDirectoryVersionNumber: "You need to enter the version number associated with the directory.",
+      needToEnterDirectoryVersionNumber: "You must enter the full version number of the version you want to upgrade. The full version number can be present in the zip name (ex: 1.7.8.1, 8.0.0).",
       confirmSkipBackup: "Please confirm that you want to skip the backup.",
       confirmPreserveFileOptions: "Please confirm that you want to preserve file options.",
       lessOptions: "Less options",
@@ -801,7 +802,7 @@ $(document).ready(function() {
         var archive_prestashop = $("select[name=archive_prestashop]").val();
         var archive_num = $("input[name=archive_num]").val();
         var archive_xml = $("select[name=archive_xml]").val();
-        if (archive_num == "") {
+        if (archive_num == "" || !archive_num.match(input.versionNumberRegex)) {
           showConfigResult(input.translation.needToEnterArchiveVersionNumber, "error");
           return false;
         }
@@ -816,8 +817,8 @@ $(document).ready(function() {
       } else if ($newChannel === "directory") {
         params.channel = "directory";
         params.directory_prestashop = $("select[name=directory_prestashop] option:selected").val();
-        var directory_num = $("input[name=directory_num]").val();
-        if (directory_num == "" || directory_num.indexOf(".") == -1) {
+        let directory_num = $("input[name=directory_num]").val();
+        if (directory_num == "" || !directory_num.match(input.versionNumberRegex)) {
           showConfigResult(input.translation.needToEnterDirectoryVersionNumber, "error");
           return false;
         }

--- a/js/upgrade.js
+++ b/js/upgrade.js
@@ -11,7 +11,6 @@ if (typeof input === 'undefined') {
     ajaxUpgradeTabExists: true,
     currentIndex: 'page.php',
     tab: input.tab,
-    versionNumberRegex: /^(1\\.(6|7)\\.(\\d)\\.(\\d+)$)|^(8\\.(\\d).(\\d)$)/,
     channel: 'major',
     translation: {
       confirmDeleteBackup: "Are you sure you want to delete this backup?",
@@ -669,7 +668,7 @@ $(document).ready(function() {
           $("#changedList").toggle();
         });
 
-        $(".toggleSublist").die().live("click", function(e) {
+        $('body').on().on("click", '.toggleSublist', function(e) {
           e.preventDefault();
           $(this).parent().next().toggle();
         });
@@ -727,7 +726,7 @@ $(document).ready(function() {
           $("#diffList").toggle();
         });
 
-        $(".toggleSublist").die().live("click", function(e) {
+        $('body').on().on("click", '.toggleSublist', function(e) {
           e.preventDefault();
           // this=a, parent=h3, next=ul
           $(this).parent().next().toggle();
@@ -767,10 +766,13 @@ $("input[name=btn_adv]").click(function(e) {
 });
 
 $(document).ready(function() {
-  $("input[name|=submitConf]").bind("click", function(e) {
+  $("input[name|=submitConf], input[name=submitConf-channel]").bind("click", function(e) {
+
     var params = {};
     var $newChannel = $("select[name=channel] option:selected").val();
     var $oldChannel = $("select[name=channel] option.current").val();
+    var versionNumberRegex = /^(1\\.(6|7)\\.(\\d)\\.(\\d+)$)|^(8\\.(\\d).(\\d)$)/;
+
     $oldChannel = "";
 
     if ($oldChannel != $newChannel) {
@@ -802,7 +804,7 @@ $(document).ready(function() {
         var archive_prestashop = $("select[name=archive_prestashop]").val();
         var archive_num = $("input[name=archive_num]").val();
         var archive_xml = $("select[name=archive_xml]").val();
-        if (archive_num == "" || !archive_num.match(input.versionNumberRegex)) {
+        if (archive_num == "" || !archive_num.match(versionNumberRegex)) {
           showConfigResult(input.translation.needToEnterArchiveVersionNumber, "error");
           return false;
         }
@@ -818,7 +820,7 @@ $(document).ready(function() {
         params.channel = "directory";
         params.directory_prestashop = $("select[name=directory_prestashop] option:selected").val();
         let directory_num = $("input[name=directory_num]").val();
-        if (directory_num == "" || !directory_num.match(input.versionNumberRegex)) {
+        if (directory_num == "" || !directory_num.match(versionNumberRegex)) {
           showConfigResult(input.translation.needToEnterDirectoryVersionNumber, "error");
           return false;
         }

--- a/js/upgrade.js
+++ b/js/upgrade.js
@@ -45,9 +45,9 @@ if (typeof input === 'undefined') {
       mailFiles: "Mail file(s)",
       translationFiles: "Translation file(s)",
       linkAndMd5CannotBeEmpty: "Link and MD5 hash cannot be empty",
-      needToEnterArchiveVersionNumber: "You need to enter the version number associated with the archive.",
+      needToEnterArchiveVersionNumber: "You must enter the full version number of the version you want to upgrade. The full version number can be present in the zip name (ex: 1.7.8.1, 8.0.0).",
       noArchiveSelected: "No archive has been selected.",
-      needToEnterDirectoryVersionNumber: "You must enter the full version number of the version you want to upgrade. The full version number can be present in the zip name (ex: 1.7.8.1, 8.0.0).",
+      needToEnterDirectoryVersionNumber: "You need to enter the version number associated with the directory.",
       confirmSkipBackup: "Please confirm that you want to skip the backup.",
       confirmPreserveFileOptions: "Please confirm that you want to preserve file options.",
       lessOptions: "Less options",
@@ -771,7 +771,7 @@ $(document).ready(function() {
     var params = {};
     var $newChannel = $("select[name=channel] option:selected").val();
     var $oldChannel = $("select[name=channel] option.current").val();
-    var versionNumberRegex = /^(1\\.(6|7)\\.(\\d)\\.(\\d+)$)|^(8\\.(\\d).(\\d)$)/;
+    var versionNumberRegex = /^8\.\d+\.\d+$|^1\.(6|7)\.\d+\.\d+$/;
 
     $oldChannel = "";
 

--- a/js/upgrade.js
+++ b/js/upgrade.js
@@ -804,7 +804,7 @@ $(document).ready(function() {
         var archive_prestashop = $("select[name=archive_prestashop]").val();
         var archive_num = $("input[name=archive_num]").val();
         var archive_xml = $("select[name=archive_xml]").val();
-        if (archive_num == "" || (archive_num !== undefined && !archive_num.match(versionNumberRegex))) {
+        if (archive_num !== undefined && (archive_num == "" || !archive_num.match(versionNumberRegex))) {
           showConfigResult(input.translation.needToEnterArchiveVersionNumber, "error");
           return false;
         }
@@ -820,7 +820,7 @@ $(document).ready(function() {
         params.channel = "directory";
         params.directory_prestashop = $("select[name=directory_prestashop] option:selected").val();
         let directory_num = $("input[name=directory_num]").val();
-        if (directory_num == "" || (directory_num !== undefined && !directory_num.match(versionNumberRegex))) {
+        if (directory_num !== undefined && (directory_num == "" || !directory_num.match(versionNumberRegex))) {
           showConfigResult(input.translation.needToEnterDirectoryVersionNumber, "error");
           return false;
         }


### PR DESCRIPTION
This PR fixes CoreUpgrader file

If you want to update to version 8.0, the core upgrader uses the CoreUpgrader17 instead of CoreUpgrader8.

(the selected core upgrader depends on the targeted version and not from the source version) 

Fixes https://github.com/PrestaShop/PrestaShop/issues/29248

## HOW TO TEST:

1/ In the autoupgrade form, choose upgrade via local archive
2/ In the field for the upgrade version, you should only be able to enter versions with a patch precision, example:

- 1.7.7.8
- 8.0.0
- 1.6.1.24

Examples of wrong versions (you will get an error message):

- 1.7.2
- 8.0
- 8.0.0.0

(Notice how for PS 8 and above, the version is made of 3 numbers, while it's 4 numbers for older versions)