### PR TITLE
Do not check version if not provided

### DIFF
--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -526,6 +526,10 @@ class UpgradeSelfCheck
      */
     public function checkKeyGeneration()
     {
+        if ($this->upgrader->version_num === null) {
+            return true;
+        }
+
         // Check if key is needed on the version we are upgrading to, if lower, not needed
         if (version_compare($this->upgrader->version_num, '8.1.0', '<')) {
             return true;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | See below
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/33886
| Sponsor company   | 
| How to test?      | See ticket

## Description

When the Configuration page of the module is opened, the checklist is being verified. Function [UpgradeSelfCheck::checkKeyGeneration()](https://github.com/PrestaShop/autoupgrade/blob/dev/classes/UpgradeSelfCheck.php#L527) is called but at this moment `$this->upgrader->version_num` is NULL so the use of version_compare [triggers a warning](https://github.com/PrestaShop/PrestaShop/issues/33886).

At the beginning I was worried about `$this->upgrader->version_num` being NULL. But then I explored the code and actually I found that `$this->upgrader->version_num` is set in [UpgradeContainer::getUpgrader()](https://github.com/PrestaShop/autoupgrade/blob/dev/classes/UpgradeContainer.php#L304) and it depends on the channel chosen. The version number variable will be set from different locations if the target version is available on the API, in a file or in a directory. So it makes sense that, when the page is opened, it is not yet set and then it is NULL.

So my solution to avoid the warning is simply not to perform the comparison if `$this->upgrader->version_num` is NULL as this is a valid usecase.