### PR TITLE
Update 9.0.0.sql

### DIFF
--- a/upgrade/sql/9.0.0.sql
+++ b/upgrade/sql/9.0.0.sql
@@ -4,6 +4,7 @@ SET NAMES 'utf8mb4';
 INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES
   ('PS_DEBUG_COOKIE_NAME', '', NOW(), NOW()),
   ('PS_DEBUG_COOKIE_VALUE', '', NOW(), NOW()),
+  ('PS_SEPARATOR_FILE_MANAGER_SQL', ';', NOW(), NOW()),
   ('PS_PRODUCT_BREADCRUMB_CATEGORY', 'default', NOW(), NOW())
 ;
 


### PR DESCRIPTION
See PR prestashop/prestashop#35843

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Goes along the PR prestashop/prestashop#35843 from prestashop/prestashop. A new configuration key is added to the core. It should be inserted in the next version autoupgrade script.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     |  NA
| Sponsor company   | Evolutive
| How to test?      | NA
