### PR TITLE
Add a check about PS_VERSION_DB

### DIFF
--- a/autoupgrade.php
+++ b/autoupgrade.php
@@ -143,9 +143,9 @@ class Autoupgrade extends Module
         require_once __DIR__ . '/vendor/autoload.php';
 
         $upgradeContainer = new \PrestaShop\Module\AutoUpgrade\UpgradeContainer(_PS_ROOT_DIR_, _PS_ADMIN_DIR_);
-        $upgrader = $upgradeContainer->getUpgrader();
         $upgradeSelfCheck = new \PrestaShop\Module\AutoUpgrade\UpgradeSelfCheck(
-            $upgrader,
+            $upgradeContainer->getUpgrader(),
+            $upgradeContainer->getPrestaShopConfiguration(),
             _PS_ROOT_DIR_,
             _PS_ADMIN_DIR_,
             __DIR__

--- a/classes/Twig/Block/UpgradeChecklist.php
+++ b/classes/Twig/Block/UpgradeChecklist.php
@@ -41,22 +41,6 @@ class UpgradeChecklist
      * @var Twig_Environment|\Twig\Environment
      */
     private $twig;
-
-    /**
-     * @var string
-     */
-    private $prodRootPath;
-
-    /**
-     * @var string
-     */
-    private $adminPath;
-
-    /**
-     * @var string
-     */
-    private $autoupgradePath;
-
     /**
      * @var UpgradeSelfCheck
      */
@@ -77,26 +61,17 @@ class UpgradeChecklist
      *
      * @param Twig_Environment|\Twig\Environment $twig
      * @param UpgradeSelfCheck $upgradeSelfCheck
-     * @param string $prodRootPath
-     * @param string $adminPath
-     * @param string $autoupgradePath
      * @param string $currentIndex
      * @param string $token
      */
     public function __construct(
         $twig,
         UpgradeSelfCheck $upgradeSelfCheck,
-        $prodRootPath,
-        $adminPath,
-        $autoupgradePath,
         $currentIndex,
         $token
     ) {
         $this->twig = $twig;
         $this->selfCheck = $upgradeSelfCheck;
-        $this->prodRootPath = $prodRootPath;
-        $this->adminPath = $adminPath;
-        $this->autoupgradePath = $autoupgradePath;
         $this->currentIndex = $currentIndex;
         $this->token = $token;
     }

--- a/classes/Twig/Block/UpgradeChecklist.php
+++ b/classes/Twig/Block/UpgradeChecklist.php
@@ -113,6 +113,7 @@ class UpgradeChecklist
             'moduleVersion' => $this->selfCheck->getModuleVersion(),
             'moduleIsUpToDate' => $this->selfCheck->isModuleVersionLatest(),
             'moduleUpdateLink' => Context::getContext()->link->getAdminLink('AdminModulesUpdates'),
+            'isShopVersionMatchingVersionInDatabase' => $this->selfCheck->isShopVersionMatchingVersionInDatabase(),
             'adminToken' => Tools14::getAdminTokenLite('AdminModules'),
             'informationsLink' => Context::getContext()->link->getAdminLink('AdminInformation'),
             'maintenanceLink' => Context::getContext()->link->getAdminLink('AdminMaintenance'),

--- a/classes/UpgradePage.php
+++ b/classes/UpgradePage.php
@@ -204,9 +204,6 @@ class UpgradePage
         return (new UpgradeChecklist(
             $this->twig,
             $this->upgradeSelfCheck,
-            $this->prodRootPath,
-            $this->adminPath,
-            $this->autoupgradePath,
             $this->currentIndex,
             $this->token
         ))->render();

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -352,7 +352,7 @@ class UpgradeSelfCheck
         return version_compare(
             Configuration::get('PS_VERSION_DB'),
             $this->prestashopConfiguration->getPrestaShopVersion(),
-            '>='
+            '=='
         );
     }
 

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -94,11 +94,6 @@ class UpgradeSelfCheck
     private $rootWritableReport;
 
     /**
-     * @var false|string
-     */
-    private $moduleVersion;
-
-    /**
      * @var int
      */
     private $maxExecutionTime;
@@ -142,6 +137,11 @@ class UpgradeSelfCheck
     private $autoUpgradePath;
 
     /**
+     * @var PrestashopConfiguration
+     */
+    private $prestashopConfiguration;
+
+    /**
      * @var bool
      */
     private $overrideDisabled;
@@ -150,13 +150,15 @@ class UpgradeSelfCheck
      * UpgradeSelfCheck constructor.
      *
      * @param Upgrader $upgrader
+     * @param PrestashopConfiguration $prestashopConfiguration
      * @param string $prodRootPath
      * @param string $adminPath
      * @param string $autoUpgradePath
      */
-    public function __construct(Upgrader $upgrader, $prodRootPath, $adminPath, $autoUpgradePath)
+    public function __construct(Upgrader $upgrader, PrestashopConfiguration $prestashopConfiguration, $prodRootPath, $adminPath, $autoUpgradePath)
     {
         $this->upgrader = $upgrader;
+        $this->prestashopConfiguration = $prestashopConfiguration;
         $this->prodRootPath = $prodRootPath;
         $this->adminPath = $adminPath;
         $this->autoUpgradePath = $autoUpgradePath;
@@ -307,11 +309,7 @@ class UpgradeSelfCheck
      */
     public function getModuleVersion()
     {
-        if (null !== $this->moduleVersion) {
-            return $this->moduleVersion;
-        }
-
-        return $this->moduleVersion = $this->checkModuleVersion();
+        return $this->prestashopConfiguration->getModuleVersion();
     }
 
     /**
@@ -347,6 +345,18 @@ class UpgradeSelfCheck
     }
 
     /**
+     * @return bool
+     */
+    public function isShopVersionMatchingVersionInDatabase()
+    {
+        return version_compare(
+            Configuration::get('PS_VERSION_DB'),
+            $this->prestashopConfiguration->getPrestaShopVersion(),
+            '>='
+        );
+    }
+
+    /**
      * Indicates if the self check status allows going ahead with the upgrade.
      *
      * @return bool
@@ -362,6 +372,7 @@ class UpgradeSelfCheck
             && $this->isCacheDisabled()
             && $this->isModuleVersionLatest()
             && $this->isPhpVersionCompatible()
+            && $this->isShopVersionMatchingVersionInDatabase()
             && $this->isApacheModRewriteEnabled()
             && $this->checkKeyGeneration()
             && $this->getNotLoadedPhpExtensions() === []
@@ -391,20 +402,6 @@ class UpgradeSelfCheck
     private function checkModuleVersionIsLastest(Upgrader $upgrader)
     {
         return version_compare($this->getModuleVersion(), $upgrader->autoupgrade_last_version, '>=');
-    }
-
-    /**
-     * @return string|false
-     */
-    private function checkModuleVersion()
-    {
-        $configFilePath = _PS_ROOT_DIR_ . $this->configDir;
-
-        if (file_exists($configFilePath) && $xml_module_version = simplexml_load_file($configFilePath)) {
-            return (string) $xml_module_version->version;
-        }
-
-        return false;
     }
 
     /**

--- a/controllers/admin/AdminSelfUpgradeController.php
+++ b/controllers/admin/AdminSelfUpgradeController.php
@@ -492,6 +492,7 @@ class AdminSelfUpgradeController extends AdminController
         $upgrader = $this->upgradeContainer->getUpgrader();
         $upgradeSelfCheck = new UpgradeSelfCheck(
             $upgrader,
+            $this->upgradeContainer->getPrestaShopConfiguration(),
             $this->prodRootDir,
             $this->adminDir,
             $this->autoupgradePath

--- a/views/templates/block/checklist.twig
+++ b/views/templates/block/checklist.twig
@@ -221,6 +221,12 @@
                     <td>{{ icons.nok }}</td>
                   </tr>
                 {% endif %}
+                {% if not isShopVersionMatchingVersionInDatabase %}
+                  <tr>
+                    <td>{{ 'The version of PrestaShop stored in database does not match the running code. Your database structure may not be up-to-date and/or the value of PS_VERSION_DB needs to be updated in the configuration table.'|trans({}, 'Modules.Autoupgrade.Admin') }}</td>
+                    <td>{{ icons.nok }}</td>
+                  </tr>
+                {% endif %}
             </table>
             <br>
             <p class="alert alert-info">{{ 'Please also make sure you make a full manual backup of your files and database.'|trans({}, 'Modules.Autoupgrade.Admin') }}</p>

--- a/views/templates/block/checklist.twig
+++ b/views/templates/block/checklist.twig
@@ -223,7 +223,12 @@
                 {% endif %}
                 {% if not isShopVersionMatchingVersionInDatabase %}
                   <tr>
-                    <td>{{ 'The version of PrestaShop stored in database does not match the running code. Your database structure may not be up-to-date and/or the value of PS_VERSION_DB needs to be updated in the configuration table.'|trans({}, 'Modules.Autoupgrade.Admin') }}</td>
+                    <td>
+                      {{ 'The version of PrestaShop does not match the one stored in database. Your database structure may not be up-to-date and/or the value of PS_VERSION_DB needs to be updated in the configuration table. [1]Learn more[/1].'|trans({
+                        '[1]': '<a href="https://devdocs.prestashop-project.org/8/faq/upgrade#the-version-of-prestashop-does-not-match-the-one-stored-in-database" target="_blank">',
+                        '[/1]': '</a>',
+                      }, 'Modules.Autoupgrade.Admin')|raw }}
+                    </td>
                     <td>{{ icons.nok }}</td>
                   </tr>
                 {% endif %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR adds a check on the value of PS_VERSION_DB. A mismatch between the current version of PrestaShop and the value store in database means all the migration files may not have run. The merchant needs to check if its structure is up-to-date by running missed SQL files and bumping PS_VERSION_DB when done.<br><br>This PR also removes some duplicated code to get the module version.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Partially fixes https://github.com/PrestaShop/PrestaShop/issues/33856, Fixes https://github.com/PrestaShop/PrestaShop/issues/15198
| Sponsor company   | @PrestaShopCorp
| How to test?      | Manually change the value of PS_VERSION_DB in the configuration table to make the error appear. Restoring its original value will make the error disappear.

![image](https://github.com/PrestaShop/autoupgrade/assets/6768917/b4d34426-2afb-40fd-a58e-7dc9fbfbb23a)

