### PR TITLE
Add force removing system for some files

### DIFF
--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
@@ -38,10 +38,27 @@ class CoreUpgrader80 extends CoreUpgrader
 {
     protected function initConstants()
     {
+        $this->forceRemovingFiles();
         parent::initConstants();
 
         // Container may be needed to run upgrade scripts
         $this->container->getSymfonyAdapter()->initAppKernel();
+    }
+
+    /**
+     * Force remove files if they aren't removed properly after files upgrade.
+     */
+    protected function forceRemovingFiles()
+    {
+        $filesToForceRemove = [
+            '/src/PrestaShopBundle/Resources/config/services/adapter/news.yml',
+        ];
+
+        foreach ($filesToForceRemove as $file) {
+            if (file_exists(_PS_ROOT_DIR_ . $file)) {
+                unlink(_PS_ROOT_DIR_ . $file);
+            }
+        }
     }
 
     protected function upgradeDb($oldversion)


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | In some case, we have a error about circuit breaker system<br/> when we upgrade from < 1.7.8.X to 8.X.<br/>This anomaly come when a `news.yml` file stay in filesystem.<br/>(on 8.X versions, we have delete this file)
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #{issue URL here}, Fixes #{another issue URL here}
| Sponsor company   | PrestaShop SA
| How to test?      | 1. Install 1.7.8.10.<br/>2. Upgrade to 8.1.1 version.<br/>3. The upgrade must be done with success.
