### PR TITLE
Disable non native modules on PS8.0 and onward

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        presta-versions: ['1.6.1.18', '1.7.2.5', '1.7.3.4', '1.7.4.4', '1.7.5.1', '1.7.6', '1.7.7', '1.7.8', 'latest']
+        presta-versions: ['1.6.1.18', '1.7.2.5', '1.7.3.4', '1.7.4.4', '1.7.5.1', '1.7.6', '1.7.7', '1.7.8', 'latest', '8.0-beta.1']
     steps:
       - name: Checkout
         uses: actions/checkout@v2.0.0

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        presta-versions: ['1.6.1.18', '1.7.2.5', '1.7.3.4', '1.7.4.4', '1.7.5.1', '1.7.6', '1.7.7', '1.7.8', 'latest', '8.0-beta.1']
+        presta-versions: ['1.6.1.18', '1.7.2.5', '1.7.3.4', '1.7.4.4', '1.7.5.1', '1.7.6', '1.7.7', '1.7.8', 'latest', '8.0.0-beta.1']
     steps:
       - name: Checkout
         uses: actions/checkout@v2.0.0

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
@@ -29,11 +29,10 @@ declare(strict_types=1);
 namespace PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader;
 
 use PrestaShop\Module\AutoUpgrade\UpgradeException;
+use PrestaShop\PrestaShop\Adapter\Module\Repository\ModuleRepository;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Domain\MailTemplate\Command\GenerateThemeMailTemplatesCommand;
-use PrestaShop\PrestaShop\Core\Domain\Module\Command\BulkToggleModuleStatusCommand;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
-use PrestaShop\PrestaShop\Adapter\Module\Repository\ModuleRepository;
 
 class CoreUpgrader80 extends CoreUpgrader
 {

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
@@ -33,6 +33,7 @@ use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Domain\MailTemplate\Command\GenerateThemeMailTemplatesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Module\Command\BulkToggleModuleStatusCommand;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
+use PrestaShop\PrestaShop\Adapter\Module\Repository\ModuleRepository;
 
 class CoreUpgrader80 extends CoreUpgrader
 {
@@ -102,23 +103,9 @@ class CoreUpgrader80 extends CoreUpgrader
         // TODO: Update AdminTranslationsController::addNewTabs to install tabs translated
     }
 
-    /**
-     * Ask the core to disable the modules not coming from PrestaShop.
-     */
     protected function disableCustomModules()
     {
-        try {
-            $bulkToggleModuleStatusCommand = new BulkToggleModuleStatusCommand(
-                $this->container->getModuleAdapter()->getModuleRepository()->getNonNativeModules(),
-                false
-            );
-
-            /** @var CommandBusInterface $commandBus */
-            $commandBus = $this->container->getModuleAdapter()->getCommandBus();
-
-            $commandBus->handle($bulkToggleModuleStatusCommand);
-        } catch (\Exception $e) {
-            throw new UpgradeException($e->getMessage());
-        }
+        $moduleRepository = new ModuleRepository(_PS_ROOT_DIR_, _PS_MODULE_DIR_);
+        $this->container->getModuleAdapter()->disableNonNativeModules80($this->pathToUpgradeScripts, $moduleRepository);
     }
 }

--- a/classes/UpgradeTools/ModuleAdapter.php
+++ b/classes/UpgradeTools/ModuleAdapter.php
@@ -102,21 +102,6 @@ class ModuleAdapter
     }
 
     /**
-     * Available since PrestaShop 8.0
-     */
-    public function getModuleRepository()
-    {
-        if (null === $this->moduleRepository) {
-            $this->moduleRepository = $this->symfonyAdapter
-                ->initAppKernel()
-                ->getContainer()
-                ->get('prestashop.adapter.module.repository.module_repository');
-        }
-
-        return $this->moduleRepository;
-    }
-
-    /**
      * Upgrade action, disabling all modules not made by PrestaShop.
      *
      * It seems the 1.6 version of is the safest, as it does not actually load the modules.

--- a/classes/UpgradeTools/ModuleAdapter.php
+++ b/classes/UpgradeTools/ModuleAdapter.php
@@ -129,6 +129,12 @@ class ModuleAdapter
         deactivate_custom_modules();
     }
 
+    public function disableNonNativeModules80($pathToUpgradeScripts, $moduleRepository)
+    {
+        require_once $pathToUpgradeScripts . 'php/deactivate_custom_modules.php';
+        deactivate_custom_modules80($moduleRepository);
+    }
+
     /**
      * list modules to upgrade and save them in a serialized array in $this->toUpgradeModuleList.
      *

--- a/classes/UpgradeTools/ModuleAdapter.php
+++ b/classes/UpgradeTools/ModuleAdapter.php
@@ -54,8 +54,6 @@ class ModuleAdapter
 
     private $commandBus;
 
-    private $moduleRepository;
-
     public function __construct($db, $translator, $modulesPath, $tempPath, $upgradeVersion, ZipAction $zipAction, SymfonyAdapter $symfonyAdapter)
     {
         $this->db = $db;

--- a/classes/UpgradeTools/ModuleAdapter.php
+++ b/classes/UpgradeTools/ModuleAdapter.php
@@ -54,6 +54,8 @@ class ModuleAdapter
 
     private $commandBus;
 
+    private $moduleRepository;
+
     public function __construct($db, $translator, $modulesPath, $tempPath, $upgradeVersion, ZipAction $zipAction, SymfonyAdapter $symfonyAdapter)
     {
         $this->db = $db;
@@ -97,6 +99,21 @@ class ModuleAdapter
         }
 
         return $this->commandBus;
+    }
+
+    /**
+     * Available since PrestaShop 8.0
+     */
+    public function getModuleRepository()
+    {
+        if (null === $this->moduleRepository) {
+            $this->moduleRepository = $this->symfonyAdapter
+                ->initAppKernel()
+                ->getContainer()
+                ->get('prestashop.adapter.module.repository.module_repository');
+        }
+
+        return $this->moduleRepository;
     }
 
     /**

--- a/tests/phpstan/phpstan-1.6.1.18.neon
+++ b/tests/phpstan/phpstan-1.6.1.18.neon
@@ -19,7 +19,6 @@ parameters:
 		- '#Call to method assign\(\) on an unknown class Smarty.#'
 		- '#Call to method fetch\(\) on an unknown class Smarty.#'
 		- '#Call to method getContainer\(\) on an unknown class AppKernel.#'
-		- '#Function deactivate_custom_modules not found.#'
 		- '#PrestaShop\\PrestaShop\\Adapter\\Module\\ModuleDataUpdater#'
 		- '#Property ModuleCore::\$version \(float\) does not accept string.#'
 		- '#Return typehint of method PrestaShop\\Module\\AutoUpgrade\\UpgradeTools\\ModuleAdapter::getCommandBus\(\) has invalid type PrestaShop\\PrestaShop\\Core\\CommandBus\\TacticianCommandBusAdapter.#'

--- a/tests/phpstan/phpstan-1.7.2.5.neon
+++ b/tests/phpstan/phpstan-1.7.2.5.neon
@@ -15,7 +15,6 @@ parameters:
 		- '#Call to method loadClassCache\(\) on an unknown class AppKernel.#'
 		- '#Caught class PrestaShop\\PrestaShop\\Core\\Exception\\CoreException not found.#'
 		- '#Class AppKernel not found.#'
-		- '#Function deactivate_custom_modules not found.#'
 		- '#Instantiated class AppKernel not found.#'
 		- '#Instantiated class PrestaShop\\PrestaShop\\Core\\Domain\\Theme\\ValueObject\\ThemeName not found.#'
 		- '#PHPDoc tag @var for variable \$commandBus contains unknown class PrestaShop\\PrestaShop\\Core\\CommandBus\\CommandBusInterface.#'

--- a/tests/phpstan/phpstan-1.7.3.4.neon
+++ b/tests/phpstan/phpstan-1.7.3.4.neon
@@ -15,7 +15,6 @@ parameters:
 		- '#Call to method loadClassCache\(\) on an unknown class AppKernel.#'
 		- '#Caught class PrestaShop\\PrestaShop\\Core\\Exception\\CoreException not found.#'
 		- '#Class AppKernel not found.#'
-		- '#Function deactivate_custom_modules not found.#'
 		- '#Instantiated class AppKernel not found.#'
 		- '#Instantiated class PrestaShop\\PrestaShop\\Core\\Domain\\Theme\\ValueObject\\ThemeName not found.#'
 		- '#PHPDoc tag @var for variable \$commandBus contains unknown class PrestaShop\\PrestaShop\\Core\\CommandBus\\CommandBusInterface.#'

--- a/tests/phpstan/phpstan-1.7.4.4.neon
+++ b/tests/phpstan/phpstan-1.7.4.4.neon
@@ -11,7 +11,6 @@ parameters:
 		- '#Call to method getMessage\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Exception\\CoreException.#'
 		- '#Call to method handle\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\CommandBus\\CommandBusInterface.#'
 		- '#Caught class PrestaShop\\PrestaShop\\Core\\Exception\\CoreException not found.#'
-		- '#Function deactivate_custom_modules not found.#'
 		- '#Instantiated class PrestaShop\\PrestaShop\\Core\\Domain\\Theme\\ValueObject\\ThemeName not found.#'
 		- '#PHPDoc tag @var for variable \$commandBus contains unknown class PrestaShop\\PrestaShop\\Core\\CommandBus\\CommandBusInterface.#'
 		- '#Property ModuleCore::\$version \(float\) does not accept string.#'

--- a/tests/phpstan/phpstan-1.7.5.1.neon
+++ b/tests/phpstan/phpstan-1.7.5.1.neon
@@ -8,6 +8,5 @@ parameters:
 		- '#Access to an undefined property Autoupgrade::\$bootstrap.#'
 		- '#Access to an undefined property Module::\$installed.#'
 		- '#Call to an undefined static method ConfigurationTest::test_memory_limit\(\).#'
-		- '#Function deactivate_custom_modules not found.#'
 		- '#Instantiated class PrestaShop\\PrestaShop\\Core\\Domain\\Theme\\ValueObject\\ThemeName not found.#'
 		- '#Property ModuleCore::\$version \(float\) does not accept string.#'

--- a/tests/phpstan/phpstan-1.7.6.neon
+++ b/tests/phpstan/phpstan-1.7.6.neon
@@ -9,7 +9,6 @@ parameters:
 		- '#Access to an undefined property Module::\$installed.#'
 		- '#Call to an undefined static method ConfigurationTest::test_memory_limit\(\).#'
 		- '#Call to method fetchLocale\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Cldr\\Update.#'
-		- '#Function deactivate_custom_modules not found.#'
 		- '#Instantiated class PrestaShop\\PrestaShop\\Core\\Cldr\\Update not found.#'
 		- '#Parameter \#1 \$id_hook of method ModuleCore::updatePosition\(\) expects bool, int given.#'
 		- '#Property ModuleCore::\$version \(float\) does not accept string.#'

--- a/tests/phpstan/phpstan-1.7.7.neon
+++ b/tests/phpstan/phpstan-1.7.7.neon
@@ -7,6 +7,4 @@ parameters:
 	ignoreErrors:
 		- '#Access to an undefined property Module::\$installed.#'
 		- '#Call to method fetchLocale\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Cldr\\Update.#'
-		- '#Function deactivate_custom_modules not found.#'
-		- '#Function deactivate_custom_modules80 not found.#'
 		- '#Instantiated class PrestaShop\\PrestaShop\\Core\\Cldr\\Update not found.#'

--- a/tests/phpstan/phpstan-1.7.7.neon
+++ b/tests/phpstan/phpstan-1.7.7.neon
@@ -8,4 +8,5 @@ parameters:
 		- '#Access to an undefined property Module::\$installed.#'
 		- '#Call to method fetchLocale\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Cldr\\Update.#'
 		- '#Function deactivate_custom_modules not found.#'
+		- '#Function deactivate_custom_modules80 not found.#'
 		- '#Instantiated class PrestaShop\\PrestaShop\\Core\\Cldr\\Update not found.#'

--- a/tests/phpstan/phpstan-1.7.8.neon
+++ b/tests/phpstan/phpstan-1.7.8.neon
@@ -7,6 +7,5 @@ parameters:
 	ignoreErrors:
 		- '#Access to an undefined property Module::\$installed.#'
 		- '#Call to method fetchLocale\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Cldr\\Update.#'
-		- '#Function deactivate_custom_modules not found.#'
 		- '#Instantiated class PrestaShop\\PrestaShop\\Core\\Cldr\\Update not found.#'
 

--- a/tests/phpstan/phpstan-8.0-beta.1.neon
+++ b/tests/phpstan/phpstan-8.0-beta.1.neon
@@ -1,8 +1,0 @@
-includes:
-	- %currentWorkingDirectory%/tests/phpstan/phpstan.neon
-
-parameters:
-	ignoreErrors:
-		- '#Access to an undefined property Module::\$installed.#'
-		- '#Call to method fetchLocale\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Cldr\\Update.#'
-		- '#Instantiated class PrestaShop\\PrestaShop\\Core\\Cldr\\Update not found.#'

--- a/tests/phpstan/phpstan-8.0-beta.1.neon
+++ b/tests/phpstan/phpstan-8.0-beta.1.neon
@@ -1,0 +1,8 @@
+includes:
+	- %currentWorkingDirectory%/tests/phpstan/phpstan.neon
+
+parameters:
+	ignoreErrors:
+		- '#Access to an undefined property Module::\$installed.#'
+		- '#Call to method fetchLocale\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Cldr\\Update.#'
+		- '#Instantiated class PrestaShop\\PrestaShop\\Core\\Cldr\\Update not found.#'

--- a/tests/phpstan/phpstan-8.0.0-beta.1.neon
+++ b/tests/phpstan/phpstan-8.0.0-beta.1.neon
@@ -1,0 +1,8 @@
+includes:
+	- %currentWorkingDirectory%/tests/phpstan/phpstan.neon
+
+parameters:
+	excludes_analyse:
+		- ./../../classes/UpgradeTools/CoreUpgrader/CoreUpgrader17.php
+		- ./../../classes/Twig/TransFilterExtension.php
+		- ./../../classes/UpgradeContainer.php

--- a/tests/phpstan/phpstan-latest.neon
+++ b/tests/phpstan/phpstan-latest.neon
@@ -2,8 +2,8 @@ includes:
 	- %currentWorkingDirectory%/tests/phpstan/phpstan.neon
 
 parameters:
-    excludes_analyse:
-        - ./../../classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
+	excludes_analyse:
+		- ./../../classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
 	ignoreErrors:
 		- '#Access to an undefined property Module::\$installed.#'
 		- '#Call to method fetchLocale\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Cldr\\Update.#'

--- a/tests/phpstan/phpstan-latest.neon
+++ b/tests/phpstan/phpstan-latest.neon
@@ -2,6 +2,8 @@ includes:
 	- %currentWorkingDirectory%/tests/phpstan/phpstan.neon
 
 parameters:
+    excludes_analyse:
+        - ./../../classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
 	ignoreErrors:
 		- '#Access to an undefined property Module::\$installed.#'
 		- '#Call to method fetchLocale\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Cldr\\Update.#'

--- a/tests/phpstan/phpstan-latest.neon
+++ b/tests/phpstan/phpstan-latest.neon
@@ -7,5 +7,4 @@ parameters:
 	ignoreErrors:
 		- '#Access to an undefined property Module::\$installed.#'
 		- '#Call to method fetchLocale\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Cldr\\Update.#'
-		- '#Function deactivate_custom_modules not found.#'
 		- '#Instantiated class PrestaShop\\PrestaShop\\Core\\Cldr\\Update not found.#'

--- a/tests/phpstan/phpstan.neon
+++ b/tests/phpstan/phpstan.neon
@@ -4,6 +4,7 @@ parameters:
 	paths:
 		# From PHPStan 0.12, paths to check are relative to the neon file
 		- ./../../classes
+		- ./../../upgrade/php/deactivate_custom_modules.php
 		- ./../../AdminSelfUpgrade.php
 		- ./../../ajax-upgradetab.php
 		- ./../../ajax-upgradetabconfig.php

--- a/upgrade/php/deactivate_custom_modules.php
+++ b/upgrade/php/deactivate_custom_modules.php
@@ -128,6 +128,7 @@ function deactivate_custom_modules80($moduleRepository)
     return $return;
 }
 
-function add_quotes($str) {
+function add_quotes($str)
+{
     return sprintf("'%s'", $str);
 }

--- a/upgrade/php/deactivate_custom_modules.php
+++ b/upgrade/php/deactivate_custom_modules.php
@@ -51,7 +51,7 @@ function deactivate_custom_modules()
         $nativeModules = $nativeModules->modules;
     }
     $arrNativeModules = [];
-    if (is_array($nativeModules)) {
+    if (!empty($nativeModules)) {
         foreach ($nativeModules as $nativeModulesType) {
             if (in_array($nativeModulesType['type'], ['native', 'partner'])) {
                 $arrNativeModules[] = '""';

--- a/upgrade/php/deactivate_custom_modules.php
+++ b/upgrade/php/deactivate_custom_modules.php
@@ -95,3 +95,39 @@ function deactivate_custom_modules()
 
     return $return;
 }
+
+function deactivate_custom_modules80($moduleRepository)
+{
+    $nonNativeModulesList = $moduleRepository->getNonNativeModules();
+
+    $return = Db::getInstance()->execute(
+        'UPDATE `' . _DB_PREFIX_ . 'module` SET `active` = 0 WHERE `name` IN (' . implode(',', array_map('add_quotes', $nonNativeModulesList)) . ')'
+    );
+
+    $nonNativeModules = \Db::getInstance()->executeS('
+        SELECT *
+        FROM `' . _DB_PREFIX_ . 'module` m
+        WHERE name IN (' . implode(',', array_map('add_quotes', $nonNativeModulesList)) . ') ');
+
+    if (!is_array($nonNativeModules) || empty($nonNativeModules)) {
+        return $return;
+    }
+
+    $toBeUninstalled = [];
+    foreach ($nonNativeModules as $k => $aModule) {
+        $toBeUninstalled[] = (int) $aModule['id_module'];
+    }
+
+    if (empty($toBeUninstalled)) {
+        return $return;
+    }
+
+    $sql = 'DELETE FROM `' . _DB_PREFIX_ . 'module_shop` WHERE `id_module` IN (' . implode(',', array_map('add_quotes', $toBeUninstalled)) . ') ';
+    $return &= Db::getInstance()->execute($sql);
+
+    return $return;
+}
+
+function add_quotes($str) {
+    return sprintf("'%s'", $str);
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | when upgrading to PS8.0 or later, we want non native modules to be disabled
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes [#25649](https://github.com/PrestaShop/PrestaShop/issues/25649)
| How to test?      | 1/ Install a non native module (for example a prestashop example module) <br> 2/ Install autoupgrade module from this PR <br> 3/ Remove problematic modules (welcome mbo metrics facebook psxmarketingwithgoogle) <br> 4/ Make a release from prestashop 8.0.x [with this PR](https://github.com/PrestaShop/PrestaShop/pull/29469) <br> 4/Upgrade your  shop via local archive with your generated release <br> 5/ After upgrade, your non native module should be disabled and you should be able to navigate the BO
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
