### PR TITLE
Fix undefined method 'addPath' in TwigLoader

### DIFF
--- a/controllers/admin/AdminSelfUpgradeController.php
+++ b/controllers/admin/AdminSelfUpgradeController.php
@@ -497,7 +497,10 @@ class AdminSelfUpgradeController extends ModuleAdminController
 
             try {
                 global $kernel;
-                $kernel->getContainer()->get('twig.loader')->addPath('../modules/autoupgrade/views/templates', 'ModuleAutoUpgrade');
+                $twigLoader = $kernel->getContainer()->get('twig.loader');
+                if (method_exists($twigLoader, 'addPath')) {
+                    $twigLoader->addPath('../modules/autoupgrade/views/templates', 'ModuleAutoUpgrade');
+                }
                 $twig = $kernel->getContainer()->get('twig');
                 $this->content = $twig->render('@ModuleAutoUpgrade/error.twig', $templateData);
             } catch (Exception $e) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix undefined method 'addPath' in TwigLoader
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | -
| How to test?      | In Prestashop 1.7.3.0 with php version < 7.1, install module with marketplace, replace the content with this PR and test configuration page. An alert should be present information that the PHP version is not compatible