### PR TITLE
Check if function get_magic_quotes_gpc() exists before use it

### DIFF
--- a/classes/UpgradeTools/Translation.php
+++ b/classes/UpgradeTools/Translation.php
@@ -172,7 +172,7 @@ class Translation
         }
         fwrite($fd, "<?php\n\nglobal \$" . $var_name . ";\n\$" . $var_name . " = array();\n");
         foreach ($merge as $k => $v) {
-            if (get_magic_quotes_gpc()) {
+            if (function_exists('get_magic_quotes_gpc') && get_magic_quotes_gpc()) {
                 $v = stripslashes($v);
             }
             if ('mail' == $type) {

--- a/classes/UpgradeTools/Translation.php
+++ b/classes/UpgradeTools/Translation.php
@@ -172,9 +172,6 @@ class Translation
         }
         fwrite($fd, "<?php\n\nglobal \$" . $var_name . ";\n\$" . $var_name . " = array();\n");
         foreach ($merge as $k => $v) {
-            if (function_exists('get_magic_quotes_gpc') && get_magic_quotes_gpc()) {
-                $v = stripslashes($v);
-            }
             if ('mail' == $type) {
                 fwrite($fd, '$' . $var_name . '[\'' . $this->escape($k) . '\'] = \'' . $this->escape($v) . '\';' . "\n");
             } else {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Check if function get_magic_quotes_gpc() exists before use it. This function was DEPRECATED in PHP 7.4 and REMOVED in PHP 8.0
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | yes
| Fixed ticket?     | Fixes #{[Prestashop/Prestashop#34988](https://github.com/PrestaShop/PrestaShop/issues/34988)}
| Sponsor company   | 
| How to test?      | Run upgrade and check if it ran correctly
--



