### PR TITLE
feat(configuration): added default configuration value for category b…

### DIFF
--- a/upgrade/sql/9.0.0.sql
+++ b/upgrade/sql/9.0.0.sql
@@ -3,7 +3,8 @@ SET NAMES 'utf8mb4';
 
 INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES
   ('PS_DEBUG_COOKIE_NAME', '', NOW(), NOW()),
-  ('PS_DEBUG_COOKIE_VALUE', '', NOW(), NOW())
+  ('PS_DEBUG_COOKIE_VALUE', '', NOW(), NOW()),
+  ('PS_PRODUCT_BREADCRUMB_CATEGORY', 'default', NOW(), NOW())
 ;
 
 INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES


### PR DESCRIPTION
If the product is accessed from another category than product default category, it will generate the breadcrumb according to current category.

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | By default, product breadcrumb is generated by using product default category. With this feature, if a category is stored on the product controller and assigned to the viewed product, the breadcrumb will be generated accordingly. 
| Type?             | improvement 
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket? | 
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/30546
| How to test?      | Upgrade to 9.0.0 branch or run the query manually.