### PR TITLE
Add a failsafe require and add first working version of 1.7 in automatic tests

### DIFF
--- a/.github/action.yml
+++ b/.github/action.yml
@@ -3,10 +3,34 @@ description: Test PrestaShop upgrade process
 runs:
   using: composite
   steps:
+    - name: Get base version
+      shell: bash
+      run: |
+        case ${{ matrix.from }} in
+          1.6* | 1.7.[1-4]*)
+          export BASE_VERSION='7.1-apache'
+          ;;
+          1.7.[5-6]*)
+          export BASE_VERSION='7.2-apache'
+          ;;
+          1.7.7*)
+          export BASE_VERSION='7.3-apache'
+          ;;
+          1.7.8*)
+          export BASE_VERSION='7.4-apache'
+          ;;
+          8.0* | 8.1*)
+          export BASE_VERSION='8.1-apache'
+          ;;
+          *)
+          export BASE_VERSION='7.1-apache' 
+          ;;
+        esac
+
     - name: Build docker compose stack
       env:
         VERSION: ${{ matrix.from }}
-        BASE_VERSION: ${{ startsWith(matrix.from, '1.6') && '7.1-apache' || startsWith(matrix.from, '8.1') && '8.1-apache' || startsWith(matrix.from, '8.0') && '8.1-apache' || '7.2-apache' }}
+        BASE_VERSION: ${{ env.BASE_VERSION }}
       shell: bash
       run: |
         docker compose up -d

--- a/.github/action.yml
+++ b/.github/action.yml
@@ -4,33 +4,34 @@ runs:
   using: composite
   steps:
     - name: Get base version
+      id: get_base_version
       shell: bash
       run: |
         case ${{ matrix.from }} in
           1.6* | 1.7.[1-4]*)
-          export BASE_VERSION='7.1-apache'
+          echo "BASE_VERSION='7.1-apache" >> "$GITHUB_OUTPUT"
           ;;
           1.7.[5-6]*)
-          export BASE_VERSION='7.2-apache'
+          echo "BASE_VERSION='7.2-apache" >> "$GITHUB_OUTPUT"
           ;;
           1.7.7*)
-          export BASE_VERSION='7.3-apache'
+          echo "BASE_VERSION='7.3-apache" >> "$GITHUB_OUTPUT"
           ;;
           1.7.8*)
-          export BASE_VERSION='7.4-apache'
+          echo "BASE_VERSION='7.4-apache" >> "$GITHUB_OUTPUT"
           ;;
           8.0* | 8.1*)
-          export BASE_VERSION='8.1-apache'
+          echo "BASE_VERSION='8.1-apache" >> "$GITHUB_OUTPUT"
           ;;
           *)
-          export BASE_VERSION='7.1-apache' 
+          echo "BASE_VERSION='7.1-apache" >> "$GITHUB_OUTPUT"
           ;;
         esac
 
     - name: Build docker compose stack
       env:
         VERSION: ${{ matrix.from }}
-        BASE_VERSION: ${{ env.BASE_VERSION }}
+        BASE_VERSION: ${{ steps.get_base_version.outputs.BASE_VERSION }}
       shell: bash
       run: |
         docker compose up -d

--- a/.github/action.yml
+++ b/.github/action.yml
@@ -9,22 +9,22 @@ runs:
       run: |
         case ${{ matrix.from }} in
           1.6* | 1.7.[1-4]*)
-          echo "BASE_VERSION='7.1-apache" >> "$GITHUB_OUTPUT"
+          echo "BASE_VERSION=7.1-apache" >> "$GITHUB_OUTPUT"
           ;;
           1.7.[5-6]*)
-          echo "BASE_VERSION='7.2-apache" >> "$GITHUB_OUTPUT"
+          echo "BASE_VERSION=7.2-apache" >> "$GITHUB_OUTPUT"
           ;;
           1.7.7*)
-          echo "BASE_VERSION='7.3-apache" >> "$GITHUB_OUTPUT"
+          echo "BASE_VERSION=7.3-apache" >> "$GITHUB_OUTPUT"
           ;;
           1.7.8*)
-          echo "BASE_VERSION='7.4-apache" >> "$GITHUB_OUTPUT"
+          echo "BASE_VERSION=7.4-apache" >> "$GITHUB_OUTPUT"
           ;;
           8.0* | 8.1*)
-          echo "BASE_VERSION='8.1-apache" >> "$GITHUB_OUTPUT"
+          echo "BASE_VERSION=8.1-apache" >> "$GITHUB_OUTPUT"
           ;;
           *)
-          echo "BASE_VERSION='7.1-apache" >> "$GITHUB_OUTPUT"
+          echo "BASE_VERSION=7.1-apache" >> "$GITHUB_OUTPUT"
           ;;
         esac
 

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -7,7 +7,7 @@ jobs:
   upgrade:
     strategy:
       matrix:
-        from: ['1.7.1.0', '1.7.6.9', '1.7.6.1', '1.7.7.0', '8.0.0', '8.1.0']
+        from: ['1.7.0.1', '1.7.1.0', '1.7.6.9', '1.7.6.1', '1.7.7.0', '8.0.0', '8.1.0']
         ps-versions:
           - channel: minor
           - channel: major

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -7,7 +7,7 @@ jobs:
   upgrade:
     strategy:
       matrix:
-        from: ['1.7.0.1', '1.7.1.0', '1.7.6.9', '1.7.6.1', '1.7.7.0', '8.0.0', '8.1.0']
+        from: ['1.7.0.6', '1.7.6.9', '1.7.6.1', '1.7.7.0', '8.0.0', '8.1.0']
         ps-versions:
           - channel: minor
           - channel: major

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -7,7 +7,7 @@ jobs:
   upgrade:
     strategy:
       matrix:
-        from: ['1.7.6.9', '1.7.6.1', '1.7.7.0', '8.0.0', '8.1.0']
+        from: ['1.7.1.0', '1.7.6.9', '1.7.6.1', '1.7.7.0', '8.0.0', '8.1.0']
         ps-versions:
           - channel: minor
           - channel: major

--- a/classes/UpgradeTools/SymfonyAdapter.php
+++ b/classes/UpgradeTools/SymfonyAdapter.php
@@ -69,14 +69,14 @@ class SymfonyAdapter
     {
         global $kernel;
         if (!$kernel instanceof \AppKernel) {
-
+            // Only necessary one version before 1.7.3 because he is not classmaped on composer
+            require_once _PS_ROOT_DIR_ . '/app/AppKernel.php';
             $env = (true == _PS_MODE_DEV_) ? 'dev' : 'prod';
 
-            if ($this->isAppKernelAbstract()) { // From version 9 the AppKernel becomes an abstract so we need to check if it is one to know which Kernel to use
-                require_once _PS_ROOT_DIR_ . '/app/AdminKernel.php';
+            // From version 9 the AppKernel becomes an abstract so we need to check if it is one to know which Kernel to use
+            if ($this->isAppKernelAbstract()) {
                 $kernelClass = 'AdminKernel';
             } else {
-                require_once _PS_ROOT_DIR_ . '/app/AppKernel.php';
                 $kernelClass = 'AppKernel';
             }
 

--- a/classes/UpgradeTools/SymfonyAdapter.php
+++ b/classes/UpgradeTools/SymfonyAdapter.php
@@ -69,7 +69,6 @@ class SymfonyAdapter
     {
         global $kernel;
         if (!$kernel instanceof \AppKernel) {
-            require_once _PS_ROOT_DIR_ . '/app/AppKernel.php';
 
             $env = (true == _PS_MODE_DEV_) ? 'dev' : 'prod';
 
@@ -77,6 +76,7 @@ class SymfonyAdapter
                 require_once _PS_ROOT_DIR_ . '/app/AdminKernel.php';
                 $kernelClass = 'AdminKernel';
             } else {
+                require_once _PS_ROOT_DIR_ . '/app/AppKernel.php';
                 $kernelClass = 'AppKernel';
             }
 

--- a/classes/UpgradeTools/SymfonyAdapter.php
+++ b/classes/UpgradeTools/SymfonyAdapter.php
@@ -69,13 +69,14 @@ class SymfonyAdapter
     {
         global $kernel;
         if (!$kernel instanceof \AppKernel) {
+            require_once _PS_ROOT_DIR_ . '/app/AppKernel.php';
+
             $env = (true == _PS_MODE_DEV_) ? 'dev' : 'prod';
 
             if ($this->isAppKernelAbstract()) { // From version 9 the AppKernel becomes an abstract so we need to check if it is one to know which Kernel to use
                 require_once _PS_ROOT_DIR_ . '/app/AdminKernel.php';
                 $kernelClass = 'AdminKernel';
             } else {
-                require_once _PS_ROOT_DIR_ . '/app/AppKernel.php';
                 $kernelClass = 'AppKernel';
             }
 


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | If you try upgrading from 1.7.1.0 to a version below 1.7.3.0, you get an error about AppKernel because this class is not present in the core autoload classmap. This PR adds: <ul><li>A safety net while loading AppKernel</li><li>Expands the tested versions of PrestaShop in CI,</li><li>Improved the readability of the base version running the shop in CI.</li></ul>
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | NA
| Sponsor company   | @PrestaShopCorp
| How to test?      | Check if CI is green. To check the fix, try upgrading a PrestaShop 1.7.1.0 to 1.7.2.0.
