### PR TITLE
Add method to recursively remove tabs, and use it for PS8 upgrade

### DIFF
--- a/upgrade/php/ps_remove_controller_tab.php
+++ b/upgrade/php/ps_remove_controller_tab.php
@@ -19,7 +19,7 @@ function ps_remove_controller_tab($className, $quickAccessUrls = [])
     // delete tabs fetched by the recursive function
     Db::getInstance()->execute(
         sprintf(
-            "DELETE FROM %stab WHERE id_tab IN (%s)",
+            'DELETE FROM %stab WHERE id_tab IN (%s)',
             _DB_PREFIX_,
             implode(', ', $tabsToBeDeleted)
         )
@@ -28,14 +28,15 @@ function ps_remove_controller_tab($className, $quickAccessUrls = [])
     // delete orphan tab langs
     Db::getInstance()->execute(
         sprintf(
-            "DELETE FROM `%stab_lang` WHERE `id_tab` NOT IN (SELECT id_tab FROM `%s_tab`)",
+            'DELETE FROM `%stab_lang` WHERE `id_tab` NOT IN (SELECT id_tab FROM `%s_tab`)',
             _DB_PREFIX_,
             _DB_PREFIX_
         )
     );
 
     // delete orphan legacy quick access links
-    $sqlLegacyQuickAccessLinkDeletion = sprintf("DELETE FROM `%squick_access_lang`
+    $sqlLegacyQuickAccessLinkDeletion = sprintf(
+        "DELETE FROM `%squick_access_lang`
         WHERE id_quick_access IN (SELECT id_quick_access FROM `%squick_access` WHERE link LIKE '%%controller=%s%%')",
         _DB_PREFIX_,
         _DB_PREFIX_,
@@ -65,7 +66,6 @@ function ps_remove_controller_tab($className, $quickAccessUrls = [])
         );
     }
 
-
     // delete orphan roles
     $sqlRoleDeletion = sprintf('DELETE FROM %sauthorization_role WHERE ', _DB_PREFIX_);
     foreach ($rolesToBeDeleted as $key => $role) {
@@ -82,7 +82,7 @@ function getElementsToBeDeleted($idTab, $idParent, $className, &$tabsToBeDeleted
 {
     // add current tab to tabs that will be deleted
     $tabsToBeDeleted[] = $idTab;
-    $rolesToBeDeleted[] = sprintf('ROLE_MOD_TAB_%s%%', strToUpper($className));
+    $rolesToBeDeleted[] = sprintf('ROLE_MOD_TAB_%s%%', strtoupper($className));
     if (empty($idParent)) {
         return;
     }
@@ -90,7 +90,7 @@ function getElementsToBeDeleted($idTab, $idParent, $className, &$tabsToBeDeleted
     // check if parent has any other children
     $sibling = Db::getInstance()->getRow(
         sprintf(
-            "SELECT id_tab FROM %stab WHERE id_parent = " . $idParent . " AND id_tab NOT IN (%s)",
+            'SELECT id_tab FROM %stab WHERE id_parent = ' . $idParent . ' AND id_tab NOT IN (%s)',
             _DB_PREFIX_,
             implode(', ', $tabsToBeDeleted)
         )
@@ -103,12 +103,12 @@ function getElementsToBeDeleted($idTab, $idParent, $className, &$tabsToBeDeleted
 
     // no sibling, get parent and repeat the process recursively
     $parentTab = Db::getInstance()->getRow(
-        sprintf("SELECT id_tab, id_parent, class_name FROM %stab WHERE id_tab = %s", _DB_PREFIX_, $idParent)
+        sprintf('SELECT id_tab, id_parent, class_name FROM %stab WHERE id_tab = %s', _DB_PREFIX_, $idParent)
     );
 
     // this is just in case, it should never happen, if a tab has an id_parent, parent should exist
     if (empty($parentTab)) {
-        return ;
+        return;
     }
 
     getElementsToBeDeleted($parentTab['id_tab'], $parentTab['id_parent'], $parentTab['class_name'], $tabsToBeDeleted, $rolesToBeDeleted);

--- a/upgrade/php/ps_remove_controller_tab.php
+++ b/upgrade/php/ps_remove_controller_tab.php
@@ -1,0 +1,115 @@
+<?php
+
+function ps_remove_controller_tab($className, $quickAccessUrls = [])
+{
+    // select given tab
+    $tabsToBeDeleted = [];
+    $rolesToBeDeleted = [];
+    $tabToDelete = Db::getInstance()->getRow(
+        sprintf("SELECT id_tab, id_parent, class_name FROM %stab WHERE class_name = '%s'", _DB_PREFIX_, $className)
+    );
+
+    if (empty($tabToDelete)) {
+        return;
+    }
+
+    // get tabs and roles that should be deleted
+    getElementsToBeDeleted($tabToDelete['id_tab'], $tabToDelete['id_parent'], $className, $tabsToBeDeleted, $rolesToBeDeleted);
+
+    // delete tabs fetched by the recursive function
+    Db::getInstance()->execute(
+        sprintf(
+            "DELETE FROM %stab WHERE id_tab IN (%s)",
+            _DB_PREFIX_,
+            implode(', ', $tabsToBeDeleted)
+        )
+    );
+
+    // delete orphan tab langs
+    Db::getInstance()->execute(
+        sprintf(
+            "DELETE FROM `%stab_lang` WHERE `id_tab` NOT IN (SELECT id_tab FROM `%s_tab`)",
+            _DB_PREFIX_,
+            _DB_PREFIX_
+        )
+    );
+
+    // delete orphan legacy quick access links
+    $sqlLegacyQuickAccessLinkDeletion = sprintf("DELETE FROM `%squick_access_lang`
+        WHERE id_quick_access IN (SELECT id_quick_access FROM `%squick_access` WHERE link LIKE '%%controller=%s%%')",
+        _DB_PREFIX_,
+        _DB_PREFIX_,
+        $className
+    );
+
+    Db::getInstance()->execute($sqlLegacyQuickAccessLinkDeletion);
+    Db::getInstance()->execute(
+        sprintf(
+            "DELETE FROM `%squick_access` WHERE link LIKE '%%controller=%s%%'",
+            _DB_PREFIX_,
+            $className
+        )
+    );
+
+    if (!empty($quickAccessUrls)) {
+        // delete orphan quick access links (given links, for symfony urls)
+        foreach ($quickAccessUrls as &$link) {
+            $link = "'" . $link . "'";
+        }
+        Db::getInstance()->execute(
+            sprintf(
+                'DELETE FROM %squick_access WHERE link IN (%s)',
+                _DB_PREFIX_,
+                implode(', ', $quickAccessUrls)
+            )
+        );
+    }
+
+
+    // delete orphan roles
+    $sqlRoleDeletion = sprintf('DELETE FROM %sauthorization_role WHERE ', _DB_PREFIX_);
+    foreach ($rolesToBeDeleted as $key => $role) {
+        if ($key === 0) {
+            $sqlRoleDeletion .= "slug LIKE '" . $role . "'";
+            continue;
+        }
+        $sqlRoleDeletion .= "OR slug LIKE '" . $role . "'";
+    }
+    Db::getInstance()->execute($sqlRoleDeletion);
+}
+
+function getElementsToBeDeleted($idTab, $idParent, $className, &$tabsToBeDeleted, &$rolesToBeDeleted)
+{
+    // add current tab to tabs that will be deleted
+    $tabsToBeDeleted[] = $idTab;
+    $rolesToBeDeleted[] = sprintf('ROLE_MOD_TAB_%s%%', strToUpper($className));
+    if (empty($idParent)) {
+        return;
+    }
+
+    // check if parent has any other children
+    $sibling = Db::getInstance()->getRow(
+        sprintf(
+            "SELECT id_tab FROM %stab WHERE id_parent = " . $idParent . " AND id_tab NOT IN (%s)",
+            _DB_PREFIX_,
+            implode(', ', $tabsToBeDeleted)
+        )
+    );
+
+    // tab has at least one sibling, we stop here
+    if (!empty($sibling)) {
+        return;
+    }
+
+    // no sibling, get parent and repeat the process recursively
+    $parentTab = Db::getInstance()->getRow(
+        sprintf("SELECT id_tab, id_parent, class_name FROM %stab WHERE id_tab = %s", _DB_PREFIX_, $idParent)
+    );
+
+    // this is just in case, it should never happen, if a tab has an id_parent, parent should exist
+    if (empty($parentTab)) {
+        return ;
+    }
+
+    getElementsToBeDeleted($parentTab['id_tab'], $parentTab['id_parent'], $parentTab['class_name'], $tabsToBeDeleted, $rolesToBeDeleted);
+}

--- a/upgrade/sql/8.0.0.sql
+++ b/upgrade/sql/8.0.0.sql
@@ -7,10 +7,10 @@ DROP TABLE IF EXISTS `PREFIX_referrer_shop`;
 
 /* Remove page Referrers */
 ## Remove Tabs
-DELETE FROM `PREFIX_tab` WHERE `class_name` = 'AdminReferrers';
-DELETE FROM `PREFIX_tab_lang` WHERE `id_tab` NOT IN (SELECT id_tab FROM `PREFIX_tab`);
+/* PHP:ps_remove_controller_tab('AdminModulesCatalog'); */;
+/* PHP:ps_remove_controller_tab('AdminAddonsCatalog'); */;
+/* PHP:ps_remove_controller_tab('AdminReferrers'); */;
 ## Remove Roles
-DELETE FROM `PREFIX_access` WHERE `id_tab` NOT IN (SELECT id_tab FROM `PREFIX_tab`);
 /* For SalesMan profile, remove parent tab `Traffic & SEO` */
 DELETE FROM `PREFIX_access`
   WHERE `id_authorization_role` IN (SELECT `id_authorization_role` FROM `PREFIX_authorization_role` WHERE `slug` LIKE 'ROLE_MOD_TAB_ADMINPARENTMETA_%')
@@ -20,13 +20,6 @@ DELETE FROM `PREFIX_authorization_role`
 ## Remove Configuration
 DELETE FROM `PREFIX_configuration`
   WHERE `name` IN ('PS_REFERRERS_CACHE_LIKE', 'PS_REFERRERS_CACHE_DATE');
-## Remove Quick Access
-DELETE FROM `PREFIX_quick_access_lang`
-  WHERE id_quick_access IN (
-    SELECT id_quick_access FROM `PREFIX_quick_access` WHERE link LIKE '%controller=AdminReferrers%'
-  );
-DELETE FROM `PREFIX_quick_access`
-  WHERE link LIKE '%controller=AdminReferrers%';
 
 INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES
     ('PS_MAIL_DKIM_ENABLE', '0', NOW(), NOW()),

--- a/upgrade/sql/8.0.0.sql
+++ b/upgrade/sql/8.0.0.sql
@@ -7,6 +7,7 @@ DROP TABLE IF EXISTS `PREFIX_referrer_shop`;
 
 /* Remove page Referrers */
 ## Remove Tabs
+/* PHP:ps_remove_controller_tab('AdminThemesCatalog'); */;
 /* PHP:ps_remove_controller_tab('AdminModulesCatalog'); */;
 /* PHP:ps_remove_controller_tab('AdminAddonsCatalog'); */;
 /* PHP:ps_remove_controller_tab('AdminReferrers'); */;
@@ -15,8 +16,6 @@ DROP TABLE IF EXISTS `PREFIX_referrer_shop`;
 DELETE FROM `PREFIX_access`
   WHERE `id_authorization_role` IN (SELECT `id_authorization_role` FROM `PREFIX_authorization_role` WHERE `slug` LIKE 'ROLE_MOD_TAB_ADMINPARENTMETA_%')
   AND `id_profile` = 4;
-DELETE FROM `PREFIX_authorization_role`
-  WHERE `slug` LIKE 'ROLE_MOD_TAB_ADMINREFERRERS_%';
 ## Remove Configuration
 DELETE FROM `PREFIX_configuration`
   WHERE `name` IN ('PS_REFERRERS_CACHE_LIKE', 'PS_REFERRERS_CACHE_DATE');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Theme and module catalog tab links have been removed in 8.0.0, autoupgrade should take that into account
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes [#29394](https://github.com/PrestaShop/PrestaShop/issues/29394)
| How to test?      | See how to test in issue [#29394](https://github.com/PrestaShop/PrestaShop/issues/29394)
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
