### PR TITLE
Change the APE field validation to match all formats

### DIFF
--- a/upgrade/sql/8.1.3.sql
+++ b/upgrade/sql/8.1.3.sql
@@ -1,0 +1,5 @@
+SET SESSION sql_mode='';
+SET NAMES 'utf8mb4';
+
+ALTER TABLE co_customer 
+	CHANGE `ape` `ape` varchar(6) DEFAULT NULL;

--- a/upgrade/sql/8.1.3.sql
+++ b/upgrade/sql/8.1.3.sql
@@ -1,5 +1,5 @@
 SET SESSION sql_mode='';
 SET NAMES 'utf8mb4';
 
-ALTER TABLE co_customer 
+ALTER TABLE `PREFIX_customer` 
 	CHANGE `ape` `ape` varchar(6) DEFAULT NULL;


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      |  This PR is linked to PR [34242](https://github.com/PrestaShop/PrestaShop/pull/34242). It just update the PREFIX_customer.ape field from varchar(5) to varchar(6) to match all french APE code formats. I hope I haven't forgotten anything.
| Type?             |  improvement 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes for PR [34242](https://github.com/PrestaShop/PrestaShop/pull/34242), Fixes for issue [34216](https://github.com/PrestaShop/PrestaShop/discussions/34216)
| Sponsor company   | coquille.fr
| How to test?      | The ape field in  PREFIX_customer table should be varchar(6) after upgrade.
