### PR TITLE
Sanitize sensitive data (admin folder) from logs

### DIFF
--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -408,7 +408,10 @@ class UpgradeContainer
         if (is_writable($this->getProperty(self::TMP_PATH))) {
             $logFile = $this->getProperty(self::TMP_PATH) . DIRECTORY_SEPARATOR . 'log.txt';
         }
-        $this->logger = new LegacyLogger($logFile);
+        $this->logger = (new LegacyLogger($logFile))
+            ->setSensitiveData([
+                $this->getProperty(self::PS_ADMIN_SUBDIR) => '**admin_folder**',
+            ]);
 
         return $this->logger;
     }

--- a/tests/unit/Log/LegacyLoggerTest.php
+++ b/tests/unit/Log/LegacyLoggerTest.php
@@ -69,4 +69,24 @@ class LegacyLoggerTest extends TestCase
         $this->assertCount(0, $logger->getErrors());
         $this->assertSame('Some stuff happened', end($messages));
     }
+
+    public function testSensitiveDataAreReplaced()
+    {
+        $logger = new LegacyLogger();
+        $logger->setSensitiveData([
+            'my-aldmin-folder' => '******',
+            '🚬' => '🚭',
+            'some@email.com' => '***@****.**',
+        ]);
+
+        $this->assertSame(
+            'File /shop/******/config.yml created',
+            $logger->cleanFromSensitiveData('File /shop/my-aldmin-folder/config.yml created')
+        );
+
+        $this->assertSame(
+            '***@****.** suggested 🚭',
+            $logger->cleanFromSensitiveData('some@email.com suggested 🚬')
+        );
+    }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | In order to make sharing of upgrade logs safer for merchants, we sanitize some critical details before inserting in the logs. This starts with the name of the admin folder. Logs shown in CLI are not impacted.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Admin folder is not anymore written in the file `log.txt` and on the logs displayed on the page.
