### PR TITLE
Revert mbo link removal

### DIFF
--- a/upgrade/sql/8.0.0.sql
+++ b/upgrade/sql/8.0.0.sql
@@ -8,7 +8,6 @@ DROP TABLE IF EXISTS `PREFIX_referrer_shop`;
 /* Remove page Referrers */
 ## Remove Tabs
 /* PHP:ps_remove_controller_tab('AdminThemesCatalog'); */;
-/* PHP:ps_remove_controller_tab('AdminParentModulesCatalog'); */;
 /* PHP:ps_remove_controller_tab('AdminModulesCatalog'); */;
 /* PHP:ps_remove_controller_tab('AdminAddonsCatalog'); */;
 /* PHP:ps_remove_controller_tab('AdminReferrers'); */;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | revert mbo link removal
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | Update from 1.7.8 to PS 8.0 or 8.1, the MBO module should be present before the upgrade As long as it was not uninstalled before the upgrade it should still be present after the upgrade
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
