### PR TITLE
Fix getPrestaShopVersion on 8.1

### DIFF
--- a/classes/PrestashopConfiguration.php
+++ b/classes/PrestashopConfiguration.php
@@ -76,6 +76,7 @@ class PrestashopConfiguration
             $this->psRootDir . '/config/settings.inc.php',
             $this->psRootDir . '/config/autoload.php',
             $this->psRootDir . '/app/AppKernel.php',
+            $this->psRootDir . '/src/Core/Version.php',
         ];
         foreach ($files as $file) {
             if (!file_exists($file)) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Get PrestaShop 8.1 version
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | WEB AREA
| How to test?      | on PrestaShop 8.1


On PrestaShop 8.1 the version number has been moved to `/src/Core/Version.php`

See https://github.com/PrestaShop/PrestaShop/blob/8.1.x/src/Core/Version.php#L35