### PR TITLE
Add and fill combination lang table

### DIFF
--- a/upgrade/php/ps_810_add_product_attribute_lang_data.php
+++ b/upgrade/php/ps_810_add_product_attribute_lang_data.php
@@ -27,9 +27,10 @@ function ps_810_add_product_attribute_lang_data()
 {
     foreach (Language::getLanguages() as $language) {
         Db::getInstance()->execute(
-      'INSERT INTO ' . _DB_PREFIX_ . 'product_attribute_lang 
-      (id_product_attribute, id_lang, available_now, available_later)
-      SELECT pa.id_product_attribute, ' . (int) $language['id_lang'] . ", '', ''
-      FROM " . _DB_PREFIX_ . 'product_attribute pa');
+            'INSERT INTO ' . _DB_PREFIX_ . 'product_attribute_lang 
+            (id_product_attribute, id_lang, available_now, available_later)
+            SELECT pa.id_product_attribute, ' . (int) $language['id_lang'] . ", '', ''
+            FROM " . _DB_PREFIX_ . 'product_attribute pa'
+        );
     }
 }

--- a/upgrade/php/ps_810_add_product_attribute_lang_data.php
+++ b/upgrade/php/ps_810_add_product_attribute_lang_data.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+function ps_810_add_product_attribute_lang_data()
+{
+    foreach (Language::getLanguages() as $language) {
+        Db::getInstance()->execute(
+      'INSERT INTO ' . _DB_PREFIX_ . 'product_attribute_lang 
+      (id_product_attribute, id_lang, available_now, available_later)
+      SELECT pa.id_product_attribute, ' . (int) $language['id_lang'] . ", '', ''
+      FROM " . _DB_PREFIX_ . 'product_attribute pa');
+    }
+}

--- a/upgrade/sql/8.1.0.sql
+++ b/upgrade/sql/8.1.0.sql
@@ -14,3 +14,14 @@ INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VAL
 /* Keep sending e-mails with prefixed subject to avoid behaviour change */
 INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES
   ('PS_MAIL_SUBJECT_PREFIX', '1', NOW(), NOW());
+
+/* Add new product_attribute_lang table and fill it with data */
+CREATE TABLE `PREFIX_product_attribute_lang` (
+  `id_product_attribute` int(10) unsigned NOT NULL,
+  `id_lang` int(10) unsigned NOT NULL,
+  `available_now` varchar(255) COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  `available_later` varchar(255) COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  PRIMARY KEY (`id_product_attribute`, `id_lang`)
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+/* PHP:ps_810_add_product_attribute_lang_data(); */;


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Autoupgrade PR for https://github.com/PrestaShop/PrestaShop/pull/29411
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| How to test?      | Have some products with combinations. Do upgrade to 8.1 and check that new table `ps_product_attribute_lang` with data is created. Try to edit some combinations, should work fine.
| Possible impacts? | no
