### PR TITLE
Disable e2e tests cron to not push on nightly

### DIFF
--- a/.github/workflows/e2e_nightly_upgrade.yml
+++ b/.github/workflows/e2e_nightly_upgrade.yml
@@ -1,8 +1,8 @@
 name: Nightly upgrades with user interfaces
 
 on:
-  schedule:
-    - cron: "0 6 * * *" # Every day at 06:00Am
+  #schedule:
+  #  - cron: "0 6 * * *" # Every day at 06:00Am
 
 env:
   reports_directory: ${{ github.workspace }}/json-reports

--- a/.github/workflows/e2e_nightly_upgrade.yml
+++ b/.github/workflows/e2e_nightly_upgrade.yml
@@ -1,6 +1,7 @@
 name: Nightly upgrades with user interfaces
 
 on:
+  #Disabled for now : dependencies used are hard to maintain, should be fixed
   #schedule:
   #  - cron: "0 6 * * *" # Every day at 06:00Am
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Disable e2e tests cron to not push on nightly
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| How to test?      | N/A
| Possible impacts? | N/A

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
