### PR TITLE
Clean non existent addresses in DB table cart

### DIFF
--- a/upgrade/sql/9.0.0.sql
+++ b/upgrade/sql/9.0.0.sql
@@ -13,3 +13,6 @@ ALTER TABLE `PREFIX_feature_flag` ADD `type` VARCHAR(64) DEFAULT 'env,dotenv,db'
 
 /* Increase size of customized data - https://github.com/PrestaShop/PrestaShop/pull/31109 */
 ALTER TABLE `PREFIX_customized_data` MODIFY `value` varchar(1024) NOT NULL;
+
+DELETE FROM `PREFIX_cart` WHERE id_address_delivery NOT IN (SELECT id_address FROM `PREFIX_address`);
+DELETE FROM `PREFIX_cart` WHERE id_address_invoice NOT IN (SELECT id_address FROM `PREFIX_address`);

--- a/upgrade/sql/9.0.0.sql
+++ b/upgrade/sql/9.0.0.sql
@@ -14,5 +14,6 @@ ALTER TABLE `PREFIX_feature_flag` ADD `type` VARCHAR(64) DEFAULT 'env,dotenv,db'
 /* Increase size of customized data - https://github.com/PrestaShop/PrestaShop/pull/31109 */
 ALTER TABLE `PREFIX_customized_data` MODIFY `value` varchar(1024) NOT NULL;
 
-DELETE FROM `PREFIX_cart` WHERE id_address_delivery > 0 && id_address_delivery NOT IN (SELECT id_address FROM `PREFIX_address`);
-DELETE FROM `PREFIX_cart` WHERE id_address_invoice > 0 && id_address_invoice NOT IN (SELECT id_address FROM `PREFIX_address`);
+DELETE FROM `PREFIX_cart` WHERE `id_address_delivery` > 0 && id_address_delivery` NOT IN (SELECT `id_address` FROM `PREFIX_address`);
+DELETE FROM `PREFIX_cart` WHERE `id_address_invoice` > 0 && `id_address_invoice` NOT IN (SELECT `id_address` FROM `PREFIX_address`);
+DELETE FROM `PREFIX_cart_product` WHERE `id_cart` NOT IN (SELECT `id_cart` FROM `PREFIX_cart`);

--- a/upgrade/sql/9.0.0.sql
+++ b/upgrade/sql/9.0.0.sql
@@ -14,5 +14,5 @@ ALTER TABLE `PREFIX_feature_flag` ADD `type` VARCHAR(64) DEFAULT 'env,dotenv,db'
 /* Increase size of customized data - https://github.com/PrestaShop/PrestaShop/pull/31109 */
 ALTER TABLE `PREFIX_customized_data` MODIFY `value` varchar(1024) NOT NULL;
 
-DELETE FROM `PREFIX_cart` WHERE id_address_delivery NOT IN (SELECT id_address FROM `PREFIX_address`);
-DELETE FROM `PREFIX_cart` WHERE id_address_invoice NOT IN (SELECT id_address FROM `PREFIX_address`);
+DELETE FROM `PREFIX_cart` WHERE id_address_delivery > 0 && id_address_delivery NOT IN (SELECT id_address FROM `PREFIX_address`);
+DELETE FROM `PREFIX_cart` WHERE id_address_invoice > 0 && id_address_invoice NOT IN (SELECT id_address FROM `PREFIX_address`);

--- a/upgrade/sql/9.0.0.sql
+++ b/upgrade/sql/9.0.0.sql
@@ -14,6 +14,6 @@ ALTER TABLE `PREFIX_feature_flag` ADD `type` VARCHAR(64) DEFAULT 'env,dotenv,db'
 /* Increase size of customized data - https://github.com/PrestaShop/PrestaShop/pull/31109 */
 ALTER TABLE `PREFIX_customized_data` MODIFY `value` varchar(1024) NOT NULL;
 
-DELETE FROM `PREFIX_cart` WHERE `id_address_delivery` > 0 && id_address_delivery` NOT IN (SELECT `id_address` FROM `PREFIX_address`);
+DELETE FROM `PREFIX_cart` WHERE `id_address_delivery` > 0 && `id_address_delivery` NOT IN (SELECT `id_address` FROM `PREFIX_address`);
 DELETE FROM `PREFIX_cart` WHERE `id_address_invoice` > 0 && `id_address_invoice` NOT IN (SELECT `id_address` FROM `PREFIX_address`);
 DELETE FROM `PREFIX_cart_product` WHERE `id_cart` NOT IN (SELECT `id_cart` FROM `PREFIX_cart`);


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Time to time accidentaly and magically appears in DB table "cart" (column _id_address_invoice_/_id_address_delivery_) any record, what isn't exists in DB table "address" (column _id_address_). It show error 500 in section "Shopping Carts" and it's unusable becouse of error. **We should use next major version PS 9.0.0 like good starting point for cleaning old database inconsistency.**
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #34510 (and other similar issues)
| Sponsor company   | https://www.openservis.cz/
| How to test?      | 


![500Ka cart ](https://github.com/PrestaShop/autoupgrade/assets/8518736/43c3257b-dd46-4da4-be49-f8e6951318bd)



