### PR TITLE
Add domain in all trans calls in twig templates

### DIFF
--- a/views/templates/block/activityLog.twig
+++ b/views/templates/block/activityLog.twig
@@ -1,7 +1,7 @@
 <div class="bootstrap" id="activityLogBlock" style="display:none">
     <div class="panel">
         <div class="panel-heading">
-            {{ 'Activity Log'|trans }}
+            {{ 'Activity Log'|trans({}, 'Modules.Autoupgrade.Admin') }}
         </div>
         <p id="upgradeResultCheck" style="display: none;" class="alert alert-success"></p>
 
@@ -9,15 +9,15 @@
 
         <div class="row">
             <div id="currentlyProcessing" class="col-xs-12" style="display:none;">
-                <h4 id="pleaseWait">{{ 'Currently processing'|trans }} <img class="pleaseWait" src="{{ psBaseUri }}img/loader.gif"/></h4>
-                <div id="infoStep" class="processing">{{ 'Analyzing the situation...'|trans }}</div>
+                <h4 id="pleaseWait">{{ 'Currently processing'|trans({}, 'Modules.Autoupgrade.Admin') }} <img class="pleaseWait" src="{{ psBaseUri }}img/loader.gif"/></h4>
+                <div id="infoStep" class="processing">{{ 'Analyzing the situation...'|trans({}, 'Modules.Autoupgrade.Admin') }}</div>
             </div>
         </div><br>
         <div id="quickInfo" class="clear processing col-xs-12"></div>
         {# this block will show errors and important warnings that happens during upgrade #}
         <div class="row">
             <div id="errorDuringUpgrade" class="col-xs-12" style="display:none;">
-                <h4>{{ 'Errors'|trans }}</h4>
+                <h4>{{ 'Errors'|trans({}, 'Modules.Autoupgrade.Admin') }}</h4>
                 <div id="infoError" class="processing"></div>
             </div>
         </div>

--- a/views/templates/block/channelInfo.twig
+++ b/views/templates/block/channelInfo.twig
@@ -1,7 +1,7 @@
 <div id="channel-infos" ><br>
     {% if upgradeInfo.branch is not empty %}
         <div style="clear:both">
-            <label class="label-small">{{ 'Branch:'|trans }}</label>
+            <label class="label-small">{{ 'Branch:'|trans({}, 'Modules.Autoupgrade.Admin') }}</label>
             <span class="available">
                 <img src="../img/admin/{% if upgradeInfo.available is not empty %}enabled{% else %}disabled{% endif %}.gif">
                 {% if upgradeInfo.available is not empty %}
@@ -21,26 +21,26 @@
         {% endif %}
         {% if upgradeInfo.version_num is not empty %}
             <div style="clear:both;">
-                <label class="label-small">{{ 'Version number:'|trans }}</label>
+                <label class="label-small">{{ 'Version number:'|trans({}, 'Modules.Autoupgrade.Admin') }}</label>
                 <span class="version">{{ upgradeInfo.version_num }}</span>
             </div>
         {% endif %}
         {% if upgradeInfo.link is not empty %}
             <div style="clear:both;">
-                <label class="label-small">{{ 'URL:'|trans }}</label>
+                <label class="label-small">{{ 'URL:'|trans({}, 'Modules.Autoupgrade.Admin') }}</label>
                 <a class="url" href="{{ upgradeInfo.link }}">{{ upgradeInfo.link }}</a>
             </div>
         {% endif %}
         {% if upgradeInfo.md5 is not empty %}
             <div style="clear:both;">
-                <label class="label-small">{{ 'MD5 hash:'|trans }}</label>
+                <label class="label-small">{{ 'MD5 hash:'|trans({}, 'Modules.Autoupgrade.Admin') }}</label>
                 <span class="md5">{{ upgradeInfo.md5 }}</span>
             </div>
         {% endif %}
         {% if upgradeInfo.changelog is not empty %}
             <div style="clear:both;">
-                <label class="label-small">{{ 'Changelog:'|trans }}</label>
-                <a class="changelog" href="{{ upgradeInfo.changelog }}">{{ 'see changelog'|trans }}</a>
+                <label class="label-small">{{ 'Changelog:'|trans({}, 'Modules.Autoupgrade.Admin') }}</label>
+                <a class="changelog" href="{{ upgradeInfo.changelog }}">{{ 'See changelog'|trans({}, 'Modules.Autoupgrade.Admin') }}</a>
             </div>
         {% endif %}
     </div>

--- a/views/templates/block/checklist.twig
+++ b/views/templates/block/checklist.twig
@@ -3,29 +3,29 @@
 <div class="bootstrap" id="currentConfigurationBlock">
     <div class="panel">
         <div class="panel-heading">
-            {{ 'The pre-Upgrade checklist'|trans }}
+            {{ 'The pre-Upgrade checklist'|trans({}, 'Modules.Autoupgrade.Admin') }}
         </div>
         {% if not moduleIsUpToDate %}
             <p class="alert alert-warning">
-                {{ 'Your current version of the module is out of date. Update now'|trans }}
-                <a href=" {{ moduleUpdateLink }} ">{{ 'Modules >  Module Manager > Updates'|trans|raw }}</a>
+                {{ 'Your current version of the module is out of date. Update now'|trans({}, 'Modules.Autoupgrade.Admin') }}
+                <a href=" {{ moduleUpdateLink }} ">{{ 'Modules > Module Manager > Updates'|trans({}, 'Modules.Autoupgrade.Admin') }}</a>
             </p>
         {% endif %}
         {% if showErrorMessage %}
-            <p class="alert alert-warning">{{ 'The checklist is not OK. You can only upgrade your shop once all indicators are green.'|trans }}</p>
+            <p class="alert alert-warning">{{ 'The checklist is not OK. You can only upgrade your shop once all indicators are green.'|trans({}, 'Modules.Autoupgrade.Admin') }}</p>
         {% endif %}
         <div id="currentConfiguration">
-            <p class="alert alert-info">{{ 'Before starting the upgrade process, please make sure this checklist is all green.'|trans }}</p>
+            <p class="alert alert-info">{{ 'Before starting the upgrade process, please make sure this checklist is all green.'|trans({}, 'Modules.Autoupgrade.Admin') }}</p>
             <table class="table" cellpadding="0" cellspacing="0">
                 <tr>
                     <td>
                         {% if not phpUpgradeRequired %}
-                            {{ 'Your server is running on a supported PHP version.'|trans }}
+                            {{ 'Your server is running on a supported PHP version.'|trans({}, 'Modules.Autoupgrade.Admin') }}
                         {% else %}
                             {{ 'The PHP version your server is running on is obsolete and needs to be upgraded. [1]Learn more[/1].'|trans({
                                 '[1]': '<a href="https://devdocs.prestashop.com/1.7/basics/installation/system-requirements/" target="_blank">',
                                 '[/1]': '</a>',
-                            })|raw }}
+                            }, 'Modules.Autoupgrade.Admin')|raw }}
                         {% endif %}
                     </td>
                     <td>
@@ -37,7 +37,7 @@
                     </td>
                 </tr>
                 <tr>
-                    <td>{{ 'Your store\'s root directory (%s) is writable (with appropriate CHMOD permissions).'|trans([rootDirectory]) }}</td>
+                    <td>{{ 'Your store\'s root directory (%s) is writable (with appropriate CHMOD permissions).'|trans([rootDirectory], 'Modules.Autoupgrade.Admin') }}</td>
                     <td>
                         {% if rootDirectoryIsWritable %}
                             {{ icons.ok }}
@@ -48,7 +48,7 @@
                 </tr>
                 {% if adminDirectoryWritableReport %}
                     <tr>
-                        <td>{{ 'The "/admin/autoupgrade" directory is writable (appropriate CHMOD permissions)'|trans|raw }}</td>
+                        <td>{{ 'The "/admin/autoupgrade" directory is writable (appropriate CHMOD permissions)'|trans({}, 'Modules.Autoupgrade.Admin') }}</td>
                         <td>
                             {% if adminDirectoryIsWritable %}
                                 {{ icons.ok }}
@@ -59,7 +59,7 @@
                     </tr>
                 {% endif %}
                 <tr>
-                    <td>{{ 'PHP\'s "Safe mode" option is turned off'|trans|raw }}</td>
+                    <td>{{ 'PHP\'s "Safe mode" option is turned off'|trans({}, 'Modules.Autoupgrade.Admin') }}</td>
                     <td>
                         {% if safeModeIsDisabled %}
                             {{ icons.ok }}
@@ -69,7 +69,7 @@
                     </td>
                 </tr>
                 <tr>
-                    <td>{{ 'PHP\'s "allow_url_fopen" option is turned on, or cURL is installed'|trans|raw }}</td>
+                    <td>{{ 'PHP\'s "allow_url_fopen" option is turned on, or cURL is installed'|trans({}, 'Modules.Autoupgrade.Admin') }}</td>
                     <td>
                         {% if allowUrlFopenOrCurlIsEnabled %}
                             {{ icons.ok }}
@@ -79,7 +79,7 @@
                     </td>
                 </tr>
                 <tr>
-                    <td>{{ 'PHP\'s "zip" extension is enabled'|trans|raw }}</td>
+                    <td>{{ 'PHP\'s "zip" extension is enabled'|trans({}, 'Modules.Autoupgrade.Admin') }}</td>
                     <td>
                         {% if zipIsEnabled %}
                             {{ icons.ok }}
@@ -91,12 +91,12 @@
                 <tr>
                     <td>
                         {% if storeIsInMaintenance %}
-                            {{ 'Your store is in maintenance mode'|trans }}
+                            {{ 'Your store is in maintenance mode'|trans({}, 'Modules.Autoupgrade.Admin') }}
                         {% else %}
                             {{ 'Enable maintenance mode and add your maintenance IP in [1]Shop parameters > General > Maintenance[/1]'|trans({
                               '[1]' : '<a href="' ~ maintenanceLink ~'" target="_blank">',
                               '[/1]' : '</a>',
-                            })|raw }}
+                            }, 'Modules.Autoupgrade.Admin')|raw }}
                         {% endif %}
                     </td>
                     <td>
@@ -108,7 +108,7 @@
                     </td>
                 </tr>
                 <tr>
-                    <td>{{ 'PrestaShop\'s caching features are disabled'|trans }}</td>
+                    <td>{{ 'PrestaShop\'s caching features are disabled'|trans({}, 'Modules.Autoupgrade.Admin') }}</td>
                     <td>
                         {% if cachingIsDisabled %}
                             {{ icons.ok }}
@@ -120,9 +120,9 @@
                 <tr>
                     <td>
                         {% if maxExecutionTime == 0 %}
-                            {{ 'PHP\'s max_execution_time setting has a high value or is disabled entirely (current value: unlimited)'|trans }}
+                            {{ 'PHP\'s max_execution_time setting has a high value or is disabled entirely (current value: unlimited)'|trans({}, 'Modules.Autoupgrade.Admin') }}
                         {% else %}
-                            {{ 'PHP\'s max_execution_time setting has a high value or is disabled entirely (current value: %s seconds)'|trans([maxExecutionTime]) }}
+                            {{ 'PHP\'s max_execution_time setting has a high value or is disabled entirely (current value: %s seconds)'|trans([maxExecutionTime], 'Modules.Autoupgrade.Admin') }}
                         {% endif %}
                     </td>
                     <td>
@@ -135,13 +135,13 @@
                 </tr>
                 {% if not checkPhpVersionCompatibility %}
                   <tr>
-                    <td>{{ 'Your current PHP version isn\'t compatible with your PrestaShop version.'|trans }}</td>
+                    <td>{{ 'Your current PHP version isn\'t compatible with your PrestaShop version.'|trans({}, 'Modules.Autoupgrade.Admin') }}</td>
                     <td>{{ icons.nok }}</td>
                   </tr>
                 {% endif %}
                 {% if not checkApacheModRewrite %}
                   <tr>
-                    <td>{{ 'Apache mod_rewrite is disabled.'|trans }}</td>
+                    <td>{{ 'Apache mod_rewrite is disabled.'|trans({}, 'Modules.Autoupgrade.Admin') }}</td>
                     <td>{{ icons.nok }}</td>
                   </tr>
                 {% endif %}
@@ -149,9 +149,9 @@
                   <tr>
                     <td>
                       {% if notLoadedPhpExtensions|length > 1 %}
-                        {{ 'The following PHP extensions are not installed: %s.'|trans([notLoadedPhpExtensions|join(', ')]) }}
+                        {{ 'The following PHP extensions are not installed: %s.'|trans([notLoadedPhpExtensions|join(', ')], 'Modules.Autoupgrade.Admin') }}
                       {% else %}
-                        {{ 'The following PHP extension is not installed: %s.'|trans([notLoadedPhpExtensions|first]) }}
+                        {{ 'The following PHP extension is not installed: %s.'|trans([notLoadedPhpExtensions|first], 'Modules.Autoupgrade.Admin') }}
                       {% endif %}
                     </td>
                     <td>{{ icons.nok }}</td>
@@ -159,13 +159,13 @@
                 {% endif %}
                 {% if not checkMemoryLimit %}
                 <tr>
-                  <td>{{ 'PHP memory_limit is inferior to 256 MB.'|trans }}</td>
+                  <td>{{ 'PHP memory_limit is inferior to 256 MB.'|trans({}, 'Modules.Autoupgrade.Admin') }}</td>
                   <td>{{ icons.nok }}</td>
                 </tr>
                 {% endif %}
                 {% if not checkFileUploads %}
                 <tr>
-                  <td>{{ 'PHP file_uploads configuration is disabled.'|trans }}</td>
+                  <td>{{ 'PHP file_uploads configuration is disabled.'|trans({}, 'Modules.Autoupgrade.Admin') }}</td>
                   <td>{{ icons.nok }}</td>
                 </tr>
                 {% endif %}
@@ -173,9 +173,9 @@
                   <tr>
                     <td>
                       {% if notExistsPhpFunctions|length > 1 %}
-                        {{ 'The following PHP functions are not installed: %s.'|trans([notExistsPhpFunctions|join(', ')]) }}
+                        {{ 'The following PHP functions are not installed: %s.'|trans([notExistsPhpFunctions|join(', ')], 'Modules.Autoupgrade.Admin') }}
                       {% else %}
-                        {{ 'The following PHP function is not installed: %s.'|trans([notExistsPhpFunctions|first]) }}
+                        {{ 'The following PHP function is not installed: %s.'|trans([notExistsPhpFunctions|first], 'Modules.Autoupgrade.Admin') }}
                       {% endif %}
                     </td>
                     <td>{{ icons.nok }}</td>
@@ -183,14 +183,14 @@
                 {% endif %}
                 {% if not checkPhpSessions %}
                   <tr>
-                    <td>{{ 'It\'s not possible to create a PHP session.'|trans }}</td>
+                    <td>{{ 'It\'s not possible to create a PHP session.'|trans({}, 'Modules.Autoupgrade.Admin') }}</td>
                     <td>{{ icons.nok }}</td>
                   </tr>
                 {% endif %}
                 {% if missingFiles|length > 0 %}
                   <tr>
                     <td>
-                      {{ 'The following files are missing:'|trans }}
+                      {{ 'The following files are missing:'|trans({}, 'Modules.Autoupgrade.Admin') }}
                       <ul>
                         {% for file in missingFiles %}
                         <li>{{ file }}</li>
@@ -203,7 +203,7 @@
                 {% if notWritingDirectories|length > 0 %}
                   <tr>
                     <td>
-                      {{ 'It\'s not possible to write in the following folders:'|trans }}
+                      {{ 'It\'s not possible to write in the following folders:'|trans({}, 'Modules.Autoupgrade.Admin') }}
                       <ul>
                         {% for missingFile in notWritingDirectories %}
                         <li>{{ missingFile }}</li>
@@ -215,9 +215,9 @@
                 {% endif %}
             </table>
             <br>
-            <p class="alert alert-info">{{ 'Please also make sure you make a full manual backup of your files and database.'|trans }}</p>
+            <p class="alert alert-info">{{ 'Please also make sure you make a full manual backup of your files and database.'|trans({}, 'Modules.Autoupgrade.Admin') }}</p>
             {% if showErrorMessage %}
-              <p class="alert alert-danger">{{ 'PrestaShop requirements are not satisfied.'|trans }}</p>
+              <p class="alert alert-danger">{{ 'PrestaShop requirements are not satisfied.'|trans({}, 'Modules.Autoupgrade.Admin') }}</p>
             {% endif %}
         </div>
     </div>

--- a/views/templates/block/rollbackForm.twig
+++ b/views/templates/block/rollbackForm.twig
@@ -1,17 +1,17 @@
 <div class="bootstrap" id="rollbackForm">
     <div class="panel">
         <div class="panel-heading">
-            {{ 'Rollback'|trans }}
+            {{ 'Rollback'|trans({}, 'Modules.Autoupgrade.Admin') }}
         </div>
         <p class="alert alert-info">
-            {{ 'After upgrading your shop, you can rollback to the previous database and files. Use this function if your theme or an essential module is not working correctly.'|trans }}
+            {{ 'After upgrading your shop, you can rollback to the previous database and files. Use this function if your theme or an essential module is not working correctly.'|trans({}, 'Modules.Autoupgrade.Admin') }}
         </p>
 
         <div class="row" id="restoreBackupContainer">
-            <label class="col-lg-3 control-label text-right">{{ 'Choose your backup:'|trans }}</label>
+            <label class="col-lg-3 control-label text-right">{{ 'Choose your backup:'|trans({}, 'Modules.Autoupgrade.Admin') }}</label>
             <div class="col-lg-9">
                 <select name="restoreName">
-                    <option value="0">{{ '-- Choose a backup to restore --'|trans }}</option>';
+                    <option value="0">{{ '-- Choose a backup to restore --'|trans({}, 'Modules.Autoupgrade.Admin') }}</option>';
                     {% if availableBackups is not empty %}
                         {% for backupName in availableBackups %}
                         <option value="{{ backupName }}">{{ backupName }}</option>
@@ -24,7 +24,7 @@
         <br>
         <div class="row">
             <p id="rollbackContainer" class="col-lg-offset-3 col-lg-9">
-                <a disabled="disabled" class="upgradestep button btn btn-primary" href="" id="rollback">{{ 'Rollback'|trans }}</a>
+                <a disabled="disabled" class="upgradestep button btn btn-primary" href="" id="rollback">{{ 'Rollback'|trans({}, 'Modules.Autoupgrade.Admin') }}</a>
             </p>
         </div>
     </div>

--- a/views/templates/block/upgradeButtonBlock.twig
+++ b/views/templates/block/upgradeButtonBlock.twig
@@ -1,64 +1,64 @@
 <div class="bootstrap" id="upgradeButtonBlock">
     <div class="panel">
         <div class="panel-heading">
-            {{ 'Start your Upgrade'|trans }}
+            {{ 'Start your Upgrade'|trans({}, 'Modules.Autoupgrade.Admin') }}
         </div>
         <div class="blocOneClickUpgrade">
             {% if versionCompare > 0 %}
-            <p class="alert alert-warning">{{ 'You come from the future! You are using a more recent version than the latest available!'|trans }}</p>
+            <p class="alert alert-warning">{{ 'You come from the future! You are using a more recent version than the latest available!'|trans({}, 'Modules.Autoupgrade.Admin') }}</p>
             {% elseif versionCompare == 0 %}
-            <p class="alert alert-success">{{ 'Congratulations, you are already using the latest version available!'|trans }}</p>
+            <p class="alert alert-success">{{ 'Congratulations, you are already using the latest version available!'|trans({}, 'Modules.Autoupgrade.Admin') }}</p>
             {% endif %}
             <p>
-                {{ 'Your current PrestaShop version'|trans }}: <strong>{{ currentPsVersion }}</strong>
+                {{ 'Your current PrestaShop version'|trans({}, 'Modules.Autoupgrade.Admin') }}: <strong>{{ currentPsVersion }}</strong>
             </p>
             <p>
-                {{ 'Your current PHP version'|trans }}: <strong>{{ phpVersion }}</strong>
+                {{ 'Your current PHP version'|trans({}, 'Modules.Autoupgrade.Admin') }}: <strong>{{ phpVersion }}</strong>
             </p>
             <p>
-                {{ 'Latest official version for %s channel.'|trans([channel]) }}: <strong>{{ latestChannelVersion }}</strong>
+                {{ 'Latest official version for %s channel.'|trans([channel], 'Modules.Autoupgrade.Admin') }}: <strong>{{ latestChannelVersion }}</strong>
             </p>
         </div>
         <br>
         {% if showUpgradeButton %}
             <div>
-                <a href="#" id="upgradeNow" class="button-autoupgrade upgradestep btn btn-primary">{{ 'Upgrade PrestaShop now!'|trans }}</a>
+                <a href="#" id="upgradeNow" class="button-autoupgrade upgradestep btn btn-primary">{{ 'Upgrade PrestaShop now!'|trans({}, 'Modules.Autoupgrade.Admin') }}</a>
                 {% if showUpgradeLink %}
-                    <small><a href="{{ upgradeLink }}">{{ 'PrestaShop will be downloaded from %s'|trans([upgradeLink]) }}</a></small>
+                    <small><a href="{{ upgradeLink }}">{{ 'PrestaShop will be downloaded from %s'|trans([upgradeLink], 'Modules.Autoupgrade.Admin') }}</a></small>
                     {% if changelogLink is not empty %}
                     <p>
-                        <a href="{{ changelogLink }}" target="_blank" >{{ 'Open changelog in a new window'|trans }}</a>
+                        <a href="{{ changelogLink }}" target="_blank" >{{ 'Open changelog in a new window'|trans({}, 'Modules.Autoupgrade.Admin') }}</a>
                     </p>
                     {% endif %}
                 {% else %}
-                    {{ 'No file will be downloaded (channel %s is used)'|trans([channel]) }}
+                    {{ 'No file will be downloaded (channel %s is used)'|trans([channel], 'Modules.Autoupgrade.Admin') }}
                 {% endif %}
             </div>
             {% if skipActions is not empty %}
                 <div id="skipAction-list" class="alert alert-warning">
-                    <p>{{ 'The following action are automatically replaced'|trans }}</p>
+                    <p>{{ 'The following action are automatically replaced'|trans({}, 'Modules.Autoupgrade.Admin') }}</p>
                     <ul>
                         {% for old, new in skipActions %}
                             <li>
-                                {{ '%old% will be replaced by %new%'|trans({'%old%': old, '%new%': new}) }}
+                                {{ '%old% will be replaced by %new%'|trans({'%old%': old, '%new%': new}, 'Modules.Autoupgrade.Admin') }}
                             </li>
                         {% endfor %}
                     </ul>
-                    <p>{{ 'To change this behavior, you need to manually edit your php files'|trans }}</p>
+                    <p>{{ 'To change this behavior, you need to manually edit your php files'|trans({}, 'Modules.Autoupgrade.Admin') }}</p>
                 </div>
             {% endif %}
         {% endif %}
         <br>
         <p>
             {% if showUpgradeButton %}
-            <a class="button button-autoupgrade btn btn-default" href="index.php?tab=AdminSelfUpgrade&amp;token={{ token }}&amp;refreshCurrentVersion=1">{{ 'Refresh the page'|trans }}</a> -
+            <a class="button button-autoupgrade btn btn-default" href="index.php?tab=AdminSelfUpgrade&amp;token={{ token }}&amp;refreshCurrentVersion=1">{{ 'Refresh the page'|trans({}, 'Modules.Autoupgrade.Admin') }}</a> -
             {% else %}
-            <a class="button button-autoupgrade btn btn-primary" href="index.php?tab=AdminSelfUpgrade&amp;token={{ token }}&amp;refreshCurrentVersion=1">{{ 'Check if a new version is available'|trans }}</a> -
+            <a class="button button-autoupgrade btn btn-primary" href="index.php?tab=AdminSelfUpgrade&amp;token={{ token }}&amp;refreshCurrentVersion=1">{{ 'Check if a new version is available'|trans({}, 'Modules.Autoupgrade.Admin') }}</a> -
             {% endif %}
             <span style="font-style: italic; font-size: 11px;">{% if lastVersionCheck %}
-                {{ 'Last check: %s'|trans([lastVersionCheck|date('Y-m-d H:i:s')]) }}
+                {{ 'Last check: %s'|trans([lastVersionCheck|date('Y-m-d H:i:s')], 'Modules.Autoupgrade.Admin') }}
                 {% else %}
-                {{ 'Last check: never'|trans }}
+                {{ 'Last check: never'|trans({}, 'Modules.Autoupgrade.Admin') }}
                 {% endif %}
             </span>
         </p>
@@ -66,22 +66,22 @@
         <!-- advanced configuration -->
         <div class="row">
             <div class="pull-right">
-                <p><input type="button" class="button btn btn-warning" name="btn_adv" value="{{ 'More options (Expert mode)'|trans }}"/></p>
+                <p><input type="button" class="button btn btn-warning" name="btn_adv" value="{{ 'More options (Expert mode)'|trans({}, 'Modules.Autoupgrade.Admin') }}"/></p>
             </div>
             <div class="col-xs-12">
                 <p class="alert alert-info" style="display:none;" id="configResult">&nbsp;</p>
                 <div id="advanced" style="margin-top: 30px;">
                     <div class="panel-heading">
-                        {{ 'Expert mode'|trans }}
+                        {{ 'Expert mode'|trans({}, 'Modules.Autoupgrade.Admin') }}
                     </div>
-                    <h4 style="margin-top: 0">{{ 'Please select your channel:'|trans }}</h4>
+                    <h4 style="margin-top: 0">{{ 'Please select your channel:'|trans({}, 'Modules.Autoupgrade.Admin') }}</h4>
                     <p>
-                        {{ 'Channels are offering you different ways to perform an upgrade. You can either upload the new version manually or let the 1-Click Upgrade module download it for you.'|trans }}<br>
-                        {{ 'The Alpha, Beta and Private channels give you the ability to upgrade to a non-official or unstable release (for testing purposes only).'|trans }}<br>
-                        {{ 'By default, you should use the "Minor release" channel which is offering the latest stable version available.'|trans|raw }}
+                        {{ 'Channels are offering you different ways to perform an upgrade. You can either upload the new version manually or let the 1-Click Upgrade module download it for you.'|trans({}, 'Modules.Autoupgrade.Admin') }}<br>
+                        {{ 'The Alpha, Beta and Private channels give you the ability to upgrade to a non-official or unstable release (for testing purposes only).'|trans({}, 'Modules.Autoupgrade.Admin') }}<br>
+                        {{ 'By default, you should use the "Minor release" channel which is offering the latest stable version available.'|trans({}, 'Modules.Autoupgrade.Admin') }}
                     </p>
                     <br>
-                    <label for="channel">{{ 'Channel:'|trans }}</label>
+                    <label for="channel">{{ 'Channel:'|trans({}, 'Modules.Autoupgrade.Admin') }}</label>
                     <select name="channel" id="channel">
                         {% for channelOpt in channelOptions %}
                             {% set selected = (channel == channelOpt[1]) %}
@@ -92,34 +92,34 @@
                     </select>
                     {{ channelInfoBlock|raw }}
                     <div id="for-usePrivate">
-                        <p><label for="private_release_link">{{ 'Link:'|trans }} *</label>
+                        <p><label for="private_release_link">{{ 'Link:'|trans({}, 'Modules.Autoupgrade.Admin') }} *</label>
                             <input type="text" size="50" id="private_release_link" name="private_release_link" value="{{ privateChannel.releaseLink }}">
                         </p>
-                        <p><label for="private_release_md5">{{ 'Hash key:'|trans }} *</label>
+                        <p><label for="private_release_md5">{{ 'Hash key:'|trans({}, 'Modules.Autoupgrade.Admin') }} *</label>
                             <input type="text" size="32" id="private_release_md5" name="private_release_md5" value="{{ privateChannel.releaseMd5 }}">
                         </p>
-                        <p><label for="private_allow_major">{{ 'Allow major upgrade:'|trans }}</label>
+                        <p><label for="private_allow_major">{{ 'Allow major upgrade:'|trans({}, 'Modules.Autoupgrade.Admin') }}</label>
                             <input type="checkbox" id="private_allow_major" name="private_allow_major" value="1"{% if privateChannel.allowMajor %} checked{% endif %}>
                         </p>
                     </div>
                     <div id="for-useArchive">
                         {% if archiveFiles is not empty %}
-                            <label for="archive_prestashop">{{ 'Archive to use:'|trans }}</label>
+                            <label for="archive_prestashop">{{ 'Archive to use:'|trans({}, 'Modules.Autoupgrade.Admin') }}</label>
                             <div>
                                 <select id="archive_prestashop" name="archive_prestashop">
-                                    <option value="">{{ 'Choose an archive'|trans }}</option>
+                                    <option value="">{{ 'Choose an archive'|trans({}, 'Modules.Autoupgrade.Admin') }}</option>
                                     {% for file in archiveFiles %}
                                         {% set fileName = file|replace({(downloadPath): ''}) %}
                                         <option {% if archiveFileName == fileName %} selected{% endif %} value="{{ fileName }}">{{ fileName }}</option>
                                     {% endfor %}
                                 </select>
                                 <br>
-                                <label for="archive_num">{{ 'Number of the version you want to upgrade to:'|trans }} * </label>
+                                <label for="archive_num">{{ 'Number of the version you want to upgrade to:'|trans({}, 'Modules.Autoupgrade.Admin') }} * </label>
                                 <input type="text" size="10" id="archive_num" name="archive_num" value="{{ archiveVersionNumber }}" placeholder="1.7.0.1" />
                                 <br>
-                                <label for="archive_xml">{{ 'XML file to use:'|trans }}</label>
+                                <label for="archive_xml">{{ 'XML file to use:'|trans({}, 'Modules.Autoupgrade.Admin') }}</label>
                                 <select id="archive_xml" name="archive_xml">
-                                    <option value="">{{ 'Choose an XML file'|trans }}</option>
+                                    <option value="">{{ 'Choose an XML file'|trans({}, 'Modules.Autoupgrade.Admin') }}</option>
                                     {% for file in xmlFiles %}
                                         {% set fileName = file|replace({(downloadPath): ''}) %}
                                         <option {% if xmlFileName == fileName %} selected{% endif %} value="{{ fileName }}">{{ fileName }}</option>
@@ -127,23 +127,23 @@
                                 </select>
                             </div>
                         {% else %}
-                            <div class="alert alert-warning">{{ 'No archive found in your admin/autoupgrade/download directory'|trans }}</div>
+                            <div class="alert alert-warning">{{ 'No archive found in your admin/autoupgrade/download directory'|trans({}, 'Modules.Autoupgrade.Admin') }}</div>
                         {% endif %}
                         <div class="margin-form">
-                            {{ 'Save in the following directory the archive file and XML file of the version you want to upgrade to: %s'|trans(['<b>/admin/autoupgrade/download/</b>'])|raw }}<br>
-                            {{ 'Click to save once the archive is there.'|trans }}<br>
-                            {{ 'This option will skip the download step.'|trans }}
+                            {{ 'Save in the following directory the archive file and XML file of the version you want to upgrade to: %s'|trans(['<b>/admin/autoupgrade/download/</b>'], 'Modules.Autoupgrade.Admin')|raw }}<br>
+                            {{ 'Click to save once the archive is there.'|trans({}, 'Modules.Autoupgrade.Admin') }}<br>
+                            {{ 'This option will skip the download step.'|trans({}, 'Modules.Autoupgrade.Admin') }}
                         </div>
                     </div>
                     <div id="for-useDirectory">
                         <div>
-                            {{ 'Save in the following directory the uncompressed PrestaShop files of the version you want to upgrade to: %s'|trans(['<b>/admin/autoupgrade/latest/</b>'])|raw }}
+                            {{ 'Save in the following directory the uncompressed PrestaShop files of the version you want to upgrade to: %s'|trans(['<b>/admin/autoupgrade/latest/</b>'], 'Modules.Autoupgrade.Admin')|raw }}
                             <br><br>
-                            <label for="directory_num">{{ 'Please tell us which version you are upgrading to [1](1.7.0.1 for instance)[/1]'|trans({'[1]': '<small>', '[/1]': '</small>'})|raw }}</label>
+                            <label for="directory_num">{{ 'Please tell us which version you are upgrading to [1](1.7.0.1 for instance)[/1]'|trans({'[1]': '<small>', '[/1]': '</small>'}, 'Modules.Autoupgrade.Admin')|raw }}</label>
                             <input type="text" size="10" id="directory_num" name="directory_num" value="{{ directoryVersionNumber }}" placeholder="1.7.0.1">
                             <div class="margin-form">
-                                {{ 'Click to save once the archive is there.'|trans }}<br>
-                                * {{ 'This option will skip both download and unzip steps and will use %1$s as the source directory'|trans(['<b>/admin/autoupgrade/latest/</b>'])|raw }}
+                                {{ 'Click to save once the archive is there.'|trans({}, 'Modules.Autoupgrade.Admin') }}<br>
+                                * {{ 'This option will skip both download and unzip steps and will use %1$s as the source directory'|trans(['<b>/admin/autoupgrade/latest/</b>'], 'Modules.Autoupgrade.Admin')|raw }}
                             </div>
                         </div>
                     </div>
@@ -157,8 +157,8 @@
 
         {% if manualMode %}
             <br class="clear"/>
-            <fieldset class="autoupgradeSteps"><legend>{{ 'Step'|trans }}</legend>
-                <h4>{{ 'Upgrade steps'|trans }} : </h4>
+            <fieldset class="autoupgradeSteps"><legend>{{ 'Step'|trans({}, 'Modules.Autoupgrade.Admin') }}</legend>
+                <h4>{{ 'Upgrade steps'|trans({}, 'Modules.Autoupgrade.Admin') }} : </h4>
                 <div>
                     <a id="download" class="upgradestep">download</a>
                     <a id="unzip" class="upgradestep">unzip</a>{# unzip in autoupgrade/latest #}

--- a/views/templates/block/versionComparison.twig
+++ b/views/templates/block/versionComparison.twig
@@ -1,16 +1,16 @@
 <div class="bootstrap" id="comparisonBlock">
     <div class="panel">
         <div class="panel-heading">
-            {{ 'Version comparison'|trans }}
+            {{ 'Version comparison'|trans({}, 'Modules.Autoupgrade.Admin') }}
         </div>
         <p>
-            <b>{{ 'PrestaShop Original version'|trans }}:</b><br>
+            <b>{{ 'PrestaShop Original version'|trans({}, 'Modules.Autoupgrade.Admin') }}:</b><br>
             <span id="checkPrestaShopFilesVersion">
                 <img id="pleaseWait" src="{{ psBaseUri }}img/loader.gif"/>
             </span>
         </p>
         <p>
-            <b>{{ 'Differences between versions'|trans }}:</b><br>
+            <b>{{ 'Differences between versions'|trans({}, 'Modules.Autoupgrade.Admin') }}:</b><br>
             <span id="checkPrestaShopModifiedFiles">
                 <img id="pleaseWait" src="{{ psBaseUri }}img/loader.gif"/>
             </span>

--- a/views/templates/main.twig
+++ b/views/templates/main.twig
@@ -12,13 +12,13 @@
 <div class="bootstrap" id="informationBlock">
     <div class="panel">
         <div class="panel-heading">
-            {{ 'Welcome!'|trans }}
+            {{ 'Welcome!'|trans({}, 'Modules.Autoupgrade.Admin') }}
         </div>
         <p>
-            {{ 'Upgrade your store to benefit from the latest improvements, bug fixes and security patches.'|trans }}
+            {{ 'Upgrade your store to benefit from the latest improvements, bug fixes and security patches.'|trans({}, 'Modules.Autoupgrade.Admin') }}
         </p>
         <p class="alert alert-warning">
-            {{ 'Upgrading your store on your own can be risky. If you don\'t feel comfortable doing the upgrade yourself, many agencies and developers in your area may also provide this kind of service.'|trans }}
+            {{ 'Upgrading your store on your own can be risky. If you don\'t feel comfortable doing the upgrade yourself, many agencies and developers in your area may also provide this kind of service.'|trans({}, 'Modules.Autoupgrade.Admin') }}
         </p>
     </div>
 </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add domain in all trans calls in twig templates, the `Modules.Autoupgrade.Admin` was missing thus, the wordings could not be scanned and be included in the PrestaShop catalog
| Type?             | bug fix
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | ~
| How to test?      | Check that the module is still usable, but we can't check if the translation works fine since the catalog has not been updated yet
| Possible impacts? | Previously the module relied on internal PHP trad, now it will use the catalog from the core So for a while, the translations may not be available anymore

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
