### PR TITLE
Do not escape already escaped translation

### DIFF
--- a/views/templates/block/checklist.twig
+++ b/views/templates/block/checklist.twig
@@ -8,7 +8,7 @@
         {% if not moduleIsUpToDate %}
             <p class="alert alert-warning">
                 {{ 'Your current version of the module is out of date. Update now'|trans({}, 'Modules.Autoupgrade.Admin') }}
-                <a href=" {{ moduleUpdateLink }} ">{{ 'Modules > Module Manager > Updates'|trans({}, 'Modules.Autoupgrade.Admin') }}</a>
+                <a href=" {{ moduleUpdateLink }} ">{{ 'Modules > Module Manager > Updates'|trans({}, 'Modules.Autoupgrade.Admin')|raw }}</a>
             </p>
         {% endif %}
         {% if showErrorMessage %}


### PR DESCRIPTION


<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Use of ```raw``` Twig operator as content is already escaped. If we let Twig escape this, it is double escaped [and does not display correctly.](https://github.com/PrestaShop/PrestaShop/issues/33889)
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/33889
| Sponsor company   | 
| How to test?      | See ticket
