### PR TITLE
Add condition when version_num is null for compute PHP compatibility range

### DIFF
--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -359,7 +359,7 @@ class UpgradeSelfCheck
             && ($this->isShopDeactivated() || $this->isLocalEnvironment())
             && $this->isCacheDisabled()
             && $this->isModuleVersionLatest()
-            && $this->getPhpRequirementsState() != $this::PHP_REQUIREMENTS_INVALID
+            && $this->getPhpRequirementsState() !== $this::PHP_REQUIREMENTS_INVALID
             && $this->isShopVersionMatchingVersionInDatabase()
             && $this->isApacheModRewriteEnabled()
             && $this->checkKeyGeneration()
@@ -451,6 +451,10 @@ class UpgradeSelfCheck
         }
 
         $targetVersion = $this->upgrader->version_num;
+
+        if (null === $targetVersion) {
+            return null;
+        }
 
         if (version_compare($targetVersion, '8', '<')) {
             $targetVersion = VersionUtils::getPrestashopMinorVersion($targetVersion);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add condition when version_num is null for compute PHP compatibility range
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | -
| How to test?      | Select "local archive" channel, save without selected files
