### PR TITLE
Fix for #33634  - Prevent overrides being wiped during upgrade to PS8

### DIFF
--- a/classes/UpgradeTools/FileFilter.php
+++ b/classes/UpgradeTools/FileFilter.php
@@ -145,6 +145,10 @@ class FileFilter
             '/app/config/parameters.yml',
             '/install',
             '/install-dev',
+            '/override',
+            '/override/classes',
+            '/override/controllers',
+            '/override/modules'
         ];
 
         // Fetch all existing native modules

--- a/classes/UpgradeTools/FileFilter.php
+++ b/classes/UpgradeTools/FileFilter.php
@@ -148,7 +148,7 @@ class FileFilter
             '/override',
             '/override/classes',
             '/override/controllers',
-            '/override/modules'
+            '/override/modules',
         ];
 
         // Fetch all existing native modules


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Prevent existing overrides from being wiped during upgrade to PS8
| Type?             | bug fix
| BC breaks?        | n/a
| Deprecations?     | n/a
| Fixed ticket?     | Fixes #33634  ( https://github.com/PrestaShop/PrestaShop/issues/33634 )
| How to test?      | Upgrade from PS 1.7.x to PS 8.x having some overrides - compare override folder before / after this PR
