### PR TITLE
Fix product redirect_type

### DIFF
--- a/upgrade/php/ps_811_update_redirect_type.php
+++ b/upgrade/php/ps_811_update_redirect_type.php
@@ -40,14 +40,14 @@ function ps_811_update_redirect_type()
     }
 
     // If not, we execute our upgrade queries
-    Db::getInstance()->execute("ALTER TABLE `" . _DB_PREFIX_ . "product` MODIFY COLUMN `redirect_type` ENUM(
+    Db::getInstance()->execute('ALTER TABLE `' . _DB_PREFIX_ . "product` MODIFY COLUMN `redirect_type` ENUM(
         '','404','410','301-product','302-product','301-category','302-category','200-displayed','404-displayed','410-displayed','default'
         ) NOT NULL DEFAULT 'default';");
-    Db::getInstance()->execute("ALTER TABLE `" . _DB_PREFIX_ . "product_shop` MODIFY COLUMN `redirect_type` ENUM(
+    Db::getInstance()->execute('ALTER TABLE `' . _DB_PREFIX_ . "product_shop` MODIFY COLUMN `redirect_type` ENUM(
         '','404','410','301-product','302-product','301-category','302-category','200-displayed','404-displayed','410-displayed','default'
         ) NOT NULL DEFAULT 'default';");
-    Db::getInstance()->execute("UPDATE `" . _DB_PREFIX_ . "product` SET `redirect_type` = 'default' WHERE `redirect_type` = '404';");
-    Db::getInstance()->execute("UPDATE `" . _DB_PREFIX_ . "product_shop` SET `redirect_type` = 'default' WHERE `redirect_type` = '404';");
+    Db::getInstance()->execute('UPDATE `' . _DB_PREFIX_ . "product` SET `redirect_type` = 'default' WHERE `redirect_type` = '404';");
+    Db::getInstance()->execute('UPDATE `' . _DB_PREFIX_ . "product_shop` SET `redirect_type` = 'default' WHERE `redirect_type` = '404';");
 
     return true;
 }

--- a/upgrade/php/ps_811_update_redirect_type.php
+++ b/upgrade/php/ps_811_update_redirect_type.php
@@ -46,8 +46,8 @@ function ps_811_update_redirect_type()
     Db::getInstance()->execute('ALTER TABLE `' . _DB_PREFIX_ . "product_shop` MODIFY COLUMN `redirect_type` ENUM(
         '','404','410','301-product','302-product','301-category','302-category','200-displayed','404-displayed','410-displayed','default'
         ) NOT NULL DEFAULT 'default';");
-    Db::getInstance()->execute('UPDATE `' . _DB_PREFIX_ . "product` SET `redirect_type` = 'default' WHERE `redirect_type` = '404';");
-    Db::getInstance()->execute('UPDATE `' . _DB_PREFIX_ . "product_shop` SET `redirect_type` = 'default' WHERE `redirect_type` = '404';");
+    Db::getInstance()->execute('UPDATE `' . _DB_PREFIX_ . "product` SET `redirect_type` = 'default' WHERE `redirect_type` = '404' OR `redirect_type` = '';");
+    Db::getInstance()->execute('UPDATE `' . _DB_PREFIX_ . "product_shop` SET `redirect_type` = 'default' WHERE `redirect_type` = '404' OR `redirect_type` = '';");
 
     return true;
 }

--- a/upgrade/php/ps_811_update_redirect_type.php
+++ b/upgrade/php/ps_811_update_redirect_type.php
@@ -46,8 +46,8 @@ function ps_811_update_redirect_type()
     Db::getInstance()->execute('ALTER TABLE `' . _DB_PREFIX_ . "product_shop` MODIFY COLUMN `redirect_type` ENUM(
         '','404','410','301-product','302-product','301-category','302-category','200-displayed','404-displayed','410-displayed','default'
         ) NOT NULL DEFAULT 'default';");
-    Db::getInstance()->execute('UPDATE `' . _DB_PREFIX_ . "product` SET `redirect_type` = 'default' WHERE `redirect_type` = '404' OR `redirect_type` = '';");
-    Db::getInstance()->execute('UPDATE `' . _DB_PREFIX_ . "product_shop` SET `redirect_type` = 'default' WHERE `redirect_type` = '404' OR `redirect_type` = '';");
+    Db::getInstance()->execute('UPDATE `' . _DB_PREFIX_ . "product` SET `redirect_type` = 'default' WHERE `redirect_type` = '404' OR `redirect_type` = '' OR `redirect_type` IS NULL;");
+    Db::getInstance()->execute('UPDATE `' . _DB_PREFIX_ . "product_shop` SET `redirect_type` = 'default' WHERE `redirect_type` = '404' OR `redirect_type` = '' OR `redirect_type` IS NULL;");
 
     return true;
 }

--- a/upgrade/php/ps_811_update_redirect_type.php
+++ b/upgrade/php/ps_811_update_redirect_type.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+function ps_811_update_redirect_type()
+{
+    // Get information about redirect_type column
+    $columnInformation = Db::getInstance()->executeS('SHOW COLUMNS FROM `' . _DB_PREFIX_ . 'product` LIKE "redirect_type"');
+    if (empty($columnInformation)) {
+        return true;
+    }
+
+    // Get first record found
+    $columnInformation = reset($columnInformation);
+
+    // Check if it was already upgraded and contains new information
+    if (strpos($columnInformation['Type'], '200-displayed') !== false) {
+        return true;
+    }
+
+    // If not, we execute our upgrade queries
+    Db::getInstance()->execute("ALTER TABLE `" . _DB_PREFIX_ . "product` MODIFY COLUMN `redirect_type` ENUM(
+        '','404','410','301-product','302-product','301-category','302-category','200-displayed','404-displayed','410-displayed','default'
+        ) NOT NULL DEFAULT 'default';");
+    Db::getInstance()->execute("ALTER TABLE `" . _DB_PREFIX_ . "product_shop` MODIFY COLUMN `redirect_type` ENUM(
+        '','404','410','301-product','302-product','301-category','302-category','200-displayed','404-displayed','410-displayed','default'
+        ) NOT NULL DEFAULT 'default';");
+    Db::getInstance()->execute("UPDATE `" . _DB_PREFIX_ . "product` SET `redirect_type` = 'default' WHERE `redirect_type` = '404';");
+    Db::getInstance()->execute("UPDATE `" . _DB_PREFIX_ . "product_shop` SET `redirect_type` = 'default' WHERE `redirect_type` = '404';");
+
+    return true;
+}

--- a/upgrade/sql/8.1.0.sql
+++ b/upgrade/sql/8.1.0.sql
@@ -38,7 +38,7 @@ INSERT INTO `PREFIX_product_attribute_lang`
 SELECT pa.id_product_attribute, l.id_lang, '', ''
 FROM `PREFIX_product_attribute` pa CROSS JOIN `PREFIX_lang` l;
 
-/* Add default redirect configuration and change all '404' to 'default' */
+/* Add default redirect configuration */
 INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES
   ('PS_PRODUCT_REDIRECTION_DEFAULT', '404', NOW(), NOW()),
   ('PS_MAINTENANCE_ALLOW_ADMINS', 1, NOW(), NOW()),
@@ -46,6 +46,15 @@ INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VAL
   ('PS_IMAGE_FORMAT', 'jpg', NOW(), NOW())
 ;
 
+/* Update ENUM values in both tables*/
+ALTER TABLE `PREFIX_product` MODIFY COLUMN `redirect_type` ENUM(
+  '','404','410','301-product','302-product','301-category','302-category','200-displayed','404-displayed','410-displayed','default'
+) NOT NULL DEFAULT 'default';
+ALTER TABLE `PREFIX_product_shop` MODIFY COLUMN `redirect_type` ENUM(
+  '','404','410','301-product','302-product','301-category','302-category','200-displayed','404-displayed','410-displayed','default'
+) NOT NULL DEFAULT 'default';
+
+/* and change all '404' to 'default' */
 UPDATE `PREFIX_product` SET `redirect_type` = 'default' WHERE `redirect_type` = '404';
 UPDATE `PREFIX_product_shop` SET `redirect_type` = 'default' WHERE `redirect_type` = '404';
 

--- a/upgrade/sql/8.1.0.sql
+++ b/upgrade/sql/8.1.0.sql
@@ -55,8 +55,8 @@ ALTER TABLE `PREFIX_product_shop` MODIFY COLUMN `redirect_type` ENUM(
 ) NOT NULL DEFAULT 'default';
 
 /* and change all '404' to 'default' */
-UPDATE `PREFIX_product` SET `redirect_type` = 'default' WHERE `redirect_type` = '404';
-UPDATE `PREFIX_product_shop` SET `redirect_type` = 'default' WHERE `redirect_type` = '404';
+UPDATE `PREFIX_product` SET `redirect_type` = 'default' WHERE `redirect_type` = '404' OR `redirect_type` = '' OR `redirect_type` IS NULL;
+UPDATE `PREFIX_product_shop` SET `redirect_type` = 'default' WHERE `redirect_type` = '404' OR `redirect_type` = '' OR `redirect_type` IS NULL;
 
 /* Update feature flags */
 /* PHP:ps_810_update_product_page_feature_flags(); */;

--- a/upgrade/sql/8.1.1.sql
+++ b/upgrade/sql/8.1.1.sql
@@ -1,0 +1,5 @@
+SET SESSION sql_mode='';
+SET NAMES 'utf8mb4';
+
+/* We forgot to update redirect_type in 8.1.0. This updates it, if it's not done already */
+/* PHP:ps_811_update_redirect_type(); */;


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | I forgot to update product redirect_type and QA did not catch that it doesn't work on upgraded 8.1.0 installs. This adds the missing queries for people upgrading to 8.1.0 and it adds a script that will fix it for people who updated to 8.1.0 already.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/33488
| Sponsor company   | 
| How to test?      | Upgrade 8.0 to 8.1, open phpmyadmin, check structure of ps_product table and see that column redirect_type has is `ENUM('','404','410','301-product','302-product','301-category','302-category','200-displayed','404-displayed','410-displayed','default');`.