### PR TITLE
Align ignoring rules between copy and deletion of files + ignore native module only if they have they vendor/ folder

### DIFF
--- a/classes/TaskRunner/Miscellaneous/CheckFilesVersion.php
+++ b/classes/TaskRunner/Miscellaneous/CheckFilesVersion.php
@@ -29,6 +29,7 @@ namespace PrestaShop\Module\AutoUpgrade\TaskRunner\Miscellaneous;
 
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeFileNames;
 use PrestaShop\Module\AutoUpgrade\TaskRunner\AbstractTask;
+use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 
 /**
  * List the files modified in the current installation regards to the original version.
@@ -39,8 +40,9 @@ class CheckFilesVersion extends AbstractTask
     {
         // do nothing after this request (see javascript function doAjaxRequest )
         $this->next = '';
-        $upgrader = $this->container->getUpgrader();
-        $changedFileList = $upgrader->getChangedFilesList();
+        $checksumCompare = $this->container->getChecksumCompare();
+        $currentPrestaShopVersion = $this->container->getProperty(UpgradeContainer::PS_VERSION);
+        $changedFileList = $checksumCompare->getTamperedFilesOnShop($currentPrestaShopVersion);
 
         if ($changedFileList === false) {
             $this->nextParams['status'] = 'error';
@@ -55,7 +57,7 @@ class CheckFilesVersion extends AbstractTask
             }
         }
 
-        if ($upgrader->isAuthenticPrestashopVersion() === true) {
+        if ($checksumCompare->isAuthenticPrestashopVersion($currentPrestaShopVersion)) {
             $this->nextParams['status'] = 'ok';
             $this->nextParams['msg'] = $this->translator->trans('Core files are ok', [], 'Modules.Autoupgrade.Admin');
         } else {

--- a/classes/TaskRunner/Miscellaneous/CompareReleases.php
+++ b/classes/TaskRunner/Miscellaneous/CompareReleases.php
@@ -42,6 +42,7 @@ class CompareReleases extends AbstractTask
         $this->next = '';
         $channel = $this->container->getUpgradeConfiguration()->get('channel');
         $upgrader = $this->container->getUpgrader();
+        $checksumCompare = $this->container->getChecksumCompare();
         switch ($channel) {
             case 'archive':
                 $version = $this->container->getUpgradeConfiguration()->get('archive.version_num');
@@ -63,7 +64,7 @@ class CompareReleases extends AbstractTask
 
         // Get list of differences between these two versions. The differences will be fetched from a local
         // XML file if it exists, or from PrestaShop API.
-        $diffFileList = $upgrader->getDiffFilesList(_PS_VERSION_, $version);
+        $diffFileList = $checksumCompare->getFilesDiffBetweenVersions(_PS_VERSION_, $version);
         if (!is_array($diffFileList)) {
             $this->nextParams['status'] = 'error';
             $this->nextParams['msg'] = sprintf('Unable to generate diff file list between %1$s and %2$s.', _PS_VERSION_, $version);

--- a/classes/TaskRunner/Miscellaneous/CompareReleases.php
+++ b/classes/TaskRunner/Miscellaneous/CompareReleases.php
@@ -70,17 +70,13 @@ class CompareReleases extends AbstractTask
             $this->nextParams['msg'] = sprintf('Unable to generate diff file list between %1$s and %2$s.', _PS_VERSION_, $version);
         } else {
             $this->container->getFileConfigurationStorage()->save($diffFileList, UpgradeFileNames::FILES_DIFF_LIST);
-            if (count($diffFileList) > 0) {
-                $this->nextParams['msg'] = $this->translator->trans(
-                    '%modifiedfiles% files will be modified, %deletedfiles% files will be deleted (if they are found).',
-                    [
-                        '%modifiedfiles%' => count($diffFileList['modified']),
-                        '%deletedfiles%' => count($diffFileList['deleted']),
-                    ],
-                    'Modules.Autoupgrade.Admin');
-            } else {
-                $this->nextParams['msg'] = $this->translator->trans('No diff files found.', [], 'Modules.Autoupgrade.Admin');
-            }
+            $this->nextParams['msg'] = $this->translator->trans(
+                '%modifiedfiles% files will be modified, %deletedfiles% files will be deleted (if they are found).',
+                [
+                    '%modifiedfiles%' => count($diffFileList['modified']),
+                    '%deletedfiles%' => count($diffFileList['deleted']),
+                ],
+                'Modules.Autoupgrade.Admin');
             $this->nextParams['result'] = $diffFileList;
         }
     }

--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -241,7 +241,8 @@ class UpgradeContainer
         }
 
         $this->checksumCompare = new ChecksumCompare(
-            $this->getFileLoader()
+            $this->getFileLoader(),
+            $this->getFilesystemAdapter()
         );
 
         return $this->checksumCompare;

--- a/classes/UpgradeTools/FileFilter.php
+++ b/classes/UpgradeTools/FileFilter.php
@@ -29,6 +29,7 @@ namespace PrestaShop\Module\AutoUpgrade\UpgradeTools;
 
 use DirectoryIterator;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
+use SplFileInfo;
 
 class FileFilter
 {
@@ -160,9 +161,15 @@ class FileFilter
                 if (!$fileinfo->isDir() || $fileinfo->isDot()) {
                     continue;
                 }
-                if (in_array($fileinfo->getFilename(), $nativeModules)) {
-                    $this->excludeAbsoluteFilesFromUpgrade[] = '/modules/' . $fileinfo->getFilename();
+                if (!in_array($fileinfo->getFilename(), $nativeModules)) {
+                    continue;
                 }
+                if (!(new SplFileInfo($this->rootDir . '/modules/' . $fileinfo->getFilename() . '/vendor'))->isDir()) {
+                    // If a vendor folder is found in the module, this means it has been upgraded or manually installed
+                    // and can be ignored during the upgrade process
+                    continue;
+                }
+                $this->excludeAbsoluteFilesFromUpgrade[] = '/modules/' . $fileinfo->getFilename();
             }
         }
 

--- a/classes/Upgrader.php
+++ b/classes/Upgrader.php
@@ -27,7 +27,7 @@
 
 namespace PrestaShop\Module\AutoUpgrade;
 
-use Configuration;
+use PrestaShop\Module\AutoUpgrade\Xml\FileLoader;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -38,20 +38,15 @@ class Upgrader
     const DEFAULT_FILENAME = 'prestashop.zip';
 
     public $addons_api = 'api.addons.prestashop.com';
-    public $rss_channel_link = 'https://api.prestashop.com/xml/channel.xml';
-    public $rss_md5file_link_dir = 'https://api.prestashop.com/xml/md5/';
 
     /**
      * @var bool contains true if last version is not installed
      */
     private $need_upgrade = false;
-    private $changed_files = [];
-    private $missing_files = [];
 
     public $version_name;
     public $version_num;
     public $version_is_modified;
-    public $version_md5 = [];
     /**
      * @var string contains hte url where to download the file
      */
@@ -69,24 +64,15 @@ class Upgrader
     public $branch = '';
 
     protected $currentPsVersion;
+    /**
+     * @var FileLoader
+     */
+    protected $fileLoader;
 
-    public function __construct($version, $autoload = false)
+    public function __construct($version, FileLoader $fileLoader)
     {
         $this->currentPsVersion = $version;
-        if ($autoload) {
-            $matches = [];
-            preg_match('#([0-9]+\.[0-9]+)\.[0-9]+\.[0-9]+#', $this->currentPsVersion, $matches);
-            $this->branch = $matches[1];
-            if (empty($this->channel)) {
-                $this->channel = self::$default_channel;
-            }
-            // checkPSVersion to get need_upgrade
-            $this->checkPSVersion();
-        }
-        if (!extension_loaded('openssl')) {
-            $this->rss_channel_link = str_replace('https://', 'http://', $this->rss_channel_link);
-            $this->rss_md5file_link_dir = str_replace('https://', 'http://', $this->rss_md5file_link_dir);
-        }
+        $this->fileLoader = $fileLoader;
     }
 
     /**
@@ -140,7 +126,7 @@ class Upgrader
     {
         // if we use the autoupgrade process, we will never refresh it
         // except if no check has been done before
-        $feed = $this->getXmlChannel($refresh);
+        $feed = $this->fileLoader->getXmlChannel($refresh);
         $branch_name = '';
         $channel_name = '';
 
@@ -295,255 +281,5 @@ class Upgrader
         }
 
         return $xml;
-    }
-
-    public function getXmlFile($xml_localfile, $xml_remotefile, $refresh = false)
-    {
-        // @TODO : this has to be moved in autoupgrade.php > install method
-        if (!is_dir(_PS_ROOT_DIR_ . '/config/xml')) {
-            if (is_file(_PS_ROOT_DIR_ . '/config/xml')) {
-                unlink(_PS_ROOT_DIR_ . '/config/xml');
-            }
-            mkdir(_PS_ROOT_DIR_ . '/config/xml', 0777);
-        }
-        if ($refresh || !file_exists($xml_localfile) || @filemtime($xml_localfile) < (time() - (3600 * self::DEFAULT_CHECK_VERSION_DELAY_HOURS))) {
-            $xml_string = Tools14::file_get_contents($xml_remotefile, false, stream_context_create(['http' => ['timeout' => 10]]));
-            $xml = @simplexml_load_string($xml_string);
-            if ($xml !== false) {
-                file_put_contents($xml_localfile, $xml_string);
-            }
-        } else {
-            $xml = @simplexml_load_file($xml_localfile);
-        }
-
-        return $xml;
-    }
-
-    public function getXmlChannel($refresh = false)
-    {
-        $xml = $this->getXmlFile(
-            _PS_ROOT_DIR_ . '/config/xml/' . pathinfo($this->rss_channel_link, PATHINFO_BASENAME),
-            $this->rss_channel_link,
-            $refresh
-        );
-        if ($refresh) {
-            if (class_exists('Configuration', false)) {
-                Configuration::updateValue('PS_LAST_VERSION_CHECK', time());
-            }
-        }
-
-        return $xml;
-    }
-
-    /**
-     * return xml containing the list of all default PrestaShop files for version $version,
-     * and their respective md5sum.
-     *
-     * @param string $version
-     *
-     * @return \SimpleXMLElement|false if error
-     */
-    public function getXmlMd5File($version, $refresh = false)
-    {
-        if (isset($this->version_md5[$version])) {
-            return @simplexml_load_file($this->version_md5[$version]);
-        }
-
-        return $this->getXmlFile(_PS_ROOT_DIR_ . '/config/xml/' . $version . '.xml', $this->rss_md5file_link_dir . $version . '.xml', $refresh);
-    }
-
-    /**
-     * returns an array of files which are present in PrestaShop version $version and has been modified
-     * in the current filesystem.
-     *
-     * @return array|false
-     */
-    public function getChangedFilesList($version = null, $refresh = false)
-    {
-        if (empty($version)) {
-            $version = $this->currentPsVersion;
-        }
-        if (is_array($this->changed_files) && count($this->changed_files) == 0) {
-            $checksum = $this->getXmlMd5File($version, $refresh);
-            if ($checksum == false) {
-                $this->changed_files = false;
-            } else {
-                $this->browseXmlAndCompare($checksum->ps_root_dir[0]);
-            }
-        }
-
-        return $this->changed_files;
-    }
-
-    /** populate $this->changed_files with $path
-     * in sub arrays  mail, translation and core items.
-     *
-     * @param string $path filepath to add, relative to _PS_ROOT_DIR_
-     */
-    protected function addChangedFile($path)
-    {
-        $this->version_is_modified = true;
-
-        if (strpos($path, 'mails/') !== false) {
-            $this->changed_files['mail'][] = $path;
-        } elseif (strpos($path, '/en.php') !== false || strpos($path, '/fr.php') !== false
-            || strpos($path, '/es.php') !== false || strpos($path, '/it.php') !== false
-            || strpos($path, '/de.php') !== false || strpos($path, 'translations/') !== false) {
-            $this->changed_files['translation'][] = $path;
-        } else {
-            $this->changed_files['core'][] = $path;
-        }
-    }
-
-    /** populate $this->missing_files with $path
-     * @param string $path filepath to add, relative to _PS_ROOT_DIR_
-     */
-    protected function addMissingFile($path)
-    {
-        $this->version_is_modified = true;
-        $this->missing_files[] = $path;
-    }
-
-    public function md5FileAsArray($node, $dir = '/')
-    {
-        $array = [];
-        foreach ($node as $key => $child) {
-            if (is_object($child) && $child->getName() == 'dir') {
-                $dir = (string) $child['name'];
-                /**
-                 * $current_path = $dir.(string)$child['name'];.
-                 *
-                 * @todo : something else than array pop ?
-                 */
-                $dir_content = $this->md5FileAsArray($child, $dir);
-                $array[$dir] = $dir_content;
-            } elseif (is_object($child) && $child->getName() == 'md5file') {
-                $array[(string) $child['name']] = (string) $child;
-            }
-        }
-
-        return $array;
-    }
-
-    /**
-     * getDiffFilesList.
-     *
-     * @param string $version1
-     * @param string $version2
-     * @param bool $show_modif
-     *
-     * @return array|false array('modified'=>array(...), 'deleted'=>array(...))
-     */
-    public function getDiffFilesList($version1, $version2, $show_modif = true, $refresh = false)
-    {
-        $checksum1 = $this->getXmlMd5File($version1, $refresh);
-        $checksum2 = $this->getXmlMd5File($version2, $refresh);
-        if ($checksum1) {
-            $v1 = $this->md5FileAsArray($checksum1->ps_root_dir[0]);
-        }
-        if ($checksum2) {
-            $v2 = $this->md5FileAsArray($checksum2->ps_root_dir[0]);
-        }
-        if (empty($v1) || empty($v2)) {
-            return false;
-        }
-        $filesList = $this->compareReleases($v1, $v2, $show_modif);
-        if (!$show_modif) {
-            return $filesList['deleted'];
-        }
-
-        return $filesList;
-    }
-
-    /**
-     * returns an array of files which.
-     *
-     * @param array $v1 result of method $this->md5FileAsArray()
-     * @param array $v2 result of method $this->md5FileAsArray()
-     * @param bool $show_modif if set to false, the method will only
-     *                         list deleted files
-     * @param string $path
-     *                     deleted files in version $v2. Otherwise, only deleted.
-     *
-     * @return array('modified' => array(files..), 'deleted' => array(files..)
-     */
-    public function compareReleases($v1, $v2, $show_modif = true, $path = '/')
-    {
-        // in that array the list of files present in v1 deleted in v2
-        static $deletedFiles = [];
-        // in that array the list of files present in v1 modified in v2
-        static $modifiedFiles = [];
-
-        foreach ($v1 as $file => $md5) {
-            if (is_array($md5)) {
-                $subpath = $path . $file;
-                if (isset($v2[$file]) && is_array($v2[$file])) {
-                    $this->compareReleases($md5, $v2[$file], $show_modif, $path . $file . '/');
-                } else { // also remove old dir
-                    $deletedFiles[] = $subpath;
-                }
-            } else {
-                if (in_array($file, array_keys($v2))) {
-                    if ($show_modif && ($v1[$file] != $v2[$file])) {
-                        $modifiedFiles[] = $path . $file;
-                    }
-                    $exists = true;
-                } else {
-                    $deletedFiles[] = $path . $file;
-                }
-            }
-        }
-
-        return ['deleted' => $deletedFiles, 'modified' => $modifiedFiles];
-    }
-
-    /**
-     * Compare the md5sum of the current files with the md5sum of the original.
-     *
-     * @param mixed $node
-     * @param array $current_path
-     * @param int $level
-     */
-    protected function browseXmlAndCompare($node, &$current_path = [], $level = 1)
-    {
-        foreach ($node as $key => $child) {
-            if (is_object($child) && $child->getName() == 'dir') {
-                $current_path[$level] = (string) $child['name'];
-                $this->browseXmlAndCompare($child, $current_path, $level + 1);
-            } elseif (is_object($child) && $child->getName() == 'md5file') {
-                // We will store only relative path.
-                // absolute path is only used for file_exists and compare
-                $relative_path = '';
-                for ($i = 1; $i < $level; ++$i) {
-                    $relative_path .= $current_path[$i] . '/';
-                }
-                $relative_path .= (string) $child['name'];
-
-                $fullpath = _PS_ROOT_DIR_ . DIRECTORY_SEPARATOR . $relative_path;
-                $fullpath = str_replace('ps_root_dir', _PS_ROOT_DIR_, $fullpath);
-
-                // replace default admin dir by current one
-                $fullpath = str_replace(_PS_ROOT_DIR_ . '/admin', _PS_ADMIN_DIR_, $fullpath);
-                $fullpath = str_replace(_PS_ROOT_DIR_ . DIRECTORY_SEPARATOR . 'admin', _PS_ADMIN_DIR_, $fullpath);
-                if (!file_exists($fullpath)) {
-                    $this->addMissingFile($relative_path);
-                } elseif (!$this->compareChecksum($fullpath, (string) $child) && substr(str_replace(DIRECTORY_SEPARATOR, '-', $relative_path), 0, 19) != 'modules/autoupgrade') {
-                    $this->addChangedFile($relative_path);
-                }
-                // else, file is original (and ok)
-            }
-        }
-    }
-
-    protected function compareChecksum($filepath, $md5sum)
-    {
-        return md5_file($filepath) == $md5sum;
-    }
-
-    public function isAuthenticPrestashopVersion($version = null, $refresh = false)
-    {
-        $this->getChangedFilesList($version, $refresh);
-
-        return !$this->version_is_modified;
     }
 }

--- a/classes/Xml/ChecksumCompare.php
+++ b/classes/Xml/ChecksumCompare.php
@@ -46,12 +46,12 @@ class ChecksumCompare
      * @param string $version2
      * @param bool $show_modif
      *
-     * @return array|false array('modified'=>array(...), 'deleted'=>array(...))
+     * @return false|array{'modified': string[], "deleted": string[]}
      */
-    public function getFilesDiffBetweenVersions($version1, $version2, $show_modif = true, $refresh = false)
+    public function getFilesDiffBetweenVersions($version1, $version2)
     {
-        $checksum1 = $this->fileLoader->getXmlMd5File($version1, $refresh);
-        $checksum2 = $this->fileLoader->getXmlMd5File($version2, $refresh);
+        $checksum1 = $this->fileLoader->getXmlMd5File($version1);
+        $checksum2 = $this->fileLoader->getXmlMd5File($version2);
         if ($checksum1) {
             $v1 = $this->md5FileAsArray($checksum1->ps_root_dir[0]);
         }
@@ -61,12 +61,7 @@ class ChecksumCompare
         if (empty($v1) || empty($v2)) {
             return false;
         }
-        $filesList = $this->compareReleases($v1, $v2, $show_modif);
-        if (!$show_modif) {
-            return $filesList['deleted'];
-        }
-
-        return $filesList;
+        return $this->compareReleases($v1, $v2);
     }
 
     /**
@@ -104,9 +99,10 @@ class ChecksumCompare
      * @param string $path
      *                     deleted files in version $v2. Otherwise, only deleted.
      *
+     * @internal Made public for tests
      * @return array{'modified': string[], "deleted": string[]}
      */
-    protected function compareReleases($v1, $v2, $show_modif = true, $path = '/')
+    public function compareReleases($v1, $v2, $show_modif = true, $path = '/')
     {
         // in that array the list of files present in v1 deleted in v2
         static $deletedFiles = [];

--- a/classes/Xml/ChecksumCompare.php
+++ b/classes/Xml/ChecksumCompare.php
@@ -1,0 +1,228 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+namespace PrestaShop\Module\AutoUpgrade\Xml;
+
+class ChecksumCompare
+{
+    /**
+     * @var FileLoader
+     */
+    private $fileLoader;
+    private $changed_files = [];
+    private $missing_files = [];
+
+    public function __construct(FileLoader $fileLoader)
+    {
+        $this->fileLoader = $fileLoader;
+    }
+
+    /**
+     * @param string $version1
+     * @param string $version2
+     * @param bool $show_modif
+     *
+     * @return array|false array('modified'=>array(...), 'deleted'=>array(...))
+     */
+    public function getFilesDiffBetweenVersions($version1, $version2, $show_modif = true, $refresh = false)
+    {
+        $checksum1 = $this->fileLoader->getXmlMd5File($version1, $refresh);
+        $checksum2 = $this->fileLoader->getXmlMd5File($version2, $refresh);
+        if ($checksum1) {
+            $v1 = $this->md5FileAsArray($checksum1->ps_root_dir[0]);
+        }
+        if ($checksum2) {
+            $v2 = $this->md5FileAsArray($checksum2->ps_root_dir[0]);
+        }
+        if (empty($v1) || empty($v2)) {
+            return false;
+        }
+        $filesList = $this->compareReleases($v1, $v2, $show_modif);
+        if (!$show_modif) {
+            return $filesList['deleted'];
+        }
+
+        return $filesList;
+    }
+
+    /**
+     * returns an array of files which are present in PrestaShop version $version and has been modified
+     * in the current filesystem.
+     *
+     * @return array|false
+     */
+    public function getTamperedFilesOnShop($version)
+    {
+        if (is_array($this->changed_files) && count($this->changed_files) == 0) {
+            $checksum = $this->fileLoader->getXmlMd5File($version);
+            if ($checksum == false) {
+                $this->changed_files = false;
+            } else {
+                $this->browseXmlAndCompare($checksum->ps_root_dir[0]);
+            }
+        }
+
+        return $this->changed_files;
+    }
+
+    public function isAuthenticPrestashopVersion($version)
+    {
+        return !$this->getTamperedFilesOnShop($version);
+    }
+
+    /**
+     * returns an array of files which.
+     *
+     * @param array $v1 result of method $this->md5FileAsArray()
+     * @param array $v2 result of method $this->md5FileAsArray()
+     * @param bool $show_modif if set to false, the method will only
+     *                         list deleted files
+     * @param string $path
+     *                     deleted files in version $v2. Otherwise, only deleted.
+     *
+     * @return array{'modified': string[], "deleted": string[]}
+     */
+    protected function compareReleases($v1, $v2, $show_modif = true, $path = '/')
+    {
+        // in that array the list of files present in v1 deleted in v2
+        static $deletedFiles = [];
+        // in that array the list of files present in v1 modified in v2
+        static $modifiedFiles = [];
+
+        foreach ($v1 as $file => $md5) {
+            if (is_array($md5)) {
+                $subpath = $path . $file;
+                if (isset($v2[$file]) && is_array($v2[$file])) {
+                    $this->compareReleases($md5, $v2[$file], $show_modif, $path . $file . '/');
+                } else { // also remove old dir
+                    $deletedFiles[] = $subpath;
+                }
+            } else {
+                if (in_array($file, array_keys($v2))) {
+                    if ($show_modif && ($v1[$file] != $v2[$file])) {
+                        $modifiedFiles[] = $path . $file;
+                    }
+                } else {
+                    $deletedFiles[] = $path . $file;
+                }
+            }
+        }
+
+        return ['deleted' => $deletedFiles, 'modified' => $modifiedFiles];
+    }
+
+    /**
+     * Compare the md5sum of the current files with the md5sum of the original.
+     *
+     * @param mixed $node
+     * @param array $current_path
+     * @param int $level
+     */
+    protected function browseXmlAndCompare($node, &$current_path = [], $level = 1)
+    {
+        foreach ($node as $child) {
+            if (is_object($child) && $child->getName() == 'dir') {
+                $current_path[$level] = (string) $child['name'];
+                $this->browseXmlAndCompare($child, $current_path, $level + 1);
+            } elseif (is_object($child) && $child->getName() == 'md5file') {
+                // We will store only relative path.
+                // absolute path is only used for file_exists and compare
+                $relative_path = '';
+                for ($i = 1; $i < $level; ++$i) {
+                    $relative_path .= $current_path[$i] . '/';
+                }
+                $relative_path .= (string) $child['name'];
+
+                // TODO: Drop use of constants and use args instead
+                $fullpath = _PS_ROOT_DIR_ . DIRECTORY_SEPARATOR . $relative_path;
+                $fullpath = str_replace('ps_root_dir', _PS_ROOT_DIR_, $fullpath);
+
+                // replace default admin dir by current one
+                $fullpath = str_replace(_PS_ROOT_DIR_ . '/admin', _PS_ADMIN_DIR_, $fullpath);
+                $fullpath = str_replace(_PS_ROOT_DIR_ . DIRECTORY_SEPARATOR . 'admin', _PS_ADMIN_DIR_, $fullpath);
+                if (!file_exists($fullpath)) {
+                    $this->addMissingFile($relative_path);
+                } elseif (!$this->compareChecksum($fullpath, (string) $child) && substr(str_replace(DIRECTORY_SEPARATOR, '-', $relative_path), 0, 19) != 'modules/autoupgrade') {
+                    $this->addChangedFile($relative_path);
+                }
+                // else, file is original (and ok)
+            }
+        }
+    }
+
+    protected function md5FileAsArray($node, $dir = '/')
+    {
+        $array = [];
+        foreach ($node as $child) {
+            if (is_object($child) && $child->getName() == 'dir') {
+                $dir = (string) $child['name'];
+                /**
+                 * $current_path = $dir.(string)$child['name'];.
+                 *
+                 * @todo : something else than array pop ?
+                 */
+                $dir_content = $this->md5FileAsArray($child, $dir);
+                $array[$dir] = $dir_content;
+            } elseif (is_object($child) && $child->getName() == 'md5file') {
+                $array[(string) $child['name']] = (string) $child;
+            }
+        }
+
+        return $array;
+    }
+
+    /** populate $this->changed_files with $path
+     * in sub arrays  mail, translation and core items.
+     *
+     * @param string $path filepath to add, relative to _PS_ROOT_DIR_
+     */
+    protected function addChangedFile($path)
+    {
+        if (strpos($path, 'mails/') !== false) {
+            $this->changed_files['mail'][] = $path;
+        } elseif (strpos($path, '/en.php') !== false || strpos($path, '/fr.php') !== false
+            || strpos($path, '/es.php') !== false || strpos($path, '/it.php') !== false
+            || strpos($path, '/de.php') !== false || strpos($path, 'translations/') !== false) {
+            $this->changed_files['translation'][] = $path;
+        } else {
+            $this->changed_files['core'][] = $path;
+        }
+    }
+
+    /** populate $this->missing_files with $path
+     * @param string $path filepath to add, relative to _PS_ROOT_DIR_
+     */
+    protected function addMissingFile($path)
+    {
+        $this->missing_files[] = $path;
+    }
+
+    protected function compareChecksum($filepath, $md5sum)
+    {
+        return md5_file($filepath) == $md5sum;
+    }
+}

--- a/classes/Xml/FileLoader.php
+++ b/classes/Xml/FileLoader.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+namespace PrestaShop\Module\AutoUpgrade\Xml;
+
+use Configuration;
+use PrestaShop\Module\AutoUpgrade\Tools14;
+use PrestaShop\Module\AutoUpgrade\Upgrader;
+
+class FileLoader
+{
+    const BASE_URL_MD5_FILES = 'https://api.prestashop.com/xml/md5/';
+    const URL_CHANNELS_FILE = 'https://api.prestashop.com/xml/channel.xml';
+
+    public $version_md5 = [];
+
+    public function getXmlFile($xml_localfile, $xml_remotefile, $refresh = false)
+    {
+        // @TODO : this has to be moved in autoupgrade.php > install method
+        if (!is_dir(_PS_ROOT_DIR_ . '/config/xml')) {
+            if (is_file(_PS_ROOT_DIR_ . '/config/xml')) {
+                unlink(_PS_ROOT_DIR_ . '/config/xml');
+            }
+            mkdir(_PS_ROOT_DIR_ . '/config/xml', 0777);
+        }
+        if ($refresh || !file_exists($xml_localfile) || @filemtime($xml_localfile) < (time() - (3600 * Upgrader::DEFAULT_CHECK_VERSION_DELAY_HOURS))) {
+            $xml_string = Tools14::file_get_contents($xml_remotefile, false, stream_context_create(['http' => ['timeout' => 10]]));
+            $xml = @simplexml_load_string($xml_string);
+            if ($xml !== false) {
+                file_put_contents($xml_localfile, $xml_string);
+            }
+        } else {
+            $xml = @simplexml_load_file($xml_localfile);
+        }
+
+        return $xml;
+    }
+
+    /**
+     * return xml containing the list of all default PrestaShop files for version $version,
+     * and their respective md5sum.
+     *
+     * @param string $version
+     *
+     * @return \SimpleXMLElement|false if error
+     */
+    public function getXmlMd5File($version, $refresh = false)
+    {
+        if (isset($this->version_md5[$version])) {
+            return @simplexml_load_file($this->version_md5[$version]);
+        }
+
+        return $this->getXmlFile(_PS_ROOT_DIR_ . '/config/xml/' . $version . '.xml', self::BASE_URL_MD5_FILES . $version . '.xml', $refresh);
+    }
+
+    public function getXmlChannel($refresh = false)
+    {
+        $xml = $this->getXmlFile(
+            _PS_ROOT_DIR_ . '/config/xml/' . pathinfo(self::URL_CHANNELS_FILE, PATHINFO_BASENAME),
+            self::URL_CHANNELS_FILE,
+            $refresh
+        );
+        if ($refresh) {
+            // TODO: Check this is triggered anywhere
+            if (class_exists('Configuration', false)) {
+                Configuration::updateValue('PS_LAST_VERSION_CHECK', time());
+            }
+        }
+
+        return $xml;
+    }
+}

--- a/tests/unit/Xml/ChecksumCompareTest.php
+++ b/tests/unit/Xml/ChecksumCompareTest.php
@@ -24,8 +24,7 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
 use PHPUnit\Framework\TestCase;
-use PrestaShop\Module\AutoUpgrade\Xml\ChecksumCompare;
-use PrestaShop\Module\AutoUpgrade\Xml\FileLoader;
+use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 
 class ChecksumCompareTest extends TestCase
 {
@@ -33,28 +32,32 @@ class ChecksumCompareTest extends TestCase
     {
         // Simplest test
         $v1Structure = [
-            "composer.lock" => "75111ebd3d058964acc25a0df5f05db4",
-            "init.php" => "0c7996ca741c35ec24e82e5b116604dc",
-            "phpstan.neon.dist" => "7c19e03d141d22ceb8940ce0e4d71b01",
-            "autoload.php" => "6207fe0a4016f9d9947be8e4b8e48b89",
-            "app" => [
-                "AppKernel.php" => "37d3976fc4877231fa652567e4e02cd4",
-                "AppCache.php" => "a04845405789c16d83832e9cba9b790c",
+            'composer.lock' => '75111ebd3d058964acc25a0df5f05db4',
+            'init.php' => '0c7996ca741c35ec24e82e5b116604dc',
+            'phpstan.neon.dist' => '7c19e03d141d22ceb8940ce0e4d71b01',
+            'autoload.php' => '6207fe0a4016f9d9947be8e4b8e48b89',
+            'app' => [
+                'AppKernel.php' => '37d3976fc4877231fa652567e4e02cd4',
+                'AppCache.php' => 'a04845405789c16d83832e9cba9b790c',
+            ],
+            'install' => [
+                'index.php' => '0c7996ca741c35ec24e82e5b116604dc',
             ],
         ];
         $v2Structure = [
-            "autoload.php" => "6207fe0a4016f9d9947be8e4b8e48b89",
-            "init.php" => "0c7996ca741c35ec24e82e5b116604dc",
-            "composer.lock" => "d50e8124b90459a8e92633adcae892ff",
-            "app" => [
-                "AppCache.php" => "a04845405789c16d83832e9cba9b790c",
-                "AppKernel.php" => "1d6ea5b88cbf8e6b589760991a16094d",
+            'autoload.php' => '6207fe0a4016f9d9947be8e4b8e48b89',
+            'init.php' => '0c7996ca741c35ec24e82e5b116604dc',
+            'composer.lock' => 'd50e8124b90459a8e92633adcae892ff',
+            'app' => [
+                'AppCache.php' => 'a04845405789c16d83832e9cba9b790c',
+                'AppKernel.php' => '1d6ea5b88cbf8e6b589760991a16094d',
+            ],
+            'install' => [
+                'index.php' => 'c35ec24e741c35ed83832e5b116604dc',
             ],
         ];
 
-        $checksumCompare = new ChecksumCompare(
-            new FileLoader()
-        );
+        $checksumCompare = (new UpgradeContainer('/html', '/html/admin'))->getChecksumCompare();
 
         $actual = $checksumCompare->compareReleases($v1Structure, $v2Structure);
         $expected = [

--- a/tests/unit/Xml/ChecksumCompareTest.php
+++ b/tests/unit/Xml/ChecksumCompareTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+use PHPUnit\Framework\TestCase;
+use PrestaShop\Module\AutoUpgrade\Xml\ChecksumCompare;
+use PrestaShop\Module\AutoUpgrade\Xml\FileLoader;
+
+class ChecksumCompareTest extends TestCase
+{
+    public function testCompareReleases()
+    {
+        // Simplest test
+        $v1Structure = [
+            "composer.lock" => "75111ebd3d058964acc25a0df5f05db4",
+            "init.php" => "0c7996ca741c35ec24e82e5b116604dc",
+            "phpstan.neon.dist" => "7c19e03d141d22ceb8940ce0e4d71b01",
+            "autoload.php" => "6207fe0a4016f9d9947be8e4b8e48b89",
+            "app" => [
+                "AppKernel.php" => "37d3976fc4877231fa652567e4e02cd4",
+                "AppCache.php" => "a04845405789c16d83832e9cba9b790c",
+            ],
+        ];
+        $v2Structure = [
+            "autoload.php" => "6207fe0a4016f9d9947be8e4b8e48b89",
+            "init.php" => "0c7996ca741c35ec24e82e5b116604dc",
+            "composer.lock" => "d50e8124b90459a8e92633adcae892ff",
+            "app" => [
+                "AppCache.php" => "a04845405789c16d83832e9cba9b790c",
+                "AppKernel.php" => "1d6ea5b88cbf8e6b589760991a16094d",
+            ],
+        ];
+
+        $checksumCompare = new ChecksumCompare(
+            new FileLoader()
+        );
+
+        $actual = $checksumCompare->compareReleases($v1Structure, $v2Structure);
+        $expected = [
+            'deleted' => ['/phpstan.neon.dist'],
+            'modified' => [
+                '/composer.lock',
+                '/app/AppKernel.php',
+            ],
+        ];
+        $this->assertEquals($expected, $actual);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This fixes an issue where modules files are unexpectly removed. It plugs XML diff to the method removing files to ignore, so the same rules during the copy of files are applied. <br><br>This also changes the way native modules are ignored. If one of them has never been modified (meaning their composer is still the one provided by the core), its content will be upgraded during the process.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/36184
| Sponsor company   | @PrestaShopCorp
| How to test?      | * Basic upgrades from 8.1.0 to 8.1.6 must upgrade files (delete + copy) in the `ps_googleanalytics` module during "Upgrade files" step.<br> * Installation of 8.1.0, deletion and reinstallation of module `ps_googleanalytics`, then upgrade to PS 8.1.6 should not delete or copy the module contents during "Upgrade files" step.

## Error currently found in the CI and fixed by this PR:

```
Fatal error: Uncaught Error: Class "PrestaShop\Module\Ps_Googleanalytics\Hooks\HookDisplayFooter" not found in /var/www/html/modules/ps_googleanalytics/ps_googleanalytics.php:132 Stack trace: #0 /var/www/html/classes/Hook.php(1043): Ps_Googleanalytics->hookDisplayBeforeBodyClosingTag(Array)
```

This is related to a module `ps_googleanalytics` provided in both packages 8.1.0 and 8.1.6. In PrestaShop releases, native module dependencies are merged in the core composer.
This can be confirmed by checking if a vendor/ folder is present in the module contents:
![image](https://github.com/PrestaShop/autoupgrade/assets/6768917/acb93911-bf14-417d-82a5-ee2b0a37552a)

When installing PrestaShop 8.1.0 and upgrade immediately to 8.1.6, the new core dependencies are copied but:
* Some files were deleted if they were not found in the new release
* The new files of the module were not copied

These 2 issues are respectively fixed by each topic covered in the description.