### PR TITLE
Clean opcache when cleaning cache

### DIFF
--- a/classes/TaskRunner/Upgrade/UpgradeDb.php
+++ b/classes/TaskRunner/Upgrade/UpgradeDb.php
@@ -78,7 +78,10 @@ class UpgradeDb extends AbstractTask
 
     public function init()
     {
+        $this->logger->info($this->translator->trans('Cleaning file cache', [], 'Modules.Autoupgrade.Admin'));
         $this->container->getCacheCleaner()->cleanFolders();
+        $this->logger->info($this->translator->trans('Running opcache_reset', [], 'Modules.Autoupgrade.Admin'));
+        $this->container->resetOpcache();
 
         // Migrating settings file
         $this->container->initPrestaShopAutoloader();

--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -578,4 +578,18 @@ class UpgradeContainer
         $id_employee = !empty($_COOKIE['id_employee']) ? $_COOKIE['id_employee'] : 1;
         \Context::getContext()->employee = new \Employee((int) $id_employee);
     }
+
+    /**
+     * Attemps to flush opcache
+     */
+    public function resetOpcache()
+    {
+        $disabled = explode(',', ini_get('disable_functions'));
+
+        if (in_array('opcache_reset', $disabled) || !is_callable('opcache_reset')) {
+            return;
+        }
+
+        opcache_reset();
+    }
 }

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -669,6 +669,9 @@ abstract class CoreUpgrader
 
     protected function runCoreCacheClean()
     {
+        $this->logger->info($this->container->getTranslator()->trans('Cleaning file cache', [], 'Modules.Autoupgrade.Admin'));
         $this->container->getCacheCleaner()->cleanFolders();
+        $this->logger->info($this->container->getTranslator()->trans('Running opcache_reset', [], 'Modules.Autoupgrade.Admin'));
+        $this->container->resetOpcache();
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Resets opcache when cleaning file cache.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Does not fix any specific issue, but there may be many issues caused by this we did not even know we fixed. :-)
| Sponsor company   | 
| How to test?      | Follow steps in issue.
