### PR TITLE
Requires the XML file when upgrading with archive

### DIFF
--- a/classes/UpgradePage.php
+++ b/classes/UpgradePage.php
@@ -356,6 +356,7 @@ class UpgradePage
                 'moreOptions' => $translator->trans('More options (Expert mode)', [], 'Modules.Autoupgrade.Admin'),
                 'filesWillBeDeleted' => $translator->trans('These files will be deleted', [], 'Modules.Autoupgrade.Admin'),
                 'filesWillBeReplaced' => $translator->trans('These files will be replaced', [], 'Modules.Autoupgrade.Admin'),
+                'noXmlSelected' => $translator->trans('No XML file has been selected.', [], 'Modules.Autoupgrade.Admin'),
             ],
         ];
 

--- a/js/upgrade.js
+++ b/js/upgrade.js
@@ -54,6 +54,7 @@ if (typeof input === 'undefined') {
       moreOptions: "More options (Expert mode)",
       filesWillBeDeleted: "These files will be deleted",
       filesWillBeReplaced: "These files will be replaced",
+      noXmlSelected: "No XML file has been selected.",
     }
   };
 }
@@ -810,6 +811,10 @@ $(document).ready(function() {
         }
         if (archive_prestashop == "") {
           showConfigResult(input.translation.noArchiveSelected, "error");
+          return false;
+        }
+        if (archive_xml == "") {
+          showConfigResult(input.translation.noXmlSelected, "error");
           return false;
         }
         params.channel = "archive";

--- a/views/templates/block/upgradeButtonBlock.twig
+++ b/views/templates/block/upgradeButtonBlock.twig
@@ -117,7 +117,7 @@
                                 <label for="archive_num">{{ 'Number of the version you want to upgrade to:'|trans({}, 'Modules.Autoupgrade.Admin') }} * </label>
                                 <input type="text" size="10" id="archive_num" name="archive_num" value="{{ archiveVersionNumber }}" placeholder="1.7.0.1" />
                                 <br>
-                                <label for="archive_xml">{{ 'XML file to use:'|trans({}, 'Modules.Autoupgrade.Admin') }}</label>
+                                <label for="archive_xml">{{ 'XML file to use:'|trans({}, 'Modules.Autoupgrade.Admin') }} *</label>
                                 <select id="archive_xml" name="archive_xml">
                                     <option value="">{{ 'Choose an XML file'|trans({}, 'Modules.Autoupgrade.Admin') }}</option>
                                     {% for file in xmlFiles %}

--- a/views/templates/block/upgradeButtonBlock.twig
+++ b/views/templates/block/upgradeButtonBlock.twig
@@ -93,10 +93,10 @@
                     {{ channelInfoBlock|raw }}
                     <div id="for-usePrivate">
                         <p><label for="private_release_link">{{ 'Link:'|trans({}, 'Modules.Autoupgrade.Admin') }} *</label>
-                            <input type="text" size="50" id="private_release_link" name="private_release_link" value="{{ privateChannel.releaseLink }}">
+                            <input type="text" size="50" id="private_release_link" name="private_release_link" value="{{ privateChannel.releaseLink }}" required>
                         </p>
                         <p><label for="private_release_md5">{{ 'Hash key:'|trans({}, 'Modules.Autoupgrade.Admin') }} *</label>
-                            <input type="text" size="32" id="private_release_md5" name="private_release_md5" value="{{ privateChannel.releaseMd5 }}">
+                            <input type="text" size="32" id="private_release_md5" name="private_release_md5" value="{{ privateChannel.releaseMd5 }}" required>
                         </p>
                         <p><label for="private_allow_major">{{ 'Allow major upgrade:'|trans({}, 'Modules.Autoupgrade.Admin') }}</label>
                             <input type="checkbox" id="private_allow_major" name="private_allow_major" value="1"{% if privateChannel.allowMajor %} checked{% endif %}>
@@ -104,9 +104,9 @@
                     </div>
                     <div id="for-useArchive">
                         {% if archiveFiles is not empty %}
-                            <label for="archive_prestashop">{{ 'Archive to use:'|trans({}, 'Modules.Autoupgrade.Admin') }}</label>
+                            <label for="archive_prestashop">{{ 'Archive to use:'|trans({}, 'Modules.Autoupgrade.Admin') }} *</label>
                             <div>
-                                <select id="archive_prestashop" name="archive_prestashop">
+                                <select id="archive_prestashop" name="archive_prestashop" required>
                                     <option value="">{{ 'Choose an archive'|trans({}, 'Modules.Autoupgrade.Admin') }}</option>
                                     {% for file in archiveFiles %}
                                         {% set fileName = file|replace({(downloadPath): ''}) %}
@@ -115,10 +115,10 @@
                                 </select>
                                 <br>
                                 <label for="archive_num">{{ 'Number of the version you want to upgrade to:'|trans({}, 'Modules.Autoupgrade.Admin') }} * </label>
-                                <input type="text" size="10" id="archive_num" name="archive_num" value="{{ archiveVersionNumber }}" placeholder="1.7.0.1" />
+                                <input type="text" size="10" id="archive_num" name="archive_num" value="{{ archiveVersionNumber }}" placeholder="1.7.0.1" required />
                                 <br>
                                 <label for="archive_xml">{{ 'XML file to use:'|trans({}, 'Modules.Autoupgrade.Admin') }} *</label>
-                                <select id="archive_xml" name="archive_xml">
+                                <select id="archive_xml" name="archive_xml" required>
                                     <option value="">{{ 'Choose an XML file'|trans({}, 'Modules.Autoupgrade.Admin') }}</option>
                                     {% for file in xmlFiles %}
                                         {% set fileName = file|replace({(downloadPath): ''}) %}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Requires the XML file when upgrading with archive
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/29932.
| How to test?      | Follow the steps in the issue
| Possible impacts? | Autoupgrading with an archive