### PR TITLE
Add missing hooks

### DIFF
--- a/upgrade/sql/8.1.4.sql
+++ b/upgrade/sql/8.1.4.sql
@@ -1,0 +1,10 @@
+SET SESSION sql_mode='';
+SET NAMES 'utf8mb4';
+
+/* Adds missing hook entries that have been added to 8.1.4 installer. */
+INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES
+  (NULL, 'actionSubmitAccountBefore', 'Triggers before customer registers', 'Triggers after submitting registration form, before the registration process itself. Allows to modify result of this action.', '1'),
+  (NULL, 'actionAuthenticationBefore', 'Triggers before customer logs in', 'Triggers after successful validation of login form, before the login process itself.', '1'),
+  (NULL, 'actionCartUpdateQuantityBefore', 'Triggers before product is added to cart', 'Allows responding to add to cart events.', '1'),
+  (NULL, 'actionAjaxDieBefore', 'Triggers when returning AJAX response', 'Allows to modify AJAX response of controllers using ajaxRender method.', '1');
+  


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | There are several issues when there is an alias for a hook, but this module is not present in the database. It should be fixed in the core probably, but this mitigates the issue. Related to https://github.com/PrestaShop/PrestaShop/pull/35215.
| Type?             | refactor
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | 
| How to test?      | Run these queries in phpmyadmin, replace PREFIX_hook with your prefix.
