### PR TITLE
Helper for adding hooks in upgrade scripts

### DIFF
--- a/upgrade/php/add_hook.php
+++ b/upgrade/php/add_hook.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+function add_hook($hook, $title, $description, $position = 1)
+{
+    return (bool) Db::getInstance()->execute(
+        'INSERT IGNORE INTO `' . _DB_PREFIX_ . 'hook` (`name`, `title`, `description`, `position`) VALUES ("' . pSQL($hook) . '", "' . pSQL($title) . '", "' . pSQL($description) . '", ' . (int) $position . ')'
+    );
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This helper makes adding hooks even easier and eases the process of review of such PRs
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | n/a
| Sponsor company   | Mr Podemsky Corp
| How to test?      | Install 8.0.1, use helper in 8.0.2 upgrade script and upgrade, and see if a new hook exists. Developer feature, developer QA probably.

How to use it?

`/* PHP:add_hook('mySuperAwesomeHook', 'Super awesome hook', 'This is yet another awesome hook in PrestaShop'); */;`
