### PR TITLE
Fixed URL to download PrestaShop releases

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -5,7 +5,7 @@ ARG VERSION
 ENV PS_VERSION $VERSION
 
 # Get PrestaShop
-ADD https://www.prestashop.com/download/old/prestashop_${PS_VERSION}.zip /tmp/prestashop.zip
+ADD https://github.com/PrestaShop/PrestaShop/releases/download/${PS_VERSION}/prestashop_${PS_VERSION}.zip /tmp/prestashop.zip
 
 # Extract
 RUN mkdir -p /tmp/data-ps \

--- a/.github/Dockerfile-7.1
+++ b/.github/Dockerfile-7.1
@@ -5,7 +5,7 @@ ARG VERSION
 ENV PS_VERSION $VERSION
 
 # Get PrestaShop
-ADD https://www.prestashop.com/download/old/prestashop_${PS_VERSION}.zip /tmp/prestashop.zip
+ADD https://github.com/PrestaShop/PrestaShop/releases/download/${PS_VERSION}/prestashop_${PS_VERSION}.zip /tmp/prestashop.zip
 
 # Extract
 RUN mkdir -p /tmp/data-ps \


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | After the prestashop.com rebranding, some links were broken. 
| Type?             | bug fix 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Sponsor company   | PrestaShop SA
| How to test?      | 

This PR will work only with PrestaShop >= 1.5.6.0. 