### PR TITLE
Add sql queries to add new date_new field 

### DIFF
--- a/upgrade/sql/9.0.0.sql
+++ b/upgrade/sql/9.0.0.sql
@@ -84,3 +84,7 @@ DELETE FROM `PREFIX_tab` WHERE `class_name` = 'AdminStockCover';
 DELETE FROM `PREFIX_tab` WHERE `class_name` = 'AdminSupplyOrders';
 DELETE FROM `PREFIX_tab` WHERE `class_name` = 'AdminStockConfiguration';
 DELETE FROM `PREFIX_tab_lang` WHERE `id_tab` NOT IN (SELECT id_tab FROM `PREFIX_tab`);
+
+/* Add new date_new field on product table and give the value of date_add */
+ALTER TABLE `PREFIX_product` ADD `date_new` DATETIME NOT NULL DEFAULT '1970-01-01 00:00:00' AFTER `date_add`;
+UPDATE `PREFIX_product` SET `date_new` = `date_add`;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add new date_new field on product table, and set its value as the one of date_add field
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | PrestaShop SA
| How to test?      | to be tested with https://github.com/PrestaShop/PrestaShop/pull/35645

This PR should not be merged for now.