### PR TITLE
Added stock mvt upgrade

### DIFF
--- a/upgrade/sql/8.1.0.sql
+++ b/upgrade/sql/8.1.0.sql
@@ -59,3 +59,4 @@ VALUES
     ('multiple_image_format', 0, 'Multiple image formats', 'Admin.Advparameters.Feature', 'Enable / Disable having more than one image format (jpg, webp, avif, png...)', 'Admin.Advparameters.Help', 'stable');
 
 ALTER TABLE `PREFIX_stock_mvt` CHANGE `employee_lastname` `employee_lastname` VARCHAR(255) DEFAULT NULL, CHANGE `employee_firstname` `employee_firstname` VARCHAR(255) DEFAULT NULL;
+ALTER TABLE `PREFIX_stock_mvt` CHANGE `physical_quantity` `physical_quantity` INT(11) UNSIGNED NOT NULL;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Changing the stock_mvt tables quantity input to unsigned. It is always positive number and by doing this we can insert twice as big int and after this [PR](https://github.com/PrestaShop/PrestaShop/pull/30592) we need that.
| Type?             | improvement 
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | Fixes [27313](https://github.com/PrestaShop/PrestaShop/issues/27313).
| How to test?      | Run upgrade and check if table stock_mvt had the column physical_quantity changed to UNSIGNED.<br>IMPORTANT NOTE: since the modified table is related to a Doctrine entity it's possible that the DB is already automatically updated via the doctrine command, so before testing the module with this PR it should be tested with dev branch alone and check if the column is updated, if it is we can close this PR without testing/merging it

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
