### PR TITLE
Update version regex in JavaScript

### DIFF
--- a/js/upgrade.js
+++ b/js/upgrade.js
@@ -772,7 +772,7 @@ $(document).ready(function() {
     var params = {};
     var $newChannel = $("select[name=channel] option:selected").val();
     var $oldChannel = $("select[name=channel] option.current").val();
-    var versionNumberRegex = /^8\.\d+\.\d+$|^9\.\d+\.\d+$|^1\.(6|7)\.\d+\.\d+$/;
+    var versionNumberRegex = /^(8|9)\.\d+\.\d+$|^1\.(6|7)\.\d+\.\d+$/;
 
     $oldChannel = "";
 

--- a/js/upgrade.js
+++ b/js/upgrade.js
@@ -772,7 +772,7 @@ $(document).ready(function() {
     var params = {};
     var $newChannel = $("select[name=channel] option:selected").val();
     var $oldChannel = $("select[name=channel] option.current").val();
-    var versionNumberRegex = /^(8|9)\.\d+\.\d+$|^1\.(6|7)\.\d+\.\d+$/;
+    var versionNumberRegex = /^\d+(.\d+){2,3}$/;
 
     $oldChannel = "";
 

--- a/js/upgrade.js
+++ b/js/upgrade.js
@@ -772,7 +772,7 @@ $(document).ready(function() {
     var params = {};
     var $newChannel = $("select[name=channel] option:selected").val();
     var $oldChannel = $("select[name=channel] option.current").val();
-    var versionNumberRegex = /^8\.\d+\.\d+$|^1\.(6|7)\.\d+\.\d+$/;
+    var versionNumberRegex = /^8\.\d+\.\d+$|^9\.\d+\.\d+$|^1\.(6|7)\.\d+\.\d+$/;
 
     $oldChannel = "";
 


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Version validation regex didn't take PS 9 into account
| Type?             | bug fix 
| BC breaks?        | no
| Deprecations?     |  no
| Fixed ticket?     | Partially Fixes https://github.com/PrestaShop/PrestaShop/issues/33578
| Sponsor company   | PrestaShop SA
| How to test?      | See https://github.com/PrestaShop/PrestaShop/issues/33578