### PR TITLE
Disable 'verify if module is latest' for shops under 1.7.0.0 for 4.14.x and bump version to 4.14.3

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        presta-versions: [ '1.6.1.18', '1.7.6.9', 'latest' ]
+        presta-versions: [ '1.6.1.18', '1.7.6.9', '1.7.8.10' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2.0.0

--- a/autoupgrade.php
+++ b/autoupgrade.php
@@ -31,7 +31,7 @@ class Autoupgrade extends Module
         $this->name = 'autoupgrade';
         $this->tab = 'administration';
         $this->author = 'PrestaShop';
-        $this->version = '4.14.2';
+        $this->version = '4.14.3';
         $this->need_instance = 1;
 
         $this->bootstrap = true;

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -255,8 +255,8 @@ class UpgradeSelfCheck
     {
         $shopCurrentVersion = $this->upgrader->getCurrentPSVersion();
 
-        // For versions under 8.0.0, do not perform the check
-        if (version_compare($shopCurrentVersion, '8.0.0', '<')) {
+        // For versions under 1.7.0.0, do not perform the check
+        if (version_compare($shopCurrentVersion, '1.7.0.0', '<')) {
             return true;
         }
 

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -253,6 +253,13 @@ class UpgradeSelfCheck
      */
     public function isModuleVersionLatest()
     {
+        $shopCurrentVersion = $this->upgrader->getCurrentPSVersion();
+
+        // For versions under 8.0.0, do not perform the check
+        if (version_compare($shopCurrentVersion, '8.0.0', '<')) {
+            return true;
+        }
+
         if (null !== $this->moduleVersionIsLatest) {
             return $this->moduleVersionIsLatest;
         }

--- a/classes/Upgrader.php
+++ b/classes/Upgrader.php
@@ -546,4 +546,12 @@ class Upgrader
 
         return !$this->version_is_modified;
     }
+
+    /**
+     * @return string
+     */
+    public function getCurrentPsVersion()
+    {
+        return $this->currentPsVersion;
+    }
 }

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
   <name>autoupgrade</name>
   <displayName><![CDATA[1-Click Upgrade]]></displayName>
-  <version><![CDATA[4.14.2]]></version>
+  <version><![CDATA[4.14.3]]></version>
   <description><![CDATA[Upgrade to the latest version of PrestaShop in a few clicks, thanks to this automated method.]]></description>
   <author><![CDATA[PrestaShop]]></author>
   <tab><![CDATA[administration]]></tab>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Disable 'verify if module is latest' for shops under 1.7.0.0 for 4.14.x and bump version to 4.14.3
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | 
| How to test?      | See below

## Context

The upgrade module has a feature where it checks whether there is a more recent version of itself and if it does, it tells the user "please use the latest version, you are using an outdated version".

![Capture d’écran 2023-09-08 à 23 09 45](https://github.com/PrestaShop/autoupgrade/assets/3830050/336c544b-0e3c-43b8-a1fb-ee31af7e87ff)

Currently if someone installs the module 4.14.2 on a shop, the module will detect there is a 4.16.3 version and says to user "please don't use me! use the latest 4.16.3 version instead!"

Consequently this PR disables this check, this was a suggestion from @Hlavtox.

## How to test

Create a test autoupgrade release from this PR. Install this test module
- on a shop 1.6.1.24 : you do NOT see the warning `Your current version of the module is out of date. Update now` (because this PR disables the check on versions under 1.7.0.0)
- on a shop 1.7.8.10 : you see the warning `Your current version of the module is out of date. Update now`

> [!IMPORTANT]  
> Did you notice target branch is `4.14.x`? So if you rebase the PR against target branch with `git prc` be careful to select the right branch