### PR TITLE
Fix error validator - "Create table SQL"

### DIFF
--- a/upgrade/php/editorial_update.php
+++ b/upgrade/php/editorial_update.php
@@ -29,14 +29,14 @@ function editorial_update()
 
     if (Db::getInstance()->getValue('SELECT `id_module` FROM `' . _DB_PREFIX_ . 'module` WHERE `name`="editorial"')) {
         Db::getInstance()->execute('
-		CREATE TABLE `' . _DB_PREFIX_ . 'editorial` (
+		CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'editorial` (
 		`id_editorial` int(10) unsigned NOT NULL auto_increment,
 		`body_home_logo_link` varchar(255) NOT NULL,
 		PRIMARY KEY (`id_editorial`))
 		ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8');
 
         Db::getInstance()->execute('
-		CREATE TABLE `' . _DB_PREFIX_ . 'editorial_lang` (
+		CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'editorial_lang` (
 		`id_editorial` int(10) unsigned NOT NULL,
 		`id_lang` int(10) unsigned NOT NULL,
 		`body_title` varchar(255) NOT NULL,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix error validator - "Creating an already existing SQL table will crash the shop. Add "IF NOT EXISTS" after "CREATE TABLE""
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | NO
| How to test?      | See how to test
| Possible impacts? | no

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

**How to test**

- Connect to https://validator.prestashop.com/
- Upload the zip of the autoupgrade
- Click on process validation
- In the Errors column, Check that the error `Creating an already existing SQL table will crash the shop. Add "IF NOT EXISTS" after "CREATE TABLE"` doesn't exist

**Before**
![image](https://user-images.githubusercontent.com/92912932/196983801-a9d0a1a3-8760-42fa-8e7f-89eb89dc85d4.png)

**After**
![image](https://user-images.githubusercontent.com/92912932/196984308-83434310-fe81-441e-a05e-6593b06fb4cd.png)
