### PR TITLE
UI tests - Add PS versions from 8.0.0 ~ 8.1.7 (Minor) - PHP 7.2~ 8.1

### DIFF
--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -32,24 +32,40 @@ jobs:
             PHP_VERSION: 7.2
           - PS_VERSION_START: 8.0.0
             PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: major
+            PHP_VERSION: 7.2
+          - PS_VERSION_START: 8.0.1
+            PS_VERSION_END: 8.0.5
             UPGRADE_CHANNEL: minor
-            PHP_VERSION: 7.1
+            PHP_VERSION: 7.2
           - PS_VERSION_START: 8.0.1
             PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: major
+            PHP_VERSION: 7.2
+          - PS_VERSION_START: 8.0.2
+            PS_VERSION_END: 8.0.5
             UPGRADE_CHANNEL: minor
-            PHP_VERSION: 7.1
+            PHP_VERSION: 7.2
           - PS_VERSION_START: 8.0.2
             PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: major
+            PHP_VERSION: 7.2
+          - PS_VERSION_START: 8.0.3
+            PS_VERSION_END: 8.0.5
             UPGRADE_CHANNEL: minor
-            PHP_VERSION: 7.1
+            PHP_VERSION: 7.2
           - PS_VERSION_START: 8.0.3
             PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: major
+            PHP_VERSION: 7.2
+          - PS_VERSION_START: 8.0.4
+            PS_VERSION_END: 8.0.5
             UPGRADE_CHANNEL: minor
-            PHP_VERSION: 7.1
+            PHP_VERSION: 7.2
           - PS_VERSION_START: 8.0.4
             PS_VERSION_END: 8.1.7
-            UPGRADE_CHANNEL: minor
-            PHP_VERSION: 7.1
+            UPGRADE_CHANNEL: major
+            PHP_VERSION: 7.2
           - PS_VERSION_START: 8.0.5
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
@@ -57,31 +73,31 @@ jobs:
           - PS_VERSION_START: 8.1.0
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
-            PHP_VERSION: 7.1
+            PHP_VERSION: 7.2
           - PS_VERSION_START: 8.1.1
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
-            PHP_VERSION: 7.1
+            PHP_VERSION: 7.2
           - PS_VERSION_START: 8.1.2
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
-            PHP_VERSION: 7.1
+            PHP_VERSION: 7.2
           - PS_VERSION_START: 8.1.3
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
-            PHP_VERSION: 7.1
+            PHP_VERSION: 7.2
           - PS_VERSION_START: 8.1.4
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
-            PHP_VERSION: 7.1
+            PHP_VERSION: 7.2
           - PS_VERSION_START: 8.1.5
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
-            PHP_VERSION: 7.1
+            PHP_VERSION: 7.2
           - PS_VERSION_START: 8.1.6
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
-            PHP_VERSION: 7.1
+            PHP_VERSION: 7.2
           - PS_VERSION_START: 8.1.0
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -26,78 +26,139 @@ jobs:
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: major
             PHP_VERSION: 7.4
+            # 8.0.0 ~ minor PHP 7.2 ~ 8.1
+          - PS_VERSION_START: 8.0.0
+            PS_VERSION_END: 8.1.7
           - PS_VERSION_START: 8.0.1
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
             PHP_VERSION: 7.2
           - PS_VERSION_START: 8.0.0
             PS_VERSION_END: 8.1.7
-            UPGRADE_CHANNEL: major
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.3
+          - PS_VERSION_START: 8.0.0
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 8.0.0
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 8.0
+          - PS_VERSION_START: 8.0.0
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 8.1
+            # 8.0.1 ~ minor PHP 7.2 ~ 8.1
+          - PS_VERSION_START: 8.0.1
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
             PHP_VERSION: 7.2
           - PS_VERSION_START: 8.0.1
-            PS_VERSION_END: 8.0.5
+            PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
-            PHP_VERSION: 7.2
+            PHP_VERSION: 7.3
           - PS_VERSION_START: 8.0.1
             PS_VERSION_END: 8.1.7
-            UPGRADE_CHANNEL: major
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 8.0.1
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 8.0
+          - PS_VERSION_START: 8.0.1
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 8.1
+          # 8.0.2 ~ minor PHP 7.2 ~ 8.1
+          - PS_VERSION_START: 8.0.2
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
             PHP_VERSION: 7.2
           - PS_VERSION_START: 8.0.2
-            PS_VERSION_END: 8.0.5
+            PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
-            PHP_VERSION: 7.2
+            PHP_VERSION: 7.3
           - PS_VERSION_START: 8.0.2
             PS_VERSION_END: 8.1.7
-            UPGRADE_CHANNEL: major
-            PHP_VERSION: 7.2
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 8.0.2
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 8.0
+          - PS_VERSION_START: 8.0.2
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 8.1
+            # 8.0.3 ~ minor PHP 7.2 ~ 8.1
           - PS_VERSION_START: 8.0.3
-            PS_VERSION_END: 8.0.5
+            PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
             PHP_VERSION: 7.2
           - PS_VERSION_START: 8.0.3
             PS_VERSION_END: 8.1.7
-            UPGRADE_CHANNEL: major
-            PHP_VERSION: 7.2
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.3
+          - PS_VERSION_START: 8.0.3
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 8.0.3
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 8.0
+          - PS_VERSION_START: 8.0.3
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 8.1
+            # 8.0.4 ~ minor PHP 7.2 ~ 8.1
           - PS_VERSION_START: 8.0.4
-            PS_VERSION_END: 8.0.5
+            PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
             PHP_VERSION: 7.2
           - PS_VERSION_START: 8.0.4
             PS_VERSION_END: 8.1.7
-            UPGRADE_CHANNEL: major
-            PHP_VERSION: 7.2
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.3
+          - PS_VERSION_START: 8.0.4
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 8.0.4
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 8.0
+          - PS_VERSION_START: 8.0.4
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 8.1
           - PS_VERSION_START: 8.0.5
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
             PHP_VERSION: 7.2
-          - PS_VERSION_START: 8.1.0
+            # 8.0.4 ~ minor PHP 7.2 ~ 8.1
+          - PS_VERSION_START: 8.0.5
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
             PHP_VERSION: 7.2
-          - PS_VERSION_START: 8.1.1
+          - PS_VERSION_START: 8.0.5
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
-            PHP_VERSION: 7.2
-          - PS_VERSION_START: 8.1.2
+            PHP_VERSION: 7.3
+          - PS_VERSION_START: 8.0.5
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
-            PHP_VERSION: 7.2
-          - PS_VERSION_START: 8.1.3
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 8.0.5
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
-            PHP_VERSION: 7.2
-          - PS_VERSION_START: 8.1.4
+            PHP_VERSION: 8.0
+          - PS_VERSION_START: 8.0.5
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
-            PHP_VERSION: 7.2
-          - PS_VERSION_START: 8.1.5
-            PS_VERSION_END: 8.1.7
-            UPGRADE_CHANNEL: minor
-            PHP_VERSION: 7.2
-          - PS_VERSION_START: 8.1.6
-            PS_VERSION_END: 8.1.7
-            UPGRADE_CHANNEL: minor
-            PHP_VERSION: 7.2
+            PHP_VERSION: 8.1
+            # 8.1.0 ~ minor PHP 7.2 ~ 8.1
           - PS_VERSION_START: 8.1.0
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
@@ -106,6 +167,144 @@ jobs:
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
             PHP_VERSION: 7.3
+          - PS_VERSION_START: 8.1.0
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 8.1.0
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 8.0
+          - PS_VERSION_START: 8.1.0
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 8.1
+            # 8.1.1 ~ minor PHP 7.2 ~ 8.1
+          - PS_VERSION_START: 8.1.1
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.2
+          - PS_VERSION_START: 8.1.1
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.3
+          - PS_VERSION_START: 8.1.1
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 8.1.1
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 8.0
+          - PS_VERSION_START: 8.1.1
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 8.1
+            # 8.1.2 ~ minor PHP 7.2 ~ 8.1
+          - PS_VERSION_START: 8.1.2
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.2
+          - PS_VERSION_START: 8.1.2
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.3
+          - PS_VERSION_START: 8.1.2
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 8.1.2
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 8.0
+          - PS_VERSION_START: 8.1.2
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 8.1
+            # 8.1.3 ~ minor PHP 7.2 ~ 8.1
+          - PS_VERSION_START: 8.1.3
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.2
+          - PS_VERSION_START: 8.1.3
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.3
+          - PS_VERSION_START: 8.1.3
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 8.1.3
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 8.0
+          - PS_VERSION_START: 8.1.3
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 8.1
+            # 8.1.4 ~ minor PHP 7.2 ~ 8.1
+          - PS_VERSION_START: 8.1.4
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.2
+          - PS_VERSION_START: 8.1.4
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.3
+          - PS_VERSION_START: 8.1.4
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 8.1.4
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 8.0
+          - PS_VERSION_START: 8.1.4
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 8.1
+            # 8.1.5 ~ minor PHP 7.2 ~ 8.1
+          - PS_VERSION_START: 8.1.5
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.2
+          - PS_VERSION_START: 8.1.5
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.3
+          - PS_VERSION_START: 8.1.5
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 8.1.5
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 8.0
+          - PS_VERSION_START: 8.1.5
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 8.1
+            # 8.1.6 ~ minor PHP 7.2 ~ 8.1
+          - PS_VERSION_START: 8.1.6
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.2
+          - PS_VERSION_START: 8.1.6
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.3
+          - PS_VERSION_START: 8.1.6
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 8.1.6
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 8.0
+          - PS_VERSION_START: 8.1.6
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 8.1
 
     env:
       PS_DOCKER: ${{ matrix.PS_VERSION_START }}-${{ matrix.PHP_VERSION }}

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -29,8 +29,6 @@ jobs:
             # 8.0.0 ~ minor PHP 7.2 ~ 8.1
           - PS_VERSION_START: 8.0.0
             PS_VERSION_END: 8.1.7
-          - PS_VERSION_START: 8.0.1
-            PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
             PHP_VERSION: 7.2
           - PS_VERSION_START: 8.0.0
@@ -133,11 +131,7 @@ jobs:
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
             PHP_VERSION: 8.1
-          - PS_VERSION_START: 8.0.5
-            PS_VERSION_END: 8.1.7
-            UPGRADE_CHANNEL: minor
-            PHP_VERSION: 7.2
-            # 8.0.4 ~ minor PHP 7.2 ~ 8.1
+            # 8.0.5 ~ minor PHP 7.2 ~ 8.1
           - PS_VERSION_START: 8.0.5
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -44,7 +44,7 @@ jobs:
           - PS_VERSION_START: 8.0.0
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
-            PHP_VERSION: 8.0
+            PHP_VERSION: '8.0'
           - PS_VERSION_START: 8.0.0
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
@@ -65,7 +65,7 @@ jobs:
           - PS_VERSION_START: 8.0.1
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
-            PHP_VERSION: 8.0
+            PHP_VERSION: '8.0'
           - PS_VERSION_START: 8.0.1
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
@@ -86,7 +86,7 @@ jobs:
           - PS_VERSION_START: 8.0.2
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
-            PHP_VERSION: 8.0
+            PHP_VERSION: '8.0'
           - PS_VERSION_START: 8.0.2
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
@@ -107,7 +107,7 @@ jobs:
           - PS_VERSION_START: 8.0.3
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
-            PHP_VERSION: 8.0
+            PHP_VERSION: '8.0'
           - PS_VERSION_START: 8.0.3
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
@@ -128,7 +128,7 @@ jobs:
           - PS_VERSION_START: 8.0.4
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
-            PHP_VERSION: 8.0
+            PHP_VERSION: '8.0'
           - PS_VERSION_START: 8.0.4
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
@@ -153,7 +153,7 @@ jobs:
           - PS_VERSION_START: 8.0.5
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
-            PHP_VERSION: 8.0
+            PHP_VERSION: '8.0'
           - PS_VERSION_START: 8.0.5
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
@@ -174,7 +174,7 @@ jobs:
           - PS_VERSION_START: 8.1.0
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
-            PHP_VERSION: 8.0
+            PHP_VERSION: '8.0'
           - PS_VERSION_START: 8.1.0
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
@@ -195,7 +195,7 @@ jobs:
           - PS_VERSION_START: 8.1.1
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
-            PHP_VERSION: 8.0
+            PHP_VERSION: '8.0'
           - PS_VERSION_START: 8.1.1
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
@@ -216,7 +216,7 @@ jobs:
           - PS_VERSION_START: 8.1.2
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
-            PHP_VERSION: 8.0
+            PHP_VERSION: '8.0'
           - PS_VERSION_START: 8.1.2
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
@@ -237,7 +237,7 @@ jobs:
           - PS_VERSION_START: 8.1.3
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
-            PHP_VERSION: 8.0
+            PHP_VERSION: '8.0'
           - PS_VERSION_START: 8.1.3
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
@@ -258,7 +258,7 @@ jobs:
           - PS_VERSION_START: 8.1.4
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
-            PHP_VERSION: 8.0
+            PHP_VERSION: '8.0'
           - PS_VERSION_START: 8.1.4
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
@@ -279,7 +279,7 @@ jobs:
           - PS_VERSION_START: 8.1.5
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
-            PHP_VERSION: 8.0
+            PHP_VERSION: '8.0'
           - PS_VERSION_START: 8.1.5
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
@@ -300,7 +300,7 @@ jobs:
           - PS_VERSION_START: 8.1.6
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
-            PHP_VERSION: 8.0
+            PHP_VERSION: '8.0'
           - PS_VERSION_START: 8.1.6
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -30,10 +30,58 @@ jobs:
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
             PHP_VERSION: 7.2
+          - PS_VERSION_START: 8.0.0
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.1
+          - PS_VERSION_START: 8.0.1
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.1
+          - PS_VERSION_START: 8.0.2
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.1
+          - PS_VERSION_START: 8.0.3
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.1
+          - PS_VERSION_START: 8.0.4
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.1
           - PS_VERSION_START: 8.0.5
             PS_VERSION_END: 8.1.7
-            UPGRADE_CHANNEL: major
+            UPGRADE_CHANNEL: minor
             PHP_VERSION: 7.2
+          - PS_VERSION_START: 8.1.0
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.1
+          - PS_VERSION_START: 8.1.1
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.1
+          - PS_VERSION_START: 8.1.2
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.1
+          - PS_VERSION_START: 8.1.3
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.1
+          - PS_VERSION_START: 8.1.4
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.1
+          - PS_VERSION_START: 8.1.5
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.1
+          - PS_VERSION_START: 8.1.6
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.1
           - PS_VERSION_START: 8.1.0
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | UI tests - Add PS versions from 8.0.0 ~ 8.1.7 (Minor) - PHP 7.2~ 8.1
| Type?             | improvement
| Sponsor company   | @PrestaShopCorps
| How to test?      | CI is :green_apple: 
