### PR TITLE
Improve regeneration of RTL files during upgrade

### DIFF
--- a/classes/Parameters/UpgradeConfigurationStorage.php
+++ b/classes/Parameters/UpgradeConfigurationStorage.php
@@ -61,6 +61,7 @@ class UpgradeConfigurationStorage extends FileConfigurationStorage
             'PS_AUTOUP_CUSTOM_MOD_DESACT' => 1,
             'PS_AUTOUP_UPDATE_DEFAULT_THEME' => 1,
             'PS_AUTOUP_CHANGE_DEFAULT_THEME' => 0,
+            'PS_AUTOUP_UPDATE_RTL_FILES' => 1,
             'PS_AUTOUP_KEEP_MAILS' => 0,
             'PS_AUTOUP_BACKUP' => 1,
             'PS_AUTOUP_KEEP_IMAGES' => 1,

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -732,6 +732,10 @@ abstract class CoreUpgrader
         if (class_exists(RtlStylesheetProcessor::class)) {
             $this->logger->info($this->container->getTranslator()->trans('Upgrade the RTL files of back-office theme.', [], 'Modules.Autoupgrade.Admin'));
 
+            $this->removeExistingRTLFiles([
+                ['directory' => $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH) . DIRECTORY_SEPARATOR . 'themes'],
+            ]);
+
             (new RtlStylesheetProcessor(
                 $this->container->getProperty(UpgradeContainer::PS_ADMIN_PATH),
                 $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH) . DIRECTORY_SEPARATOR . 'themes',
@@ -774,6 +778,9 @@ abstract class CoreUpgrader
         }
     }
 
+    /**
+     * @param array{array{'directory':string,'name':string}} $themes
+     */
     private function removeExistingRTLFiles(array $themes): void
     {
         $filesystem = new Filesystem();

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -730,10 +730,10 @@ abstract class CoreUpgrader
 
         // BO theme
         if (class_exists(RtlStylesheetProcessor::class)) {
-            $this->logger->info($this->container->getTranslator()->trans('Upgrade the RTL files of back-office theme.', [], 'Modules.Autoupgrade.Admin'));
+            $this->logger->info($this->container->getTranslator()->trans('Upgrade the RTL files of back-office themes.', [], 'Modules.Autoupgrade.Admin'));
 
             $this->removeExistingRTLFiles([
-                ['directory' => $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH) . DIRECTORY_SEPARATOR . 'themes'],
+                ['directory' => $this->container->getProperty(UpgradeContainer::PS_ADMIN_PATH) . DIRECTORY_SEPARATOR . 'themes'],
             ]);
 
             (new RtlStylesheetProcessor(

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -63,6 +63,11 @@ abstract class CoreUpgrader
     protected $logger;
 
     /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
      * Version PrestaShop is upgraded to.
      *
      * @var string
@@ -87,6 +92,8 @@ abstract class CoreUpgrader
     {
         $this->container = $container;
         $this->logger = $logger;
+
+        $this->filesystem = new Filesystem();
     }
 
     public function doUpgrade()
@@ -730,7 +737,7 @@ abstract class CoreUpgrader
 
         // BO theme
         if (class_exists(RtlStylesheetProcessor::class)) {
-            $this->logger->info($this->container->getTranslator()->trans('Upgrade the RTL files of back-office themes.', [], 'Modules.Autoupgrade.Admin'));
+            $this->logger->info($this->container->getTranslator()->trans('Upgrade the RTL files of back-office themes.'));
 
             $this->removeExistingRTLFiles([
                 ['directory' => $this->container->getProperty(UpgradeContainer::PS_ADMIN_PATH) . DIRECTORY_SEPARATOR . 'themes'],
@@ -751,7 +758,7 @@ abstract class CoreUpgrader
             return;
         }
 
-        $this->logger->info($this->container->getTranslator()->trans('Upgrade the RTL files of front-office themes.', [], 'Modules.Autoupgrade.Admin'));
+        $this->logger->info($this->container->getTranslator()->trans('Upgrade the RTL files of front-office themes.'));
         $themeAdapter = new ThemeAdapter($this->db);
 
         $themes = $themeAdapter->getListFromDisk();
@@ -779,15 +786,13 @@ abstract class CoreUpgrader
     }
 
     /**
-     * @param array{array{'directory':string,'name':string}} $themes
+     * @param array{array{'directory':string}} $themes
      */
     private function removeExistingRTLFiles(array $themes): void
     {
-        $filesystem = new Filesystem();
-
         foreach ($themes as $theme) {
             $files = $this->container->getFilesystemAdapter()->listSampleFiles($theme['directory'], '_rtl.css');
-            $filesystem->remove($files);
+            $this->filesystem->remove($files);
         }
     }
 

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -730,6 +730,8 @@ abstract class CoreUpgrader
 
         // BO theme
         if (class_exists(RtlStylesheetProcessor::class)) {
+            $this->logger->info($this->container->getTranslator()->trans('Upgrade the RTL files of back-office theme.', [], 'Modules.Autoupgrade.Admin'));
+
             (new RtlStylesheetProcessor(
                 $this->container->getProperty(UpgradeContainer::PS_ADMIN_PATH),
                 $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH) . DIRECTORY_SEPARATOR . 'themes',
@@ -745,7 +747,7 @@ abstract class CoreUpgrader
             return;
         }
 
-        $this->logger->info($this->container->getTranslator()->trans('Upgrade the RTL files.', [], 'Modules.Autoupgrade.Admin'));
+        $this->logger->info($this->container->getTranslator()->trans('Upgrade the RTL files of front-office themes.', [], 'Modules.Autoupgrade.Admin'));
         $themeAdapter = new ThemeAdapter($this->db);
 
         $themes = $themeAdapter->getListFromDisk();

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader17.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader17.php
@@ -27,14 +27,7 @@
 
 namespace PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader;
 
-use Exception;
 use PrestaShop\Module\AutoUpgrade\UpgradeException;
-use PrestaShop\Module\AutoUpgrade\UpgradeTools\ThemeAdapter;
-use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
-use PrestaShop\PrestaShop\Core\Domain\Theme\Command\AdaptThemeToRTLLanguagesCommand;
-use PrestaShop\PrestaShop\Core\Domain\Theme\ValueObject\ThemeName;
-use PrestaShop\PrestaShop\Core\Exception\CoreException;
-use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * Class used to modify the core of PrestaShop, on the files are copied on the filesystem.
@@ -84,65 +77,6 @@ class CoreUpgrader17 extends CoreUpgrader
         if (version_compare($this->container->getState()->getInstallVersion(), '1.7.6.0', '<')) {
             $cldrUpdate = new \PrestaShop\PrestaShop\Core\Cldr\Update(_PS_TRANSLATIONS_DIR_);
             $cldrUpdate->fetchLocale(\Language::getLocaleByIso($isoCode));
-        }
-    }
-
-    protected function updateTheme(): void
-    {
-        parent::updateTheme();
-
-        $this->updateRTLFiles();
-    }
-
-    /**
-     * @throws Exception
-     */
-    protected function updateRTLFiles()
-    {
-        if (!class_exists(AdaptThemeToRTLLanguagesCommand::class)) {
-            return;
-        }
-
-        if (!$this->container->getUpgradeConfiguration()->shouldUpdateRTLFiles()) {
-            return;
-        }
-        $this->logger->info($this->container->getTranslator()->trans('Upgrade the RTL files.'));
-        $themeAdapter = new ThemeAdapter($this->db);
-
-        $themes = $themeAdapter->getListFromDisk();
-        $this->removeExistingRTLFiles($themes);
-
-        foreach ($themes as $theme) {
-            $adaptThemeToTRLLanguages = new AdaptThemeToRTLLanguagesCommand(
-                new ThemeName($theme['name'])
-            );
-
-            /** @var CommandBusInterface $commandBus */
-            $commandBus = $this->container->getModuleAdapter()->getCommandBus();
-
-            try {
-                $commandBus->handle($adaptThemeToTRLLanguages);
-            } catch (CoreException $e) {
-                $this->logger->error('
-                    [ERROR] PHP Impossible to generate RTL files for theme' . $theme['name'] . "\n" .
-                    $e->getMessage()
-                );
-
-                $this->container->getState()->setWarningExists(true);
-            }
-        }
-    }
-
-    /**
-     * @throws Exception
-     */
-    private function removeExistingRTLFiles(array $themes)
-    {
-        $filesystem = new Filesystem();
-
-        foreach ($themes as $theme) {
-            $files = $this->container->getFilesystemAdapter()->listSampleFiles($theme['directory'], '_rtl.css');
-            $filesystem->remove($files);
         }
     }
 }

--- a/classes/UpgradeTools/ThemeAdapter.php
+++ b/classes/UpgradeTools/ThemeAdapter.php
@@ -49,7 +49,7 @@ class ThemeAdapter
     /**
      * Get the list of theme name.
      *
-     * @return array
+     * @return array{array{'directory':string,'name':string}}
      */
     public function getListFromDisk(): array
     {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The pages in RTL languages are not displayed properly after an upgrade, this PR aims to make sure the generation is properly triggered.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/29918, Fixes https://github.com/PrestaShop/PrestaShop/issues/29916, Fixes https://github.com/PrestaShop/PrestaShop/issues/27470
| Sponsor company   | @PrestaShopCorp
| How to test?      | Install PrestaShop on 1.7 with the Arabic language and the country Saudi Arabia. After upgrading the shop, the pages on the BO + FO must be the same as on a freshly installed shop.

![Capture d’écran du 2024-06-11 12-19-33](https://github.com/PrestaShop/autoupgrade/assets/6768917/f13001d0-a179-42e4-b1ef-62bbe56f8165)
![Capture d’écran du 2024-06-11 12-24-15](https://github.com/PrestaShop/autoupgrade/assets/6768917/91bd157d-de4d-4659-8db6-4d159ff325d9)
