### PR TITLE
Use interface instant of implementation

### DIFF
--- a/classes/UpgradeTools/ModuleAdapter.php
+++ b/classes/UpgradeTools/ModuleAdapter.php
@@ -85,7 +85,7 @@ class ModuleAdapter
     /**
      * Available only since 1.7.6.0 Can't be called on PS 1.6.
      *
-     * @return \PrestaShop\PrestaShop\Core\CommandBus\TacticianCommandBusAdapter
+     * @return \PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface
      */
     public function getCommandBus()
     {

--- a/tests/phpstan/phpstan-1.6.1.18.neon
+++ b/tests/phpstan/phpstan-1.6.1.18.neon
@@ -21,4 +21,4 @@ parameters:
 		- '#Call to method getContainer\(\) on an unknown class AppKernel.#'
 		- '#PrestaShop\\PrestaShop\\Adapter\\Module\\ModuleDataUpdater#'
 		- '#Property ModuleCore::\$version \(float\) does not accept string.#'
-		- '#Return typehint of method PrestaShop\\Module\\AutoUpgrade\\UpgradeTools\\ModuleAdapter::getCommandBus\(\) has invalid type PrestaShop\\PrestaShop\\Core\\CommandBus\\TacticianCommandBusAdapter.#'
+		- '#Return typehint of method PrestaShop\\Module\\AutoUpgrade\\UpgradeTools\\ModuleAdapter::getCommandBus\(\) has invalid type PrestaShop\\PrestaShop\\Core\\CommandBus\\CommandBusInterface.#'

--- a/tests/phpstan/phpstan-1.7.2.5.neon
+++ b/tests/phpstan/phpstan-1.7.2.5.neon
@@ -19,5 +19,5 @@ parameters:
 		- '#Instantiated class PrestaShop\\PrestaShop\\Core\\Domain\\Theme\\ValueObject\\ThemeName not found.#'
 		- '#PHPDoc tag @var for variable \$commandBus contains unknown class PrestaShop\\PrestaShop\\Core\\CommandBus\\CommandBusInterface.#'
 		- '#Property ModuleCore::\$version \(float\) does not accept string.#'
-		- '#Return typehint of method PrestaShop\\Module\\AutoUpgrade\\UpgradeTools\\ModuleAdapter::getCommandBus\(\) has invalid type PrestaShop\\PrestaShop\\Core\\CommandBus\\TacticianCommandBusAdapter.#'
+		- '#Return typehint of method PrestaShop\\Module\\AutoUpgrade\\UpgradeTools\\ModuleAdapter::getCommandBus\(\) has invalid type PrestaShop\\PrestaShop\\Core\\CommandBus\\CommandBusInterface.#'
 		- '#Return typehint of method PrestaShop\\Module\\AutoUpgrade\\UpgradeTools\\SymfonyAdapter::initAppKernel\(\) has invalid type AppKernel.#'

--- a/tests/phpstan/phpstan-1.7.3.4.neon
+++ b/tests/phpstan/phpstan-1.7.3.4.neon
@@ -19,5 +19,5 @@ parameters:
 		- '#Instantiated class PrestaShop\\PrestaShop\\Core\\Domain\\Theme\\ValueObject\\ThemeName not found.#'
 		- '#PHPDoc tag @var for variable \$commandBus contains unknown class PrestaShop\\PrestaShop\\Core\\CommandBus\\CommandBusInterface.#'
 		- '#Property ModuleCore::\$version \(float\) does not accept string.#'
-		- '#Return typehint of method PrestaShop\\Module\\AutoUpgrade\\UpgradeTools\\ModuleAdapter::getCommandBus\(\) has invalid type PrestaShop\\PrestaShop\\Core\\CommandBus\\TacticianCommandBusAdapter.#'
+		- '#Return typehint of method PrestaShop\\Module\\AutoUpgrade\\UpgradeTools\\ModuleAdapter::getCommandBus\(\) has invalid type PrestaShop\\PrestaShop\\Core\\CommandBus\\CommandBusInterface.#'
 		- '#Return typehint of method PrestaShop\\Module\\AutoUpgrade\\UpgradeTools\\SymfonyAdapter::initAppKernel\(\) has invalid type AppKernel.#'

--- a/tests/phpstan/phpstan-1.7.4.4.neon
+++ b/tests/phpstan/phpstan-1.7.4.4.neon
@@ -14,4 +14,4 @@ parameters:
 		- '#Instantiated class PrestaShop\\PrestaShop\\Core\\Domain\\Theme\\ValueObject\\ThemeName not found.#'
 		- '#PHPDoc tag @var for variable \$commandBus contains unknown class PrestaShop\\PrestaShop\\Core\\CommandBus\\CommandBusInterface.#'
 		- '#Property ModuleCore::\$version \(float\) does not accept string.#'
-		- '#Return typehint of method PrestaShop\\Module\\AutoUpgrade\\UpgradeTools\\ModuleAdapter::getCommandBus\(\) has invalid type PrestaShop\\PrestaShop\\Core\\CommandBus\\TacticianCommandBusAdapter.#'
+		- '#Return typehint of method PrestaShop\\Module\\AutoUpgrade\\UpgradeTools\\ModuleAdapter::getCommandBus\(\) has invalid type PrestaShop\\PrestaShop\\Core\\CommandBus\\CommandBusInterface.#'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Use interface instant of implementation for get command-bus return. Also TacticianCommandBusAdapter no longer exist in 9.0.0
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | -
| How to test?      | -
