### PR TITLE
Install ps_distributionapiclient after upgrade >= 8.0

### DIFF
--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -669,6 +669,6 @@ abstract class CoreUpgrader
 
     protected function runCoreCacheClean()
     {
-        \Tools::clearCache();
+        $this->container->getCacheCleaner()->cleanFolders();
     }
 }

--- a/upgrade/php/install_ps_distributionapiclient.php
+++ b/upgrade/php/install_ps_distributionapiclient.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+function install_ps_distributionapiclient()
+{
+    if (class_exists('Ps_Distributionapiclient')) {
+        $module = new Ps_Distributionapiclient();
+        $module->install();
+    }
+}

--- a/upgrade/sql/8.0.0.sql
+++ b/upgrade/sql/8.0.0.sql
@@ -227,3 +227,5 @@ INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VAL
 ;
 
 UPDATE `PREFIX_carrier` SET `name` = 'Click and collect' WHERE `name` = '0';
+
+/* PHP:install_ps_distributionapiclient(); */;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Install ps_distributionapiclient after upgrade >= 8.0 to purpose modules updates without install manually ps_distributionapiclient module
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | Prestashop SA
| How to test?      | Upgrade PS 1.7.8.8 to 8.0 and check if module ps_distributionapiclient is installed and if there is updates available in modules list
