### PR TITLE
Remove module catalog tab even when MBO module is not installed

### DIFF
--- a/upgrade/sql/8.0.0.sql
+++ b/upgrade/sql/8.0.0.sql
@@ -8,6 +8,7 @@ DROP TABLE IF EXISTS `PREFIX_referrer_shop`;
 /* Remove page Referrers */
 ## Remove Tabs
 /* PHP:ps_remove_controller_tab('AdminThemesCatalog'); */;
+/* PHP:ps_remove_controller_tab('AdminParentModulesCatalog'); */;
 /* PHP:ps_remove_controller_tab('AdminModulesCatalog'); */;
 /* PHP:ps_remove_controller_tab('AdminAddonsCatalog'); */;
 /* PHP:ps_remove_controller_tab('AdminReferrers'); */;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Remove module catalog tab even when MBO module is not installed
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes [#29858](https://github.com/PrestaShop/PrestaShop/issues/29858)
| How to test?      | 1/ Install prestashop 1.7.8.7<br>2/ do not uninstall mbo module<br>3/Install autoupgrade module<br>4/Make sure the "disable non-native modules" option is activated<br>5/ Upgrade to PrestaShop 8<br>6/ After upgrade, check that the module catalog link has been removed in the left menu
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
