### PR TITLE
Change limit of filed value on ps_customized_data so that it can accepts more than 255 characters

### DIFF
--- a/upgrade/sql/8.1.0.sql
+++ b/upgrade/sql/8.1.0.sql
@@ -18,7 +18,7 @@ INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VAL
 INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES
   ('PS_MAIL_SUBJECT_PREFIX', '1', NOW(), NOW());
 
-ALTER TABLE `PREFIX_customized_data` MODIFY `value` varchar(1024) NOT NULL,;
+ALTER TABLE `PREFIX_customized_data` MODIFY `value` varchar(1024) NOT NULL;
 
 /* Add new product_attribute_lang table and fill it with data */
 CREATE TABLE `PREFIX_product_attribute_lang` (

--- a/upgrade/sql/8.1.0.sql
+++ b/upgrade/sql/8.1.0.sql
@@ -18,6 +18,8 @@ INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VAL
 INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES
   ('PS_MAIL_SUBJECT_PREFIX', '1', NOW(), NOW());
 
+ALTER TABLE `PREFIX_customized_data` MODIFY `value` varchar(1024) NOT NULL,;
+
 /* Add new product_attribute_lang table and fill it with data */
 CREATE TABLE `PREFIX_product_attribute_lang` (
   `id_product_attribute` int(10) unsigned NOT NULL,


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Change limit of filed value on ps_customized_data so that it can accepts more than 255 characters
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/27579
| Sponsor company   |
| How to test?      |
1) Install a shop with version older than develop
2) upload module autoupgrade with this PR merged
3) Use autoupgrade to upgrade to develop
4) Install classic theme with this https://github.com/PrestaShop/classic-theme/pull/100 merged (to be able to add more than 255 characters. You can instead remove the 255 characters constraint directly in the element inspector in your browser)
5)You should be able to add more than 255 characters and the display of the value should not be truncated