### PR TITLE
Add empty values for MPN fields

### DIFF
--- a/upgrade/sql/1.7.7.0.sql
+++ b/upgrade/sql/1.7.7.0.sql
@@ -11,12 +11,17 @@ INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VAL
     ('PS_SEARCH_MAX_WORD_LENGTH', '15', NOW(), NOW())
 ;
 
-/* Add field MPN to tables */
+/* Add field MPN to tables and assign empty values */
 ALTER TABLE `PREFIX_order_detail` ADD `product_mpn` VARCHAR(40) NULL AFTER `product_upc`;
 ALTER TABLE `PREFIX_supply_order_detail` ADD `mpn` VARCHAR(40) NULL AFTER `upc`;
 ALTER TABLE `PREFIX_stock` ADD `mpn` VARCHAR(40) NULL AFTER `upc`;
 ALTER TABLE `PREFIX_product_attribute` ADD `mpn` VARCHAR(40) NULL AFTER `upc`;
 ALTER TABLE `PREFIX_product` ADD `mpn` VARCHAR(40) NULL AFTER `upc`;
+UPDATE `PREFIX_order_detail` SET `product_mpn` = '';
+UPDATE `PREFIX_supply_order_detail` SET `mpn` = '';
+UPDATE `PREFIX_stock` SET `mpn` = '';
+UPDATE `PREFIX_product_attribute` SET `mpn` = '';
+UPDATE `PREFIX_product` SET `mpn` = '';
 
 /* Delete price display precision configuration */
 DELETE FROM `PREFIX_configuration` WHERE `name` = 'PS_PRICE_DISPLAY_PRECISION';


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When upgrading when PS versions 1.7.7 and lower, somebody forgot to set empty values after adding new columns for MPN field. This value is added, but is NULL. This was not a problem on legacy product page, but results in exception when opening products on new product page.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #https://github.com/PrestaShop/PrestaShop/issues/33493
| Sponsor company   | 
| How to test?      | Follow the steps in the issue and check that you can edit products just fine after upgrading.
