### PR TITLE
Cherry pick: Remove old controller AdminSelfUpgrade.php manually

### DIFF
--- a/autoupgrade.php
+++ b/autoupgrade.php
@@ -36,7 +36,7 @@ class Autoupgrade extends Module
         $this->name = 'autoupgrade';
         $this->tab = 'administration';
         $this->author = 'PrestaShop';
-        $this->version = '5.0.2';
+        $this->version = '5.0.3';
         $this->need_instance = 1;
 
         $this->bootstrap = true;

--- a/config.xml
+++ b/config.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <module>
-  <name>autoupgrade</name>
-  <displayName><![CDATA[1-Click Upgrade]]></displayName>
-  <version><![CDATA[5.0.2]]></version>
-  <description><![CDATA[Upgrade to the latest version of PrestaShop in a few clicks, thanks to this automated method.]]></description>
-  <author><![CDATA[PrestaShop]]></author>
-  <tab><![CDATA[administration]]></tab>
-  <is_configurable>1</is_configurable>
-  <need_instance>1</need_instance>
-  <limited_countries></limited_countries>
+    <name>autoupgrade</name>
+    <displayName><![CDATA[1-Click Upgrade]]></displayName>
+    <version><![CDATA[5.0.3]]></version>
+    <description><![CDATA[Upgrade to the latest version of PrestaShop in a few clicks, thanks to this automated method.]]></description>
+    <author><![CDATA[PrestaShop]]></author>
+    <tab><![CDATA[administration]]></tab>
+    <is_configurable>1</is_configurable>
+    <need_instance>1</need_instance>
 </module>

--- a/upgrade/install-5.0.3.php
+++ b/upgrade/install-5.0.3.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * 2007-2022 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2022 PrestaShop SA
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * Manually remove the legacy controller. It has been deleted from the project but remain present while upgrading the module.
+ *
+ * @return bool
+ */
+function upgrade_module_5_0_3($module)
+{
+    $path = __DIR__ . '/../AdminSelfUpgrade.php';
+    if (file_exists($path)) {
+        $result = @unlink($path);
+        if ($result !== true) {
+            PrestaShopLogger::addLog('Could not delete deprecated controller AdminSelfUpgrade.php. ' . $result, 3);
+
+            return false;
+        }
+    }
+
+    return true;
+}


### PR DESCRIPTION
This PR is a cherry pick of https://github.com/PrestaShop/autoupgrade/pull/716 for the `dev` targeting versions 6+ of the module

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When upgrading the module to 5.0.2, the old controller we removed on Git is not deleted on the shop. It remains called first by the shop, and because it does not have some the changes on how to instanciate UpgradeSelfCheck.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/36317, Fixes https://github.com/PrestaShop/PrestaShop/issues/36330
| Sponsor company   | PrestaShopCorp
| How to test?      | ~Upgrade from 5.0.1 to 5.0.3, accessing the configuration page must work.~ Checked on #716 
