### PR TITLE
Set translation theme to null is it was classic

### DIFF
--- a/upgrade/sql/1.7.8.8.sql
+++ b/upgrade/sql/1.7.8.8.sql
@@ -2,3 +2,4 @@ SET SESSION sql_mode='';
 SET NAMES 'utf8';
 
 DELETE FROM `PREFIX_configuration` WHERE `name` = 'PS_SMARTY_CACHING_TYPE';
+UPDATE `PREFIX_translation` set theme = null WHERE `theme` = 'classic';


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Since the translation system changed in 1.7.8, translating the classic theme needs to have the value `null` in the `theme` column in `ps_translation` instead if having `classic`.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/PrestaShop#29164
| How to test?      | Please see PrestaShop/PrestaShop#29164
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
