### PR TITLE
fix: minor version for upgrade from 8.0.1

### DIFF
--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -27,7 +27,7 @@ jobs:
             UPGRADE_CHANNEL: major
             PHP_VERSION: 7.4
           - PS_VERSION_START: 8.0.1
-            PS_VERSION_END: 8.0.5
+            PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor
             PHP_VERSION: 7.2
           - PS_VERSION_START: 8.0.5


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The current test to upgrade 8.0.1 to next minor end with 8.0.5, but it's not minor, it's patch. We update it to end with 8.1.7.
| Type?             | bug fix
| BC breaks?        |  no
| Deprecations?     | no
| Sponsor company   | @PrestaShopCorp
| How to test?      | Just check CI
