### PR TITLE
Show which file was trying to be closed when error on close

### DIFF
--- a/classes/ZipAction.php
+++ b/classes/ZipAction.php
@@ -110,8 +110,8 @@ class ZipAction
 
         if (!$zip->close()) {
             $this->logger->error($this->translator->trans(
-                'Could not close the Zip file properly. Check you are allowed to write on the disk and there is available space on it.',
-                [],
+                'Could not close the Zip file: %toFile% properly. Check you are allowed to write on the disk and there is available space on it.',
+                ['%toFile%' => $toFile],
                 'Modules.Autoupgrade.Admin'
             ));
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When backup zip file closing fails, show which zip file was trying to be closed
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | 
| How to test?      | try to fail zip close to see the new message. <br />Before it was just `ERROR - Could not close the Zip file properly. Check you are allowed to write on the disk and there is available space on it.` <br />now it is `ERROR - Could not close the Zip file: /path/to/admin-dev/autoupgrade/backup/auto-backupfiles_V8.0.5_20231110-142932-5b1cebf4.zip properly. Check you are allowed to write on the disk and there is available space on it.`
