### PR TITLE
add sql queries for removing tabs

### DIFF
--- a/upgrade/sql/8.0.0.sql
+++ b/upgrade/sql/8.0.0.sql
@@ -5,9 +5,13 @@ DROP TABLE IF EXISTS `PREFIX_referrer`;
 DROP TABLE IF EXISTS `PREFIX_referrer_cache`;
 DROP TABLE IF EXISTS `PREFIX_referrer_shop`;
 
-/* Remove page Referrers */
+/* Remove page Referrers, theme catalog and module catalog */
 ## Remove Tabs
 DELETE FROM `PREFIX_tab` WHERE `class_name` = 'AdminReferrers';
+DELETE FROM `PREFIX_tab` WHERE `class_name` = 'AdminThemesCatalog';
+DELETE FROM `PREFIX_tab` WHERE `class_name` = 'AdminModulesCatalog';
+DELETE FROM `PREFIX_tab` WHERE `class_name` = 'AdminAddonsCatalog';
+DELETE FROM `PREFIX_tab` WHERE `class_name` = 'AdminParentModulesCatalog';
 DELETE FROM `PREFIX_tab_lang` WHERE `id_tab` NOT IN (SELECT id_tab FROM `PREFIX_tab`);
 ## Remove Roles
 DELETE FROM `PREFIX_access` WHERE `id_tab` NOT IN (SELECT id_tab FROM `PREFIX_tab`);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Theme and module catalog tab links have been removed in 8.0.0, autoupgrade should take that into account
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes [#29394](https://github.com/PrestaShop/PrestaShop/issues/29394)
| How to test?      | See how to test in issue [#29394](https://github.com/PrestaShop/PrestaShop/issues/29394)
| Possible impacts? | 
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
