### PR TITLE
Update all languages during upgrade and fix menu translations

### DIFF
--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -486,7 +486,7 @@ abstract class CoreUpgrader
             define('_PS_MAILS_DIR_', _PS_ROOT_DIR_ . '/mails/');
         }
 
-        $langs = $this->db->executeS('SELECT * FROM `' . _DB_PREFIX_ . 'lang` WHERE `active` = 1');
+        $langs = $this->db->executeS('SELECT * FROM `' . _DB_PREFIX_ . 'lang`');
 
         if (!is_array($langs)) {
             return;

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader17.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader17.php
@@ -82,6 +82,11 @@ class CoreUpgrader17 extends CoreUpgrader
         $lang_pack = \Language::getLangDetails($isoCode);
         \Language::installSfLanguagePack($lang_pack['locale'], $errorsLanguage);
 
+        // Method does not exist in older versions of 1.7
+        if (method_exists(\Language::class, 'updateMultilangTable')) {
+            \Language::updateMultilangTable($isoCode);
+        }
+
         if (!$this->container->getUpgradeConfiguration()->shouldKeepMails()) {
             \Language::installEmailsLanguagePack($lang_pack, $errorsLanguage);
         }
@@ -90,8 +95,6 @@ class CoreUpgrader17 extends CoreUpgrader
             throw new UpgradeException($this->container->getTranslator()->trans('Error while updating translations for the language pack %lang%. %details%', ['%lang%' => $isoCode, '%details%' => implode('; ', $errorsLanguage)], 'Modules.Autoupgrade.Admin'));
         }
         \Language::loadLanguages();
-
-        // TODO: Update AdminTranslationsController::addNewTabs to install tabs translated
 
         // CLDR has been updated on PS 1.7.6.0. From this version, updates are not needed anymore.
         if (version_compare($this->container->getState()->getInstallVersion(), '1.7.6.0', '<')) {

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
@@ -91,6 +91,8 @@ class CoreUpgrader80 extends CoreUpgrader
         $lang_pack = \Language::getLangDetails($isoCode);
         \Language::installSfLanguagePack($lang_pack['locale'], $errorsLanguage);
 
+        \Language::updateMultilangTable($isoCode);
+
         if (!$this->container->getUpgradeConfiguration()->shouldKeepMails()) {
             $this->logger->debug($this->container->getTranslator()->trans('Generating mail templates for %lang%', ['%lang%' => $isoCode], 'Modules.Autoupgrade.Admin'));
             $mailTheme = \Configuration::get('PS_MAIL_THEME', null, null, null, 'modern');
@@ -120,8 +122,6 @@ class CoreUpgrader80 extends CoreUpgrader
             throw new UpgradeException($this->container->getTranslator()->trans('Error while updating translations for the language pack %lang%. %details%', ['%lang%' => $isoCode, '%details%' => implode('; ', $errorsLanguage)], 'Modules.Autoupgrade.Admin'));
         }
         \Language::loadLanguages();
-
-        // TODO: Update AdminTranslationsController::addNewTabs to install tabs translated
     }
 
     protected function disableCustomModules()


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | See below
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/33321
| Sponsor company   |
| How to test?      | See below

### Description
- Language upgrade methods do not call ALL the functions that are required to properly update language. After going from lower than 1.7.7, you get English menu on the left. The cause is missing call to `Language::updateMultilangTable();`.
- Conditioned out in 1.7 upgrader because this function does not exist in archaic versions of 1.7, in 8 upgrader, no condition.
- Also, updates all languages (even the disabled ones) during upgrade. Some users may have a disabled language just for backoffice-purposes, this language would not be updated with the current code.

### How to test
- Install 1.7.6 in Czech.
- Upgrade to 8.1.
- See that left menu is still in Czech. 
- (Without this PR, it's in English until you go to Translations and update Czech language pack again.)