### PR TITLE
Add config and data for discontinuted products

### DIFF
--- a/upgrade/sql/8.1.0.sql
+++ b/upgrade/sql/8.1.0.sql
@@ -28,3 +28,9 @@ CREATE TABLE `PREFIX_product_attribute_lang` (
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 /* PHP:ps_810_add_product_attribute_lang_data(); */;
+
+/* Add default redirect configuration and change all '404' to 'default' */
+INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES  
+  ('PS_PRODUCT_REDIRECTION_DEFAULT', '404', NOW(), NOW());
+UPDATE `PREFIX_product` SET `redirect_type` = 'default' WHERE `redirect_type` = '404';
+UPDATE `PREFIX_product_shop` SET `redirect_type` = 'default' WHERE `redirect_type` = '404';


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Autoupgrade PR for https://github.com/PrestaShop/PrestaShop/pull/29720
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/pull/29720
| How to test?      | -
| Possible impacts? | -

### How to test
- Install Prestashop 8
- Check that some or all products have `redirect_type` in `ps_product` table `404`.
- Do upgrade to 8.1.
- Go check `ps_product` again and see that these products changed `redirect_type` to `default`.