### PR TITLE
fix local module upgrade

### DIFF
--- a/classes/TaskRunner/Upgrade/UpgradeModules.php
+++ b/classes/TaskRunner/Upgrade/UpgradeModules.php
@@ -104,6 +104,12 @@ class UpgradeModules extends AbstractTask
         return true;
     }
 
+    /**
+     * Get the list of module zips in admin/autoupgrade/modules
+     * These zips will be used to upgrade related modules instead of using distant zips on addons
+     *
+     * @return array
+     */
     private function getLocalModules()
     {
         $localModuleDir = sprintf(

--- a/classes/TaskRunner/Upgrade/UpgradeModules.php
+++ b/classes/TaskRunner/Upgrade/UpgradeModules.php
@@ -54,13 +54,25 @@ class UpgradeModules extends AbstractTask
             return true;
         }
 
+        // add local modules that we want to upgrade to the list
+        $localModules = $this->getLocalModules();
+        if (!empty($localModules)) {
+            foreach($localModules as $currentLocalModule) {
+                $listModules[$currentLocalModule['name']] = [
+                    'id' => $currentLocalModule['id_module'],
+                    'name' => $currentLocalModule['name'],
+                    'is_local' => true,
+                ];
+            }
+        }
+
         // module list
         if (count($listModules) > 0) {
             do {
                 $module_info = array_pop($listModules);
                 try {
                     $this->logger->debug($this->translator->trans('Upgrading module %module%...', ['%module%' => $module_info['name']], 'Modules.Autoupgrade.Admin'));
-                    $this->container->getModuleAdapter()->upgradeModule($module_info['id'], $module_info['name']);
+                    $this->container->getModuleAdapter()->upgradeModule($module_info['id'], $module_info['name'], !empty($module_info['is_local']));
                     $this->logger->debug($this->translator->trans('The files of module %s have been upgraded.', [$module_info['name']], 'Modules.Autoupgrade.Admin'));
                 } catch (UpgradeException $e) {
                     $this->handleException($e);
@@ -90,6 +102,36 @@ class UpgradeModules extends AbstractTask
         }
 
         return true;
+    }
+
+    private function getLocalModules()
+    {
+        $localModuleDir = sprintf(
+            "%s%sautoupgrade%smodules",
+            _PS_ADMIN_DIR_,
+            DIRECTORY_SEPARATOR,
+            DIRECTORY_SEPARATOR
+        );
+
+        $zipFileNames = [];
+
+        $zipFiles = glob($localModuleDir . DIRECTORY_SEPARATOR . '*.zip');
+
+        if (empty($zipFiles)) {
+            return [];
+        }
+
+        foreach ($zipFiles as $zipFile) {
+            $zipFileNames[] = pSQL(pathinfo($zipFile, PATHINFO_FILENAME));
+        }
+
+        $sql = sprintf(
+            "SELECT id_module, name FROM %smodule WHERE name IN ('%s')",
+            _DB_PREFIX_,
+            implode("','", $zipFileNames)
+        );
+
+        return \Db::getInstance()->executeS($sql);
     }
 
     public function warmUp()

--- a/classes/TaskRunner/Upgrade/UpgradeModules.php
+++ b/classes/TaskRunner/Upgrade/UpgradeModules.php
@@ -57,7 +57,7 @@ class UpgradeModules extends AbstractTask
         // add local modules that we want to upgrade to the list
         $localModules = $this->getLocalModules();
         if (!empty($localModules)) {
-            foreach($localModules as $currentLocalModule) {
+            foreach ($localModules as $currentLocalModule) {
                 $listModules[$currentLocalModule['name']] = [
                     'id' => $currentLocalModule['id_module'],
                     'name' => $currentLocalModule['name'],
@@ -113,10 +113,10 @@ class UpgradeModules extends AbstractTask
     private function getLocalModules()
     {
         $localModuleDir = sprintf(
-            "%s%sautoupgrade%smodules",
+            '%s%sautoupgrade%smodules',
             _PS_ADMIN_DIR_,
             DIRECTORY_SEPARATOR,
-            DIRECTORY_SEPARATOR,
+            DIRECTORY_SEPARATOR
         );
 
         $zipFileNames = [];

--- a/classes/TaskRunner/Upgrade/UpgradeModules.php
+++ b/classes/TaskRunner/Upgrade/UpgradeModules.php
@@ -116,7 +116,7 @@ class UpgradeModules extends AbstractTask
             "%s%sautoupgrade%smodules",
             _PS_ADMIN_DIR_,
             DIRECTORY_SEPARATOR,
-            DIRECTORY_SEPARATOR
+            DIRECTORY_SEPARATOR,
         );
 
         $zipFileNames = [];

--- a/classes/UpgradeTools/ModuleAdapter.php
+++ b/classes/UpgradeTools/ModuleAdapter.php
@@ -179,20 +179,22 @@ class ModuleAdapter
      *
      * @param int $id
      * @param string $name
+     * @param bool $isLocalModule
      */
-    public function upgradeModule($id, $name)
+    public function upgradeModule($id, $name, $isLocalModule = false)
     {
         $zip_fullpath = $this->tempPath . DIRECTORY_SEPARATOR . $name . '.zip';
-
-        $local_module_zip = $this->getLocalModuleZip($name);
         $local_module_used = false;
 
-        if (null !== $local_module_zip) {
+        if ($isLocalModule) {
             try {
-                $filesystem = new Filesystem();
-                $filesystem->copy($local_module_zip, $zip_fullpath);
+                $local_module_zip = $this->getLocalModuleZip($name);
+                if (!empty($local_module_zip)) {
+                    $filesystem = new Filesystem();
+                    $filesystem->copy($local_module_zip, $zip_fullpath);
+                    $local_module_used = true;
+                }
 
-                $local_module_used = true;
             } catch (IOException $e) {
                 // Do nothing, we will try to upgrade module from addons
             }

--- a/classes/UpgradeTools/ModuleAdapter.php
+++ b/classes/UpgradeTools/ModuleAdapter.php
@@ -194,7 +194,6 @@ class ModuleAdapter
                     $filesystem->copy($local_module_zip, $zip_fullpath);
                     $local_module_used = true;
                 }
-
             } catch (IOException $e) {
                 // Do nothing, we will try to upgrade module from addons
             }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix local module upgrade mechanism (and improve performance by only checking if the zip exist for modules we want to upgrade locally instead of checking the existence of a zip for all modules that will be upgraded)
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | PrestaShop SA
| How to test?      | Put the zip of a module in admin/autoupgrade/modules, it should be of a version superior to the version currently installed. Do a prestashop upgrade, check that the module has been upgraded according to your zip