### PR TITLE
Fix mbo page still linked after 8.0.0 upgrade

### DIFF
--- a/upgrade/sql/8.0.0.sql
+++ b/upgrade/sql/8.0.0.sql
@@ -10,6 +10,7 @@ DROP TABLE IF EXISTS `PREFIX_referrer_shop`;
 /* PHP:ps_remove_controller_tab('AdminThemesCatalog'); */;
 /* PHP:ps_remove_controller_tab('AdminParentModulesCatalog'); */;
 /* PHP:ps_remove_controller_tab('AdminModulesCatalog'); */;
+/* PHP:ps_remove_controller_tab('AdminPsMboTheme'); */;
 /* PHP:ps_remove_controller_tab('AdminAddonsCatalog'); */;
 /* PHP:ps_remove_controller_tab('AdminReferrers'); */;
 ## Remove Roles


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR removes a broken link (mbo) after upgrade
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes [bug described in this comment](https://github.com/PrestaShop/autoupgrade/pull/516#pullrequestreview-1151232263)
| How to test?      | See how to test [here](https://github.com/PrestaShop/autoupgrade/pull/516#pullrequestreview-1151232263) 
| Possible impacts? | 
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
