### PR TITLE
Fix upgrade inconsistencies

### DIFF
--- a/upgrade/php/drop_column_if_exists.php
+++ b/upgrade/php/drop_column_if_exists.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+function drop_column_if_exists($table, $column)
+{
+    $column_exists = Db::getInstance()->executeS('SHOW COLUMNS FROM `' . _DB_PREFIX_ . $table . "` WHERE Field = '" . $column . "'");
+
+    if (!empty($column_exists)) {
+        Db::getInstance()->execute('ALTER TABLE `' . _DB_PREFIX_ . $table . '` DROP COLUMN `' . $column . '`');
+    }
+}

--- a/upgrade/sql/1.7.7.0.sql
+++ b/upgrade/sql/1.7.7.0.sql
@@ -53,7 +53,7 @@ UPDATE `PREFIX_tab_module_preference` SET `module` = SUBSTRING(`module`, 1, 191)
 ALTER TABLE `PREFIX_tab_module_preference` CHANGE `module` `module` VARCHAR(191) NOT NULL;
 
 UPDATE `PREFIX_smarty_lazy_cache` SET `cache_id` = SUBSTRING(`cache_id`, 1, 191);
-ALTER TABLE `PREFIX_smarty_lazy_cache` CHANGE `cache_id` `cache_id` VARCHAR(191) NOT NULL;
+ALTER TABLE `PREFIX_smarty_lazy_cache` CHANGE `cache_id` `cache_id` VARCHAR(191) NOT NULL DEFAULT '';
 
 /* improve performance of lookup by product reference/product_supplier avoiding full table scan */
 ALTER TABLE PREFIX_product
@@ -357,11 +357,11 @@ INSERT IGNORE INTO `PREFIX_hook_alias` (`name`, `alias`) VALUES
 ALTER TABLE `PREFIX_order_detail` ADD `total_refunded_tax_excl` DECIMAL(20, 6) NOT NULL DEFAULT '0.000000' AFTER `original_wholesale_price`;
 ALTER TABLE `PREFIX_order_detail` ADD `total_refunded_tax_incl` DECIMAL(20, 6) NOT NULL DEFAULT '0.000000' AFTER `total_refunded_tax_excl`;
 
-ALTER TABLE `PREFIX_group_reduction` CHANGE `reduction` `reduction` DECIMAL(5, 4) NOT NULL DEFAULT '0.0000';
-ALTER TABLE `PREFIX_product_group_reduction_cache` CHANGE `reduction` `reduction` DECIMAL(5, 4) NOT NULL DEFAULT '0.0000';
+ALTER TABLE `PREFIX_group_reduction` CHANGE `reduction` `reduction` DECIMAL(5, 4) NOT NULL;
+ALTER TABLE `PREFIX_product_group_reduction_cache` CHANGE `reduction` `reduction` DECIMAL(5, 4) NOT NULL;
 ALTER TABLE `PREFIX_order_slip` CHANGE `amount` `amount` DECIMAL(20, 6) NOT NULL DEFAULT '0.000000';
 ALTER TABLE `PREFIX_order_slip` CHANGE `shipping_cost_amount` `shipping_cost_amount` DECIMAL(20, 6) NOT NULL DEFAULT '0.000000';
-ALTER TABLE `PREFIX_order_payment` CHANGE `amount` `amount` DECIMAL(20, 6) NOT NULL DEFAULT '0.000000';
+ALTER TABLE `PREFIX_order_payment` CHANGE `amount` `amount` DECIMAL(20, 6) NOT NULL;
 
 /* attribute_impact price */
 UPDATE `PREFIX_attribute_impact` SET `price` = RIGHT(`price`, 17) WHERE LENGTH(`price`) > 17;
@@ -400,7 +400,7 @@ ALTER TABLE `PREFIX_order_cart_rule` CHANGE `value` `value` DECIMAL(20, 6) NOT N
 ALTER TABLE `PREFIX_order_cart_rule` CHANGE `value_tax_excl` `value_tax_excl` DECIMAL(20, 6) NOT NULL DEFAULT '0.000000';
 
 /* add deleted field */
-ALTER TABLE `PREFIX_order_cart_rule` ADD `deleted` TINYINT(1) UNSIGNED NOT NULL;
+ALTER TABLE `PREFIX_order_cart_rule` ADD `deleted` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0';
 
 UPDATE
     `PREFIX_order_detail` `od`

--- a/upgrade/sql/1.7.8.0.sql
+++ b/upgrade/sql/1.7.8.0.sql
@@ -150,9 +150,9 @@ ALTER TABLE `PREFIX_currency` CHANGE `numeric_iso_code` `numeric_iso_code` varch
 
 UPDATE `PREFIX_configuration` SET `value` = '4' WHERE `name` = 'PS_LOGS_BY_EMAIL' AND `value` = '5';
 ALTER TABLE `PREFIX_log`
-  ADD `id_shop` INT(10) NULL DEFAULT NULL after `object_id`,
-  ADD `id_shop_group` INT(10) NULL DEFAULT NULL after `id_shop`,
-  ADD `id_lang` INT(10) NULL DEFAULT NULL after `id_shop_group`,
+  ADD `id_shop` INT(10) unsigned DEFAULT NULL after `object_id`,
+  ADD `id_shop_group` INT(10) unsigned DEFAULT NULL after `id_shop`,
+  ADD `id_lang` INT(10) unsigned DEFAULT NULL after `id_shop_group`,
   ADD `in_all_shops` TINYINT(1) unsigned NOT NULL DEFAULT '0'
 ;
 

--- a/upgrade/sql/8.0.0.sql
+++ b/upgrade/sql/8.0.0.sql
@@ -231,3 +231,7 @@ INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VAL
 UPDATE `PREFIX_carrier` SET `name` = 'Click and collect' WHERE `name` = '0';
 
 /* PHP:install_ps_distributionapiclient(); */;
+
+/* Remove deprecated columns */
+/* PHP:drop_column_if_exists('product_attribute', 'location'); */;
+/* PHP:drop_column_if_exists('product_attribute', 'quantity'); */;

--- a/upgrade/sql/8.1.0.sql
+++ b/upgrade/sql/8.1.0.sql
@@ -26,8 +26,8 @@ INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VAL
 CREATE TABLE `PREFIX_product_attribute_lang` (
   `id_product_attribute` int(10) unsigned NOT NULL,
   `id_lang` int(10) unsigned NOT NULL,
-  `available_now` varchar(255) COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
-  `available_later` varchar(255) COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  `available_now` varchar(255) COLLATE utf8mb4_general_ci DEFAULT NULL,
+  `available_later` varchar(255) COLLATE utf8mb4_general_ci DEFAULT NULL,
   PRIMARY KEY (`id_product_attribute`, `id_lang`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
@@ -65,7 +65,7 @@ VALUES
     ('multiple_image_format', 0, 'Multiple image formats', 'Admin.Advparameters.Feature', 'Enable / Disable having more than one image format (jpg, webp, avif, png...)', 'Admin.Advparameters.Help', 'stable');
 
 ALTER TABLE `PREFIX_stock_mvt` CHANGE `employee_lastname` `employee_lastname` VARCHAR(255) DEFAULT NULL, CHANGE `employee_firstname` `employee_firstname` VARCHAR(255) DEFAULT NULL;
-ALTER TABLE `PREFIX_stock_mvt` CHANGE `physical_quantity` `physical_quantity` INT(11) UNSIGNED NOT NULL;
+ALTER TABLE `PREFIX_stock_mvt` CHANGE `physical_quantity` `physical_quantity` INT(10) UNSIGNED NOT NULL;
 
 /* PHP:add_hook('actionAdminBreadcrumbModifier', 'Modify back office breadcrumb', 'This hook allows modifying back office breadcrumb'); */;
 

--- a/upgrade/sql/8.1.2.sql
+++ b/upgrade/sql/8.1.2.sql
@@ -13,3 +13,18 @@ UPDATE `PREFIX_tab` SET wording_domain = 'Admin.Navigation.Menu', wording = 'Cus
 INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES
   (NULL, 'actionLanguageLinkParameters', 'Add parameters to language link', 'Allows modules to provide proper parameters for links in other languages.', '1'),
   (NULL, 'actionAfterLoadRoutes', 'Triggers after loading routes', 'Allow modules to modify routes in any way or add their own multilanguage routes.', '1');
+
+/* We fixed some issues in older upgrade scripts. These are here to fix stores that have been upgraded in the meantime. */
+/* PHP:drop_column_if_exists('product_attribute', 'location'); */;
+/* PHP:drop_column_if_exists('product_attribute', 'quantity'); */;
+ALTER TABLE `PREFIX_smarty_lazy_cache` CHANGE `cache_id` `cache_id` VARCHAR(191) NOT NULL DEFAULT '';
+ALTER TABLE `PREFIX_log` CHANGE `id_shop` `id_shop` INT(10) unsigned DEFAULT NULL;
+ALTER TABLE `PREFIX_log` CHANGE `id_shop_group` `id_shop_group` INT(10) unsigned DEFAULT NULL;
+ALTER TABLE `PREFIX_log` CHANGE `id_lang` `id_lang` INT(10) unsigned DEFAULT NULL;
+ALTER TABLE `PREFIX_product_attribute_lang` CHANGE `available_now` `available_now` VARCHAR(255) DEFAULT NULL;
+ALTER TABLE `PREFIX_product_attribute_lang` CHANGE `available_later` `available_later` VARCHAR(255) DEFAULT NULL;
+ALTER TABLE `PREFIX_order_cart_rule` CHANGE `deleted` `deleted` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0';
+ALTER TABLE `PREFIX_product_group_reduction_cache` CHANGE `reduction` `reduction` DECIMAL(5, 4) NOT NULL;
+ALTER TABLE `PREFIX_stock_mvt` CHANGE `physical_quantity` `physical_quantity` INT(10) UNSIGNED NOT NULL;
+ALTER TABLE `PREFIX_group_reduction` CHANGE `reduction` `reduction` DECIMAL(5, 4) NOT NULL;
+ALTER TABLE `PREFIX_order_payment` CHANGE `amount` `amount` DECIMAL(20, 6) NOT NULL;


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fixes some database incosistencies on upgraded installs found in https://github.com/PrestaShop/PrestaShop/issues/33483. The differences do not necessarily mean something doesn't work, but removes the chance of biting us back with it. I fixed the things for both the original upgrade scripts AND 8.1.2, so we fix users that already upgraded.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #https://github.com/PrestaShop/PrestaShop/issues/33483 partially
| Sponsor company   | 
| How to test?      | Tests green + run the queries in 8.1.2.sql manually. Make sure to put `SET SESSION sql_mode='';` to the beginning, or you will get an error 1067 because of bad default value in `PREFIX_smarty_lazy_cache`.
