### PR TITLE
Avoid warning for passing null as 2nd parameter of ZipArchive::open

### DIFF
--- a/classes/ZipAction.php
+++ b/classes/ZipAction.php
@@ -247,7 +247,7 @@ class ZipAction
     private function open($zipFile, $flags = null)
     {
         $zip = new \ZipArchive();
-        if ($zip->open($zipFile, $flags) !== true || empty($zip->filename)) {
+        if ($zip->open($zipFile, $flags ?? 0) !== true || empty($zip->filename)) {
             $this->logger->error($this->translator->trans('Unable to open zipFile %s', [$zipFile], 'Modules.Autoupgrade.Admin'));
 
             return false;

--- a/classes/ZipAction.php
+++ b/classes/ZipAction.php
@@ -247,7 +247,10 @@ class ZipAction
     private function open($zipFile, $flags = null)
     {
         $zip = new \ZipArchive();
-        if ($zip->open($zipFile, $flags ?? 0) !== true || empty($zip->filename)) {
+        if (null === $flags) {
+            $flags = 0;
+        }
+        if ($zip->open($zipFile, $flags) !== true || empty($zip->filename)) {
             $this->logger->error($this->translator->trans('Unable to open zipFile %s', [$zipFile], 'Modules.Autoupgrade.Admin'));
 
             return false;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | See below
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | -
| How to test?      | Make an upgrade with given zip file on php8.1 installation




## Bug description


https://github.com/PrestaShop/autoupgrade/assets/7426640/9c5e13d6-fd36-4db6-8442-69244f31cd20


https://github.com/PrestaShop/autoupgrade/assets/7426640/72b97a04-a1fc-433d-8f31-af7a968f2ad0

The definition of ZipArchive::open changed between php 7 and php8
Passing null as 2nd parameter results on a Warning


PHP 7 => https://durak.org/sean/pubs/software/php-7.4.3/ziparchive.open.html

PHP 8 => https://www.php.net/manual/en/ziparchive.open.php


