### PR TITLE
Update 8.1.0.sql for actionProductPriceCalculation hook

### DIFF
--- a/upgrade/sql/8.1.0.sql
+++ b/upgrade/sql/8.1.0.sql
@@ -3,3 +3,8 @@ SET NAMES 'utf8mb4';
 
 UPDATE `PREFIX_configuration` SET `value` = 'US/Pacific' WHERE `name` = 'PS_TIMEZONE' AND `value` = 'US/Pacific-New' LIMIT 1;
 DELETE FROM `PREFIX_timezone` WHERE `name` = 'US/Pacific-New';
+
+/* New hooks added for version 8.1.0 */
+INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES
+  (NULL, 'actionProductPriceCalculation', 'Product price calculation', 'This hook allows you to override or change the result of low-level price calculation', '1'),
+;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Added new hook to override price calculation
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to https://github.com/PrestaShop/PrestaShop/pull/27927
| How to test?      | Upgrade with the current branch the hook actionProductPriceCalculation should be present in the `hook` table
| Possible impacts? | ~

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
