### PR TITLE
Removed `US/Pacific New` from timezone list

### DIFF
--- a/upgrade/sql/8.1.0.sql
+++ b/upgrade/sql/8.1.0.sql
@@ -1,0 +1,5 @@
+SET SESSION sql_mode='';
+SET NAMES 'utf8mb4';
+
+UPDATE `PREFIX_configuration` SET `value` = 'US/Pacific' WHERE `name` = 'PS_TIMEZONE' AND `value` = 'US/Pacific-New' LIMIT 1;
+DELETE FROM `PREFIX_timezone` WHERE `name` = 'US/Pacific-New';


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Removed `US/Pacific New` from timezone list
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/PrestaShop#14411
| How to test?      | - Define the configuration value for `PS_TIMEZONE` to `US/Pacific-New`<br/>- Upgrade to version 8.1.0<br/>- The configuration value for `PS_TIMEZONE` should be `US/Pacific`
| Possible impacts? | N/A

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
