### PR TITLE
Attempt to replace home made files lookup with Finder

### DIFF
--- a/classes/UpgradeTools/FileFilter.php
+++ b/classes/UpgradeTools/FileFilter.php
@@ -141,35 +141,18 @@ class FileFilter
 
         // do not copy install, neither app/config/parameters.php in case it would be present
         $this->excludeAbsoluteFilesFromUpgrade = [
-            '/app/config/parameters.php',
-            '/app/config/parameters.yml',
-            '/install',
-            '/install-dev',
-            '/override',
-            '/override/classes',
-            '/override/controllers',
-            '/override/modules',
+            'app/config/parameters.php',
+            'app/config/parameters.yml',
+            'install',
+            'install-dev',
+            'override',
+            'modules',
         ];
-
-        // Fetch all existing native modules
-        $nativeModules = $this->getNativeModules();
-
-        if (is_dir($this->rootDir . '/modules')) {
-            $dir = new DirectoryIterator($this->rootDir . '/modules');
-            foreach ($dir as $fileinfo) {
-                if (!$fileinfo->isDir() || $fileinfo->isDot()) {
-                    continue;
-                }
-                if (in_array($fileinfo->getFilename(), $nativeModules)) {
-                    $this->excludeAbsoluteFilesFromUpgrade[] = '/modules/' . $fileinfo->getFilename();
-                }
-            }
-        }
 
         // this will exclude autoupgrade dir from admin, and autoupgrade from modules
         // If set to false, we need to preserve the default themes
         if (!$this->configuration->shouldUpdateDefaultTheme()) {
-            $this->excludeAbsoluteFilesFromUpgrade[] = '/themes/classic';
+            $this->excludeAbsoluteFilesFromUpgrade[] = 'themes/classic';
         }
 
         return $this->excludeAbsoluteFilesFromUpgrade;

--- a/classes/UpgradeTools/FilesystemAdapter.php
+++ b/classes/UpgradeTools/FilesystemAdapter.php
@@ -201,6 +201,8 @@ class FilesystemAdapter
      * @param string $fullpath : current file or directory fullpath eg:'/home/web/www/prestashop/app/config/parameters.php'
      * @param string $way : 'backup' , 'upgrade'
      * @param string $temporaryWorkspace : If needed, another folder than the shop root can be used (used for releases)
+     * 
+     * @deprecated in favor of Finder
      */
     public function isFileSkipped($file, $fullpath, $way = 'backup', $temporaryWorkspace = null)
     {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "ext-zip": "*",
     "symfony/filesystem": "^3.0",
     "doctrine/collections": "~1.3.0",
-    "twig/twig": "^1.35|^3"
+    "twig/twig": "^1.35|^3",
+    "symfony/finder": "^3.4"
   },
   "require-dev": {
     "phpunit/phpunit": "^5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0d1682c605cfcb4d026cde41db2fb8e8",
+    "content-hash": "afcdc8b0d4617b9aa7f3feca7ce08e74",
     "packages": [
         {
             "name": "doctrine/collections",
@@ -133,6 +133,67 @@
                 }
             ],
             "time": "2020-10-24T10:57:07+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v3.4.47",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "b6b6ad3db3edb1b4b1c1896b1975fb684994de6e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/b6b6ad3db3edb1b4b1c1896b1975fb684994de6e",
+                "reference": "b6b6ad3db3edb1b4b1c1896b1975fb684994de6e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/finder/tree/v3.4.47"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-16T17:02:08+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2599,67 +2660,6 @@
                 }
             ],
             "time": "2020-10-24T10:57:07+00:00"
-        },
-        {
-            "name": "symfony/finder",
-            "version": "v3.4.47",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/finder.git",
-                "reference": "b6b6ad3db3edb1b4b1c1896b1975fb684994de6e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/b6b6ad3db3edb1b4b1c1896b1975fb684994de6e",
-                "reference": "b6b6ad3db3edb1b4b1c1896b1975fb684994de6e",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5.9|>=7.0.8"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Finder\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Finder Component",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/finder/tree/v3.4.47"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-11-16T17:02:08+00:00"
         },
         {
             "name": "symfony/options-resolver",


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR replaces our management of files to ignore with the Finder of Symfony
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Partially fixes https://github.com/PrestaShop/PrestaShop/issues/34048
| Sponsor company   | PrestaShopCorp
| How to test?      | Run an upgrade until the end of the copy of files. Modules provided in the release should no have overwritten the modules currently installed (whatever their version is higher or lower). 

## Issue found with the current version
![Capture d’écran du 2024-04-19 14-22-27](https://github.com/PrestaShop/autoupgrade/assets/6768917/17b52d3f-2f09-42af-ae73-74c5422b56b9)

