### PR TITLE
Remove orphan tabs following deletion of old controllers

### DIFF
--- a/upgrade/sql/9.0.0.sql
+++ b/upgrade/sql/9.0.0.sql
@@ -94,7 +94,9 @@ DELETE FROM `PREFIX_tab` WHERE `class_name` = 'AdminStockInstantState';
 DELETE FROM `PREFIX_tab` WHERE `class_name` = 'AdminStockCover';
 DELETE FROM `PREFIX_tab` WHERE `class_name` = 'AdminSupplyOrders';
 DELETE FROM `PREFIX_tab` WHERE `class_name` = 'AdminStockConfiguration';
-DELETE FROM `PREFIX_tab_lang` WHERE `id_tab` NOT IN (SELECT id_tab FROM `PREFIX_tab`);
+-- Avoid Error Code: 1093 by nesting subrequest
+DELETE FROM `PREFIX_tab` WHERE `id_parent` > 0 AND `id_parent` NOT IN (SELECT `id_tab` FROM (SELECT `id_tab` FROM `PREFIX_tab`) as c);
+DELETE FROM `PREFIX_tab_lang` WHERE `id_tab` NOT IN (SELECT `id_tab` FROM `PREFIX_tab`);
 
 /* Change the length of the ean13 field */
 ALTER TABLE `PREFIX_product` MODIFY COLUMN `ean13` VARCHAR(20);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | While upgrading to PrestaShop v9, remove tabs who lost their parent relation with the previous row deletion. this cleans the table and fixes an issue reported while opening the Stock page.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     |Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/35879
| Sponsor company   | PrestaShopCorp
| How to test?      | Upgrade from PS 8 to 9, then open the Stock page. It should load without error.