### PR TITLE
Fix missing files from folders containing install

### DIFF
--- a/classes/TaskRunner/Upgrade/UpgradeFiles.php
+++ b/classes/TaskRunner/Upgrade/UpgradeFiles.php
@@ -119,7 +119,7 @@ class UpgradeFiles extends AbstractTask
                 continue;
             }
             $list[] = str_replace($this->container->getProperty(UpgradeContainer::LATEST_PATH), '', $fullPath);
-            if (is_dir($fullPath) && strpos($dir . DIRECTORY_SEPARATOR . $file, 'install') === false) {
+            if (is_dir($fullPath)) {
                 $list = array_merge($list, $this->listFilesToUpgrade($fullPath));
             }
         }


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This fixes a mystery of missing files. See below.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/34385 (partially, don't close)
| Sponsor company   | 
| How to test?      | Upgrade from 1.7.6.9 to 8.1.2 and check that these files are no longer missing or non-updated.

### How I fixed this
- I extracted latest 8.1.2 code into `admin/autoupgrade/latest`.
- I opened up AdminSelfUpgrade and constructed the class for loading files to upgrade manually.
```
$fileUpgrader = new PrestaShop\Module\AutoUpgrade\TaskRunner\Upgrade\UpgradeFiles($this->upgradeContainer);
$fileUpgrader->warmUp();
```
- I dumped the result of `listFilesToUpgrade()` in that method and found out that the files I from the related issue are missing from the list due to an old forgotten condition `strpos($dir . DIRECTORY_SEPARATOR . $file, 'install') === false`.
- This condition is not needed, because all the exclusions are already handled by a much more sophisticated condition few lines above, `isFileSkipped`.
- Result - install and install-dev still skipped and other things with install in their paths are there.

![Snímek obrazovky 2023-11-16 181137](https://github.com/PrestaShop/autoupgrade/assets/6097524/d1a7b9ce-c2f7-4b74-86f1-ea8259b7ad03)
