### PR TITLE
Fill sessions with data after adding the column

### DIFF
--- a/upgrade/sql/8.0.0.sql
+++ b/upgrade/sql/8.0.0.sql
@@ -178,8 +178,10 @@ INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `po
 
 ALTER TABLE `PREFIX_employee_session` ADD `date_upd` DATETIME NOT NULL AFTER `token`;
 ALTER TABLE `PREFIX_employee_session` ADD `date_add` DATETIME NOT NULL AFTER `date_upd`;
+UPDATE `PREFIX_employee_session` SET `date_add` = NOW(), `date_upd` = NOW();
 ALTER TABLE `PREFIX_customer_session` ADD `date_upd` DATETIME NOT NULL AFTER `token`;
 ALTER TABLE `PREFIX_customer_session` ADD `date_add` DATETIME NOT NULL AFTER `date_upd`;
+UPDATE `PREFIX_customer_session` SET `date_add` = NOW(), `date_upd` = NOW();
 
 ALTER TABLE `PREFIX_carrier` DROP COLUMN `id_tax_rules_group`;
 


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The script doesn't fill new session columns with data, resulting in an error sometimes. This fills it.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #https://github.com/PrestaShop/autoupgrade/pull/652#issuecomment-1824717816
| Sponsor company   | 
| How to test?      | Upgrade from 1.7.6.9 to 8.1.2, directly after upgrade, open phpmyadmin and check that there won't be an empty `date_add` and `date_upd` in `ps_employee_session`.