### PR TITLE
Set authorization_server feature flag true by default

### DIFF
--- a/upgrade/sql/9.0.0.sql
+++ b/upgrade/sql/9.0.0.sql
@@ -16,6 +16,8 @@ INSERT INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`
 ON DUPLICATE KEY UPDATE `title` = VALUES(`title`), `description` = VALUES(`description`);
 
 ALTER TABLE `PREFIX_feature_flag` ADD `type` VARCHAR(64) DEFAULT 'env,dotenv,db' NOT NULL AFTER `name`;
+UPDATE `PREFIX_feature_flag` SET `state` = 1 WHERE `name` = 'authorization_server';
+UPDATE `PREFIX_tab` SET `active` = 1 WHERE `class_name` = 'AdminAuthorizationServer';
 
 /* Increase size of customized data - https://github.com/PrestaShop/PrestaShop/pull/31109 */
 ALTER TABLE `PREFIX_customized_data` MODIFY `value` varchar(1024) NOT NULL;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Set authorization_server feature true by default
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     |  no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/34852
| Sponsor company   | -
| How to test?      |after an upgrade to v9, ensure the authorization_server feature flag is true by default
