### PR TITLE
Fix session test

### DIFF
--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -591,11 +591,7 @@ class UpgradeSelfCheck
      */
     public function isPhpSessionsValid()
     {
-        if (!class_exists(ConfigurationTest::class)) {
-            return true;
-        }
-
-        return ConfigurationTest::test_sessions();
+        return in_array(session_status(), [PHP_SESSION_ACTIVE, PHP_SESSION_NONE], true);
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The core PHP session test of PrestaShop checks if the sessions directory is writable, which does not always work as expected. Combined with an open_basedir configured without the session.save_path, PHP sessions are still working as intended, but the test_sessions function fails. In such a case, the One Click Upgrade module will fail checking its prerequisites in an attempt to make an upgrade. This fixes the issue on all old cores, because it implements the check inside the module.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/30658
| Sponsor company   | 
| How to test?      | 

https://github.com/PrestaShop/PrestaShop/pull/31241 will fix this issue also in the core.
Original solution provided by @alexandre-profileo in https://github.com/PrestaShop/PrestaShop/pull/31053.