### PR TITLE
Add PS_MAINTENANCE_ALLOW_ADMINS to the configuration table

### DIFF
--- a/upgrade/sql/8.1.0.sql
+++ b/upgrade/sql/8.1.0.sql
@@ -33,6 +33,8 @@ CREATE TABLE `PREFIX_product_attribute_lang` (
 
 /* Add default redirect configuration and change all '404' to 'default' */
 INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES  
-  ('PS_PRODUCT_REDIRECTION_DEFAULT', '404', NOW(), NOW());
+  ('PS_PRODUCT_REDIRECTION_DEFAULT', '404', NOW(), NOW()),
+  ('PS_MAINTENANCE_ALLOW_ADMINS', 1, NOW(), NOW())
+;
 UPDATE `PREFIX_product` SET `redirect_type` = 'default' WHERE `redirect_type` = '404';
 UPDATE `PREFIX_product_shop` SET `redirect_type` = 'default' WHERE `redirect_type` = '404';


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the option PS_MAINTENANCE_ALLOW_ADMINS (enabled by default)
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related PR https://github.com/PrestaShop/PrestaShop/pull/30169
| How to test     | Install v8. Run `SELECT * FROM ps_configuration WHERE name = 'PS_MAINTENANCE_ALLOW_ADMINS';`, finds nothing. Upgrade to v9. Run query again. Finds the configuration entry.