### PR TITLE
Fix minor channel on PS 8 and above

### DIFF
--- a/classes/ChannelInfo.php
+++ b/classes/ChannelInfo.php
@@ -43,8 +43,7 @@ class ChannelInfo
         $this->channel = $channel;
         $publicChannels = ['minor', 'major', 'rc', 'beta', 'alpha'];
 
-        preg_match('#([0-9]+\.[0-9]+)(?:\.[0-9]+){1,2}#', _PS_VERSION_, $matches);
-        $upgrader->branch = $matches[1];
+        $upgrader->branch = VersionUtils::getPrestashopMajorVersion(_PS_VERSION_);
         $upgrader->channel = $channel;
 
         if (in_array($channel, $publicChannels)) {

--- a/classes/ChannelInfo.php
+++ b/classes/ChannelInfo.php
@@ -43,7 +43,7 @@ class ChannelInfo
         $this->channel = $channel;
         $publicChannels = ['minor', 'major', 'rc', 'beta', 'alpha'];
 
-        $upgrader->branch = VersionUtils::getPrestashopMajorVersion(_PS_VERSION_);
+        $upgrader->branch = VersionUtils::splitPrestaShopVersion(_PS_VERSION_)['major'];
         $upgrader->channel = $channel;
 
         if (in_array($channel, $publicChannels)) {

--- a/classes/TaskRunner/Miscellaneous/CompareReleases.php
+++ b/classes/TaskRunner/Miscellaneous/CompareReleases.php
@@ -30,6 +30,7 @@ namespace PrestaShop\Module\AutoUpgrade\TaskRunner\Miscellaneous;
 use Exception;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeFileNames;
 use PrestaShop\Module\AutoUpgrade\TaskRunner\AbstractTask;
+use PrestaShop\Module\AutoUpgrade\VersionUtils;
 
 /**
  * This class gets the list of all modified and deleted files between current version
@@ -55,8 +56,7 @@ class CompareReleases extends AbstractTask
                 $version = $this->container->getUpgradeConfiguration()->get('directory.version_num');
                 break;
             default:
-                preg_match('#([0-9]+\.[0-9]+)(?:\.[0-9]+){1,2}#', _PS_VERSION_, $matches);
-                $upgrader->branch = $matches[1];
+                $upgrader->branch = VersionUtils::getPrestashopMajorVersion(_PS_VERSION_);
                 $upgrader->channel = $channel;
                 if ($this->container->getUpgradeConfiguration()->get('channel') == 'private' && !$this->container->getUpgradeConfiguration()->get('private_allow_major')) {
                     $upgrader->checkPSVersion(false, ['private', 'minor']);

--- a/classes/TaskRunner/Miscellaneous/CompareReleases.php
+++ b/classes/TaskRunner/Miscellaneous/CompareReleases.php
@@ -56,7 +56,7 @@ class CompareReleases extends AbstractTask
                 $version = $this->container->getUpgradeConfiguration()->get('directory.version_num');
                 break;
             default:
-                $upgrader->branch = VersionUtils::getPrestashopMajorVersion(_PS_VERSION_);
+                $upgrader->branch = VersionUtils::splitPrestaShopVersion(_PS_VERSION_)['major'];
                 $upgrader->channel = $channel;
                 if ($this->container->getUpgradeConfiguration()->get('channel') == 'private' && !$this->container->getUpgradeConfiguration()->get('private_allow_major')) {
                     $upgrader->checkPSVersion(false, ['private', 'minor']);

--- a/classes/TaskRunner/Upgrade/Download.php
+++ b/classes/TaskRunner/Upgrade/Download.php
@@ -52,7 +52,7 @@ class Download extends AbstractTask
 
         $upgrader = $this->container->getUpgrader();
         $upgrader->channel = $this->container->getUpgradeConfiguration()->get('channel');
-        $upgrader->branch = VersionUtils::getPrestashopMajorVersion(_PS_VERSION_);
+        $upgrader->branch = VersionUtils::splitPrestaShopVersion(_PS_VERSION_)['major'];
         if ($this->container->getUpgradeConfiguration()->get('channel') == 'private' && !$this->container->getUpgradeConfiguration()->get('private_allow_major')) {
             $upgrader->checkPSVersion(false, ['private', 'minor']);
         } else {

--- a/classes/TaskRunner/Upgrade/Download.php
+++ b/classes/TaskRunner/Upgrade/Download.php
@@ -31,6 +31,7 @@ use Exception;
 use PrestaShop\Module\AutoUpgrade\TaskRunner\AbstractTask;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\FilesystemAdapter;
+use PrestaShop\Module\AutoUpgrade\VersionUtils;
 
 /**
  * Download PrestaShop archive according to the chosen channel.
@@ -50,10 +51,8 @@ class Download extends AbstractTask
         }
 
         $upgrader = $this->container->getUpgrader();
-        // regex optimization
-        preg_match('#([0-9]+\.[0-9]+)(?:\.[0-9]+){1,2}#', _PS_VERSION_, $matches);
         $upgrader->channel = $this->container->getUpgradeConfiguration()->get('channel');
-        $upgrader->branch = $matches[1];
+        $upgrader->branch = VersionUtils::getPrestashopMajorVersion(_PS_VERSION_);
         if ($this->container->getUpgradeConfiguration()->get('channel') == 'private' && !$this->container->getUpgradeConfiguration()->get('private_allow_major')) {
             $upgrader->checkPSVersion(false, ['private', 'minor']);
         } else {

--- a/classes/TaskRunner/Upgrade/UpgradeNow.php
+++ b/classes/TaskRunner/Upgrade/UpgradeNow.php
@@ -50,7 +50,7 @@ class UpgradeNow extends AbstractTask
         $upgrader = $this->container->getUpgrader();
         $this->next = 'download';
 
-        $upgrader->branch = VersionUtils::getPrestashopMajorVersion(_PS_VERSION_);
+        $upgrader->branch = VersionUtils::splitPrestaShopVersion(_PS_VERSION_)['major'];
         $upgrader->channel = $channel;
         if ($this->container->getUpgradeConfiguration()->get('channel') == 'private' && !$this->container->getUpgradeConfiguration()->get('private_allow_major')) {
             $upgrader->checkPSVersion(false, ['private', 'minor']);

--- a/classes/TaskRunner/Upgrade/UpgradeNow.php
+++ b/classes/TaskRunner/Upgrade/UpgradeNow.php
@@ -29,6 +29,7 @@ namespace PrestaShop\Module\AutoUpgrade\TaskRunner\Upgrade;
 
 use Exception;
 use PrestaShop\Module\AutoUpgrade\TaskRunner\AbstractTask;
+use PrestaShop\Module\AutoUpgrade\VersionUtils;
 
 /**
  * very first step of the upgrade process. The only thing done is the selection
@@ -48,8 +49,8 @@ class UpgradeNow extends AbstractTask
         $channel = $this->container->getUpgradeConfiguration()->get('channel');
         $upgrader = $this->container->getUpgrader();
         $this->next = 'download';
-        preg_match('#([0-9]+\.[0-9]+)(?:\.[0-9]+){1,2}#', _PS_VERSION_, $matches);
-        $upgrader->branch = $matches[1];
+
+        $upgrader->branch = VersionUtils::getPrestashopMajorVersion(_PS_VERSION_);
         $upgrader->channel = $channel;
         if ($this->container->getUpgradeConfiguration()->get('channel') == 'private' && !$this->container->getUpgradeConfiguration()->get('private_allow_major')) {
             $upgrader->checkPSVersion(false, ['private', 'minor']);

--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -324,8 +324,7 @@ class UpgradeContainer
             $this->getProperty(self::PS_VERSION),
             $fileLoader
         );
-        preg_match('#([0-9]+\.[0-9]+)(?:\.[0-9]+){1,2}#', $this->getProperty(self::PS_VERSION), $matches);
-        $upgrader->branch = $matches[1];
+        $upgrader->branch = VersionUtils::getPrestashopMajorVersion($this->getProperty(self::PS_VERSION));
         $upgradeConfiguration = $this->getUpgradeConfiguration();
         $channel = $upgradeConfiguration->get('channel');
         switch ($channel) {

--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -324,7 +324,7 @@ class UpgradeContainer
             $this->getProperty(self::PS_VERSION),
             $fileLoader
         );
-        $upgrader->branch = VersionUtils::getPrestashopMajorVersion($this->getProperty(self::PS_VERSION));
+        $upgrader->branch = VersionUtils::splitPrestaShopVersion($this->getProperty(self::PS_VERSION))['major'];
         $upgradeConfiguration = $this->getUpgradeConfiguration();
         $channel = $upgradeConfiguration->get('channel');
         switch ($channel) {

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -457,13 +457,13 @@ class UpgradeSelfCheck
         }
 
         if (version_compare($targetVersion, '8', '<')) {
-            $targetVersion = VersionUtils::getPrestashopMinorVersion($targetVersion);
+            $targetMinorVersion = VersionUtils::splitPrestaShopVersion($targetVersion)['minor'];
 
-            if (!isset($this::PRESTASHOP_17_PHP_REQUIREMENTS[$targetVersion])) {
+            if (!isset($this::PRESTASHOP_17_PHP_REQUIREMENTS[$targetMinorVersion])) {
                 return null;
             }
 
-            $range = $this::PRESTASHOP_17_PHP_REQUIREMENTS[$targetVersion];
+            $range = $this::PRESTASHOP_17_PHP_REQUIREMENTS[$targetMinorVersion];
         } else {
             try {
                 $range = $this->distributionApiService->getPhpVersionRequirements($targetVersion);

--- a/classes/VersionUtils.php
+++ b/classes/VersionUtils.php
@@ -99,16 +99,9 @@ class VersionUtils
     /**
      * @param string $version
      *
-     * @return string|null
+     * @return array{'major': string,'minor': string,'patch': string}|null
      */
-    public static function getPrestashopMajorVersion($version)
-    {
-        preg_match('#(([0-1]{1}\.[0-9]+)|([0-9]+))(?:\.[0-9]+){2}#', $version, $matches);
-
-        return $matches[1];
-    }
-
-    public static function getPrestashopMinorVersion($version)
+    public static function splitPrestaShopVersion($version)
     {
         if (!is_string($version)) {
             throw new InvalidArgumentException('Version must be a string.');
@@ -119,18 +112,20 @@ class VersionUtils
             throw new InvalidArgumentException('Version string cannot be empty.');
         }
 
-        if (!preg_match('/^\d+\.\d+\.\d+(\.\d+)?$/', $version)) {
+        preg_match(
+            '#^(?<patch>(?<minor>(?<major>([0-1]{1}\.[0-9]+)|([0-9]+))(?:\.[0-9]+){1})(?:\.[0-9]+){1})$#',
+            $version,
+            $matches
+        );
+
+        if (empty($matches)) {
             throw new InvalidArgumentException('Invalid version format. Expected format: X.Y.Z or X.Y.Z.W');
         }
 
-        $parts = explode('.', $version);
-        $versionString = implode('.', $parts);
-        if (strlen($versionString) >= 8) {
-            $minorVersionParts = array_slice($parts, 0, 3);
-        } else {
-            $minorVersionParts = array_slice($parts, 0, 2);
-        }
-
-        return implode('.', $minorVersionParts);
+        return [
+            'major' => $matches['major'],
+            'minor' => $matches['minor'],
+            'patch' => $matches['patch'],
+        ];
     }
 }

--- a/classes/VersionUtils.php
+++ b/classes/VersionUtils.php
@@ -96,6 +96,18 @@ class VersionUtils
         return PHP_VERSION_ID >= self::MODULE_COMPATIBLE_PHP_VERSION;
     }
 
+    /**
+     * @param string $version
+     *
+     * @return string|null
+     */
+    public static function getPrestashopMajorVersion($version)
+    {
+        preg_match('#(([0-1]{1}\.[0-9]+)|([0-9]+))(?:\.[0-9]+){2}#', $version, $matches);
+
+        return $matches[1];
+    }
+
     public static function getPrestashopMinorVersion($version)
     {
         if (!is_string($version)) {

--- a/tests/unit/VersionUtilsTest.php
+++ b/tests/unit/VersionUtilsTest.php
@@ -106,32 +106,22 @@ class VersionUtilsTest extends TestCase
     /**
      * @dataProvider providerOfPrestaShopVersions
      */
-    public function testGetPrestashopMajorVersions(string $inputVersion, array $expected)
+    public function testSplitOfPrestaShopVersion(string $inputVersion, array $expected)
     {
-        $version = VersionUtils::getPrestashopMajorVersion($inputVersion);
+        $version = VersionUtils::splitPrestaShopVersion($inputVersion);
 
-        $this->assertSame($expected['major'], $version);
-    }
-
-    /**
-     * @dataProvider providerOfPrestaShopVersions
-     */
-    public function testGetPrestashopMinorVersion(string $inputVersion, array $expected)
-    {
-        $version = VersionUtils::getPrestashopMinorVersion($inputVersion);
-
-        $this->assertSame($expected['minor'], $version);
+        $this->assertEquals($expected, $version);
     }
 
     public function providerOfPrestaShopVersions()
     {
         return [
-            ['1.6.1.12', ['major' => '1.6', 'minor' => '1.6.1']],
-            ['1.7.8.11', ['major' => '1.7', 'minor' => '1.7.8']],
-            ['8.1.5', ['major' => '8', 'minor' => '8.1']],
-            ['8.1.5', ['major' => '8', 'minor' => '8.1']],
-            ['9.0.0', ['major' => '9', 'minor' => '9.0']],
-            ['10.1.5', ['major' => '10', 'minor' => '10.1']],
+            ['1.6.1.12', ['major' => '1.6', 'minor' => '1.6.1', 'patch' => '1.6.1.12']],
+            ['1.7.8.11', ['major' => '1.7', 'minor' => '1.7.8', 'patch' => '1.7.8.11']],
+            ['8.1.5', ['major' => '8', 'minor' => '8.1', 'patch' => '8.1.5']],
+            ['8.1.5', ['major' => '8', 'minor' => '8.1', 'patch' => '8.1.5']],
+            ['9.0.0', ['major' => '9', 'minor' => '9.0', 'patch' => '9.0.0']],
+            ['10.1.5', ['major' => '10', 'minor' => '10.1', 'patch' => '10.1.5']],
         ];
     }
 
@@ -140,7 +130,7 @@ class VersionUtilsTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Version must be a string.');
 
-        VersionUtils::getPrestashopMinorVersion(1);
+        VersionUtils::splitPrestaShopVersion(1)['minor'];
     }
 
     public function testGetPrestashopMinorVersionFailForEmptyString()
@@ -148,7 +138,7 @@ class VersionUtilsTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Version string cannot be empty.');
 
-        VersionUtils::getPrestashopMinorVersion('');
+        VersionUtils::splitPrestaShopVersion('')['minor'];
     }
 
     public function testGetPrestashopMinorVersionFailForIncorrectEntryFormatV1()
@@ -156,7 +146,7 @@ class VersionUtilsTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid version format. Expected format: X.Y.Z or X.Y.Z.W');
 
-        VersionUtils::getPrestashopMinorVersion('1');
+        VersionUtils::splitPrestaShopVersion('1')['minor'];
     }
 
     public function testGetPrestashopMinorVersionFailForIncorrectEntryFormatV2()
@@ -164,6 +154,6 @@ class VersionUtilsTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid version format. Expected format: X.Y.Z or X.Y.Z.W');
 
-        VersionUtils::getPrestashopMinorVersion('1.7.7.10.1');
+        VersionUtils::splitPrestaShopVersion('1.7.7.10.1')['minor'];
     }
 }

--- a/tests/unit/VersionUtilsTest.php
+++ b/tests/unit/VersionUtilsTest.php
@@ -103,23 +103,36 @@ class VersionUtilsTest extends TestCase
         $this->assertSame(PHP_MAJOR_VERSION * 10000 + PHP_MINOR_VERSION * 100, $version);
     }
 
-    public function testGetPrestashopMinorVersion()
+    /**
+     * @dataProvider providerOfPrestaShopVersions
+     */
+    public function testGetPrestashopMajorVersions(string $inputVersion, array $expected)
     {
-        $version = VersionUtils::getPrestashopMinorVersion('1.7.8.11');
+        $version = VersionUtils::getPrestashopMajorVersion($inputVersion);
 
-        $this->assertSame('1.7.8', $version);
+        $this->assertSame($expected['major'], $version);
+    }
 
-        $version = VersionUtils::getPrestashopMinorVersion('8.1.5');
+    /**
+     * @dataProvider providerOfPrestaShopVersions
+     */
+    public function testGetPrestashopMinorVersion(string $inputVersion, array $expected)
+    {
+        $version = VersionUtils::getPrestashopMinorVersion($inputVersion);
 
-        $this->assertSame('8.1', $version);
+        $this->assertSame($expected['minor'], $version);
+    }
 
-        $version = VersionUtils::getPrestashopMinorVersion('8.1.5');
-
-        $this->assertSame('8.1', $version);
-
-        $version = VersionUtils::getPrestashopMinorVersion('10.1.5');
-
-        $this->assertSame('10.1', $version);
+    public function providerOfPrestaShopVersions()
+    {
+        return [
+            ['1.6.1.12', ['major' => '1.6', 'minor' => '1.6.1']],
+            ['1.7.8.11', ['major' => '1.7', 'minor' => '1.7.8']],
+            ['8.1.5', ['major' => '8', 'minor' => '8.1']],
+            ['8.1.5', ['major' => '8', 'minor' => '8.1']],
+            ['9.0.0', ['major' => '9', 'minor' => '9.0']],
+            ['10.1.5', ['major' => '10', 'minor' => '10.1']],
+        ];
     }
 
     public function testGetPrestashopMinorVersionFailForBadType()


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When we switched to major versions with a single level of number, we did not update the way they are managed from the channel.xml file. As a result, we had to specify all minor versions instead of majors only. This PR fixes the management of major versions from PS 8.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/36430
| Sponsor company   | Your company or customer's name goes here (if applicable).
| How to test?      | When running a shop on PS 8.0, the minor channel should propose upgrades to PS 8.1.7
