### PR TITLE
Add primary key to DB table accessory and fix duplicates

### DIFF
--- a/upgrade/sql/8.1.3.sql
+++ b/upgrade/sql/8.1.3.sql
@@ -18,3 +18,9 @@ ALTER TABLE `PREFIX_product_group_reduction_cache` CHANGE `reduction` `reduction
 ALTER TABLE `PREFIX_stock_mvt` CHANGE `physical_quantity` `physical_quantity` INT(10) UNSIGNED NOT NULL;
 ALTER TABLE `PREFIX_group_reduction` CHANGE `reduction` `reduction` DECIMAL(5, 4) NOT NULL;
 ALTER TABLE `PREFIX_order_payment` CHANGE `amount` `amount` DECIMAL(20, 6) NOT NULL;
+
+/* Fixing duplicates for table "accessory" where can be duplicate records from older version of PrestaShop, because of missing PRIMARY index */
+CREATE TABLE `PREFIX_accessory_tmp` SELECT DISTINCT `id_product_1`, `id_product_2` FROM `PREFIX_accessory`;
+ALTER TABLE `PREFIX_accessory_tmp` ADD PRIMARY KEY (`id_product_1`, `id_product_2`);
+DROP TABLE `PREFIX_accessory`;
+RENAME TABLE `PREFIX_accessory_tmp` TO `PREFIX_accessory`;


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Related to PR #54530 (https://github.com/PrestaShop/PrestaShop/pull/34530). Problem is, there is missing PRIMARY key, so, from older PrestaShop version there can be duplicate rows, so we must "repair" this duplicate rows and set PRIMARY key then.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #30022 (https://github.com/PrestaShop/PrestaShop/issues/30022)
| Sponsor company   | https://www.openservis.cz/
| How to test?      | 
