### PR TITLE
Fix path to autoloader after moving controller

### DIFF
--- a/controllers/admin/AdminSelfUpgradeController.php
+++ b/controllers/admin/AdminSelfUpgradeController.php
@@ -34,7 +34,7 @@ use PrestaShop\Module\AutoUpgrade\UpgradePage;
 use PrestaShop\Module\AutoUpgrade\UpgradeSelfCheck;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\FilesystemAdapter;
 
-$autoloadPath = __DIR__ . '/vendor/autoload.php';
+$autoloadPath = __DIR__ . '/../../vendor/autoload.php';
 if (file_exists($autoloadPath)) {
     require_once $autoloadPath;
 }


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Autoupgrade module fails to load following merge of https://github.com/PrestaShop/autoupgrade/pull/676. Autoloaders are not called automatically from PrestaShop in early versions of PS 1.7, and still require to be loaded manually. Since we move the controller, the path was incorrect.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Open the module configuration page on PS 1.7.3.4. You'll get an error about a class Translator undefined until you get this PR.

## Fixed issue

![image](https://github.com/PrestaShop/autoupgrade/assets/6768917/d7adc575-3277-4403-bb74-9422e6ed0328)
