### PR TITLE
Add key check

### DIFF
--- a/classes/Twig/Block/UpgradeChecklist.php
+++ b/classes/Twig/Block/UpgradeChecklist.php
@@ -133,6 +133,7 @@ class UpgradeChecklist
             'checkPhpVersionCompatibility' => $this->selfCheck->isPhpVersionCompatible(),
             'checkApacheModRewrite' => $this->selfCheck->isApacheModRewriteEnabled(),
             'notLoadedPhpExtensions' => $this->selfCheck->getNotLoadedPhpExtensions(),
+            'checkKeyGeneration' => $this->selfCheck->checkKeyGeneration(),
             'checkMemoryLimit' => $this->selfCheck->isMemoryLimitValid(),
             'checkFileUploads' => $this->selfCheck->isPhpFileUploadsConfigurationEnabled(),
             'notExistsPhpFunctions' => $this->selfCheck->getNotExistsPhpFunctions(),

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -363,6 +363,7 @@ class UpgradeSelfCheck
             && $this->isModuleVersionLatest()
             && $this->isPhpVersionCompatible()
             && $this->isApacheModRewriteEnabled()
+            && $this->checkKeyGeneration()
             && $this->getNotLoadedPhpExtensions() === []
             && $this->isMemoryLimitValid()
             && $this->isPhpFileUploadsConfigurationEnabled()
@@ -515,6 +516,28 @@ class UpgradeSelfCheck
     {
         if (class_exists(ConfigurationTest::class) && is_callable([ConfigurationTest::class, 'test_apache_mod_rewrite'])) {
             return ConfigurationTest::test_apache_mod_rewrite();
+        }
+
+        return true;
+    }
+
+    /**
+     * @return bool
+     */
+    public function checkKeyGeneration()
+    {
+        // Check if key is needed on the version we are upgrading to, if lower, not needed
+        if (version_compare($this->upgrader->version_num, '8.1.0', '<')) {
+            return true;
+        }
+
+        $privateKey = openssl_pkey_new([
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]);
+
+        if ($privateKey === false) {
+            return false;
         }
 
         return true;

--- a/views/templates/block/checklist.twig
+++ b/views/templates/block/checklist.twig
@@ -189,6 +189,12 @@
                     <td>{{ icons.nok }}</td>
                   </tr>
                 {% endif %}
+                {% if not checkKeyGeneration %}
+                  <tr>
+                    <td>{{ 'Unable to generate private keys using openssl_pkey_new. Check your OpenSSL configuration, especially the path to openssl.cafile.'|trans({}, 'Modules.Autoupgrade.Admin') }}</td>
+                    <td>{{ icons.nok }}</td>
+                  </tr>
+                {% endif %}
                 {% if missingFiles|length > 0 %}
                   <tr>
                     <td>


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Adds warning about key generation in order not to crash the upgrade. Error shows up only if it fails, in order not to make the table kilometer long. :-) They key is only checked when upgrading to 8.1.0 or newer.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #https://github.com/PrestaShop/PrestaShop/issues/33286
| Sponsor company   | 
| How to test?      | See below

### How to test
- We can see that https://www.php.net/manual/en/function.openssl-pkey-new.php returns a false on failure, which is confirmed by the issue - https://github.com/PrestaShop/PrestaShop/issues/33286.
- So, to test it, put `return false;` to the beginning checkKeyGeneration method in  classes/UpgradeSelfCheck.php. You should see the error message in autoupgrade module afterwards.

### Related core PR
https://github.com/PrestaShop/PrestaShop/pull/33292

### Screenshot
![Snímek obrazovky 2023-07-19 114543](https://github.com/PrestaShop/autoupgrade/assets/6097524/60f8a390-a0ad-4902-89d3-cc9191e067b8)
