### PR TITLE
Avoid deleting a popular payment module "stripejs"

### DIFF
--- a/classes/TaskRunner/Upgrade/UpgradeModules.php
+++ b/classes/TaskRunner/Upgrade/UpgradeModules.php
@@ -29,9 +29,7 @@ namespace PrestaShop\Module\AutoUpgrade\TaskRunner\Upgrade;
 
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeFileNames;
 use PrestaShop\Module\AutoUpgrade\TaskRunner\AbstractTask;
-use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 use PrestaShop\Module\AutoUpgrade\UpgradeException;
-use PrestaShop\Module\AutoUpgrade\UpgradeTools\FilesystemAdapter;
 
 /**
  * Upgrade all partners modules according to the installed prestashop version.

--- a/classes/TaskRunner/Upgrade/UpgradeModules.php
+++ b/classes/TaskRunner/Upgrade/UpgradeModules.php
@@ -83,40 +83,6 @@ class UpgradeModules extends AbstractTask
             }
             $this->stepDone = false;
         } else {
-            $modules_to_delete = [];
-
-            foreach ($modules_to_delete as $key => $module) {
-                $this->container->getDb()->execute('DELETE ms.*, hm.*
-                FROM `' . _DB_PREFIX_ . 'module_shop` ms
-                INNER JOIN `' . _DB_PREFIX_ . 'hook_module` hm USING (`id_module`)
-                INNER JOIN `' . _DB_PREFIX_ . 'module` m USING (`id_module`)
-                WHERE m.`name` LIKE \'' . pSQL($key) . '\'');
-                $this->container->getDb()->execute('UPDATE `' . _DB_PREFIX_ . 'module` SET `active` = 0 WHERE `name` LIKE \'' . pSQL($key) . '\'');
-
-                $path = $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH) . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR . $key . DIRECTORY_SEPARATOR;
-                if (file_exists($path . $key . '.php')) {
-                    if (FilesystemAdapter::deleteDirectory($path)) {
-                        $this->logger->debug($this->translator->trans(
-                            'The %modulename% module is not compatible with version %version%, it will be removed from your FTP.',
-                            [
-                                '%modulename%' => $module,
-                                '%version%' => $this->container->getState()->getInstallVersion(),
-                            ],
-                            'Modules.Autoupgrade.Admin'
-                        ));
-                    } else {
-                        $this->logger->error($this->translator->trans(
-                            'The %modulename% module is not compatible with version %version%, please remove it from your FTP.',
-                            [
-                                '%modulename%' => $module,
-                                '%version%' => $this->container->getState()->getInstallVersion(),
-                            ],
-                            'Modules.Autoupgrade.Admin'
-                        ));
-                    }
-                }
-            }
-
             $this->stepDone = true;
             $this->status = 'ok';
             $this->next = 'cleanDatabase';

--- a/classes/TaskRunner/Upgrade/UpgradeModules.php
+++ b/classes/TaskRunner/Upgrade/UpgradeModules.php
@@ -83,16 +83,7 @@ class UpgradeModules extends AbstractTask
             }
             $this->stepDone = false;
         } else {
-            $modules_to_delete = [
-                'backwardcompatibility' => 'Backward Compatibility',
-                'dibs' => 'Dibs',
-                'cloudcache' => 'Cloudcache',
-                'mobile_theme' => 'The 1.4 mobile_theme',
-                'trustedshops' => 'Trustedshops',
-                'dejala' => 'Dejala',
-                'stripejs' => 'Stripejs',
-                'blockvariouslinks' => 'Block Various Links',
-            ];
+            $modules_to_delete = [];
 
             foreach ($modules_to_delete as $key => $module) {
                 $this->container->getDb()->execute('DELETE ms.*, hm.*


### PR DESCRIPTION
Hello,

I'm the contributor for the module "Stripejs" payment module and I've got lots of complains that the module does gets deleted while upgrading Prestashop. So I opened an issue to fix it but nothing was done after long time. https://github.com/PrestaShop/PrestaShop/issues/27561 So I decided to do it myself.

The code which I removed from this autopgrade module, is responsible to delete my module during the upgrade. 

Please consider this change at high priority because thousands of customers are constantly facing this serious issue. 
Best Regards,
Sitender

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Bug fixed to stop deleting a popular Stripe payment module during PrestaShop upgrade.https://addons.prestashop.com/en/payment-card-wallet/17856-stripe-payment-pro-sca-ready.html
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #{[issue URL here](https://github.com/PrestaShop/PrestaShop/issues/27561)}
| Sponsor company   | Your company or customer's name goes here (if applicable).
| How to test?      | Install "stripejs" => "Stripe Payment Pro" payment module. https://addons.prestashop.com/en/payment-card-wallet/17856-stripe-payment-pro-sca-ready.html and do upgrade Prestashop. It'll delete "stripejs" module. With changes, it'll not delete the module.
