### PR TITLE
feat: start creating CI for extract translation

### DIFF
--- a/.github/workflows/extract-translations.yml
+++ b/.github/workflows/extract-translations.yml
@@ -1,0 +1,37 @@
+on:
+  push:
+    branches:
+      - feat/auto-export-translation
+
+jobs:
+  sync-translations:
+    name: Extract translations and submit a PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout module-translation-tool
+        uses: actions/checkout@v4
+        with:
+          repository: PrestaShopCorp/module-translation-tool
+          ref: main
+      - name: Create config for module-translation-tool
+        run: |
+          cp ./module.cfg.example ./module.cfg
+          sed -i 's/^MODULE_NAME.*/MODULE_NAME="autoupgrade"/g' ./module.cfg
+          sed -i 's/^GIT_REPO_USERNAME.*/GIT_REPO_USERNAME="PrestaShop"/g' ./module.cfg
+          sed -i 's/^GIT_REPO_NAME.*/GIT_REPO_NAME="autoupgrade"/g' ./module.cfg
+          sed -i 's/^BRANCH.*/BRANCH="dev"/g' ./module.cfg
+      - name: Setup git config
+        run: |
+          git config --global user.name "Github Actions - Module translation tool"
+          git config --global user.email "<>"
+          git config --global credential.helper 'cache --timeout 3600'
+          git config --global url."https://oauth2:${{ secrets.JARVIS_TOKEN }}@github.com".insteadOf ssh://git@github.com
+      - run: composer install
+      - name: Extract translations and push
+        run: |
+          printenv
+          /bin/bash -eux ./scripts/extractCatalogue.sh
+          ls -la
+          /bin/bash -eux ./scripts/pushAndCreatePullRequest.sh
+        env:
+          APP_GITHUB_TOKEN: ${{ secrets.JARVIS_TOKEN }}

--- a/.github/workflows/extract-translations.yml
+++ b/.github/workflows/extract-translations.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BRANCH: ${{ github.ref_name }}
+      REPOSITORY_NAME: ${{ github.event.repository.name }}
+      OWNER_NAME: ${{ github.repository_owner }}
     steps:
       - name: Checkout module-translation-tool
         uses: actions/checkout@v4
@@ -18,9 +20,9 @@ jobs:
       - name: Create config for module-translation-tool
         run: |
           cp ./module.cfg.example ./module.cfg
-          sed -i 's/^MODULE_NAME.*/MODULE_NAME="autoupgrade"/g' ./module.cfg
-          sed -i 's/^GIT_REPO_USERNAME.*/GIT_REPO_USERNAME="PrestaShop"/g' ./module.cfg
-          sed -i 's/^GIT_REPO_NAME.*/GIT_REPO_NAME="autoupgrade"/g' ./module.cfg
+          sed -i 's/^MODULE_NAME.*/MODULE_NAME="$REPOSITORY_NAME"/g' ./module.cfg
+          sed -i 's/^GIT_REPO_USERNAME.*/GIT_REPO_USERNAME="$OWNER_NAME"/g' ./module.cfg
+          sed -i 's/^GIT_REPO_NAME.*/GIT_REPO_NAME="$REPOSITORY_NAME"/g' ./module.cfg
           sed -i 's/^BRANCH.*/BRANCH="$BRANCH"/g' ./module.cfg
       - name: Setup git config
         run: |
@@ -31,7 +33,6 @@ jobs:
       - run: composer install
       - name: Extract translations and push
         run: |
-          printenv
           /bin/bash -eux ./scripts/extractCatalogue.sh
           rm catalog/autoupgrade/translations/ModulesAutoupgradeAdmin.en.xlf
           mv catalog/autoupgrade/translations/en-US/messages.en-US.xlf catalog/autoupgrade/translations/ModulesAutoupgradeAdmin.en.xlf

--- a/.github/workflows/extract-translations.yml
+++ b/.github/workflows/extract-translations.yml
@@ -25,7 +25,7 @@ jobs:
           git config --global user.name "Github Actions - Module translation tool"
           git config --global user.email "<>"
           git config --global credential.helper 'cache --timeout 3600'
-          git config --global url."https://oauth2:${{ secrets.JARVIS_TOKEN }}@github.com".insteadOf ssh://git@github.com
+          git config --global url."https://oauth2:${{ secrets.GITHUB_TOKEN }}@github.com".insteadOf ssh://git@github.com
       - run: composer install
       - name: Extract translations and push
         run: |
@@ -36,4 +36,4 @@ jobs:
           cat catalog/autoupgrade/translations/ModulesAutoupgradeAdmin.en.xlf
           /bin/bash -eux ./scripts/pushAndCreatePullRequest.sh
         env:
-          APP_GITHUB_TOKEN: ${{ secrets.JARVIS_TOKEN }}
+          APP_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/extract-translations.yml
+++ b/.github/workflows/extract-translations.yml
@@ -19,7 +19,7 @@ jobs:
           sed -i 's/^MODULE_NAME.*/MODULE_NAME="autoupgrade"/g' ./module.cfg
           sed -i 's/^GIT_REPO_USERNAME.*/GIT_REPO_USERNAME="PrestaShop"/g' ./module.cfg
           sed -i 's/^GIT_REPO_NAME.*/GIT_REPO_NAME="autoupgrade"/g' ./module.cfg
-          sed -i 's/^BRANCH.*/BRANCH="dev"/g' ./module.cfg
+          sed -i 's/^BRANCH.*/BRANCH="${{ github.ref_name }}"/g' ./module.cfg
       - name: Setup git config
         run: |
           git config --global user.name "Github Actions - Module translation tool"

--- a/.github/workflows/extract-translations.yml
+++ b/.github/workflows/extract-translations.yml
@@ -19,7 +19,7 @@ jobs:
           sed -i 's/^MODULE_NAME.*/MODULE_NAME="autoupgrade"/g' ./module.cfg
           sed -i 's/^GIT_REPO_USERNAME.*/GIT_REPO_USERNAME="PrestaShop"/g' ./module.cfg
           sed -i 's/^GIT_REPO_NAME.*/GIT_REPO_NAME="autoupgrade"/g' ./module.cfg
-          sed -i 's/^BRANCH.*/BRANCH="${{ github.ref_name }}"/g' ./module.cfg
+          sed -i "s/^BRANCH.*/BRANCH=\"${{ github.ref_name }}\"/g" ./module.cfg
       - name: Setup git config
         run: |
           git config --global user.name "Github Actions - Module translation tool"

--- a/.github/workflows/extract-translations.yml
+++ b/.github/workflows/extract-translations.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           printenv
           /bin/bash -eux ./scripts/extractCatalogue.sh
-          ls -a catalog
+          ls -a catalog/autoupgrade
           /bin/bash -eux ./scripts/pushAndCreatePullRequest.sh
         env:
           APP_GITHUB_TOKEN: ${{ secrets.JARVIS_TOKEN }}

--- a/.github/workflows/extract-translations.yml
+++ b/.github/workflows/extract-translations.yml
@@ -14,9 +14,10 @@ jobs:
           repository: PrestaShopCorp/module-translation-tool
           ref: main
       - name: Create config for module-translation-tool
+        env:
+          BRANCH: ${{ github.ref_name }}
         run: |
           cp ./module.cfg.example ./module.cfg
-          BRANCH="${{ github.ref_name }}"
           sed -i 's/^MODULE_NAME.*/MODULE_NAME="autoupgrade"/g' ./module.cfg
           sed -i 's/^GIT_REPO_USERNAME.*/GIT_REPO_USERNAME="PrestaShop"/g' ./module.cfg
           sed -i 's/^GIT_REPO_NAME.*/GIT_REPO_NAME="autoupgrade"/g' ./module.cfg

--- a/.github/workflows/extract-translations.yml
+++ b/.github/workflows/extract-translations.yml
@@ -31,9 +31,7 @@ jobs:
         run: |
           printenv
           /bin/bash -eux ./scripts/extractCatalogue.sh
-          rm -rf catalog/autoupgrade/translations/ModulesAutoupgradeAdmin.en.xlf
-          mv catalog/autoupgrade/translations/en-US catalog/autoupgrade/translations/ModulesAutoupgradeAdmin.en.xlf
-          cat catalog/autoupgrade/translations/ModulesAutoupgradeAdmin.en.xlf
+          ls -la mv catalog/autoupgrade/translations/en-US
           /bin/bash -eux ./scripts/pushAndCreatePullRequest.sh
         env:
           APP_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/extract-translations.yml
+++ b/.github/workflows/extract-translations.yml
@@ -16,10 +16,11 @@ jobs:
       - name: Create config for module-translation-tool
         run: |
           cp ./module.cfg.example ./module.cfg
+          BRANCH="${{ github.ref_name }}"
           sed -i 's/^MODULE_NAME.*/MODULE_NAME="autoupgrade"/g' ./module.cfg
           sed -i 's/^GIT_REPO_USERNAME.*/GIT_REPO_USERNAME="PrestaShop"/g' ./module.cfg
           sed -i 's/^GIT_REPO_NAME.*/GIT_REPO_NAME="autoupgrade"/g' ./module.cfg
-          sed -i "s/^BRANCH.*/BRANCH=\"${{ github.ref_name }}\"/g" ./module.cfg
+          sed -i 's/^BRANCH.*/BRANCH="$BRANCH"/g' ./module.cfg
       - name: Setup git config
         run: |
           git config --global user.name "Github Actions - Module translation tool"

--- a/.github/workflows/extract-translations.yml
+++ b/.github/workflows/extract-translations.yml
@@ -31,7 +31,9 @@ jobs:
         run: |
           printenv
           /bin/bash -eux ./scripts/extractCatalogue.sh
-          ls -la catalog/autoupgrade/translations
+          rm -rf catalog/autoupgrade/translations/ModulesAutoupgradeAdmin.en.xlf
+          mv catalog/autoupgrade/translations/en-US catalog/autoupgrade/translations/ModulesAutoupgradeAdmin.en.xlf
+          cat catalog/autoupgrade/translations/ModulesAutoupgradeAdmin.en.xlf
           /bin/bash -eux ./scripts/pushAndCreatePullRequest.sh
         env:
           APP_GITHUB_TOKEN: ${{ secrets.JARVIS_TOKEN }}

--- a/.github/workflows/extract-translations.yml
+++ b/.github/workflows/extract-translations.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           printenv
           /bin/bash -eux ./scripts/extractCatalogue.sh
-          ls -la
+          ls -a catalog
           /bin/bash -eux ./scripts/pushAndCreatePullRequest.sh
         env:
           APP_GITHUB_TOKEN: ${{ secrets.JARVIS_TOKEN }}

--- a/.github/workflows/extract-translations.yml
+++ b/.github/workflows/extract-translations.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - feat/auto-export-translation
+      - dev
 
 jobs:
   sync-translations:

--- a/.github/workflows/extract-translations.yml
+++ b/.github/workflows/extract-translations.yml
@@ -31,7 +31,9 @@ jobs:
         run: |
           printenv
           /bin/bash -eux ./scripts/extractCatalogue.sh
-          ls -la mv catalog/autoupgrade/translations/en-US
+          rm catalog/autoupgrade/translations/ModulesAutoupgradeAdmin.en.xlf
+          mv catalog/autoupgrade/translations/en-US/messages.en-US.xlf catalog/autoupgrade/translations/ModulesAutoupgradeAdmin.en.xlf
+          rmdir catalog/autoupgrade/translations/en-US
           /bin/bash -eux ./scripts/pushAndCreatePullRequest.sh
         env:
           APP_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/extract-translations.yml
+++ b/.github/workflows/extract-translations.yml
@@ -7,6 +7,8 @@ jobs:
   sync-translations:
     name: Extract translations and submit a PR
     runs-on: ubuntu-latest
+    env:
+      BRANCH: ${{ github.ref_name }}
     steps:
       - name: Checkout module-translation-tool
         uses: actions/checkout@v4
@@ -14,8 +16,6 @@ jobs:
           repository: PrestaShopCorp/module-translation-tool
           ref: main
       - name: Create config for module-translation-tool
-        env:
-          BRANCH: ${{ github.ref_name }}
         run: |
           cp ./module.cfg.example ./module.cfg
           sed -i 's/^MODULE_NAME.*/MODULE_NAME="autoupgrade"/g' ./module.cfg

--- a/.github/workflows/extract-translations.yml
+++ b/.github/workflows/extract-translations.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           printenv
           /bin/bash -eux ./scripts/extractCatalogue.sh
-          ls -a catalog/autoupgrade
+          ls -la catalog/autoupgrade/translations
           /bin/bash -eux ./scripts/pushAndCreatePullRequest.sh
         env:
           APP_GITHUB_TOKEN: ${{ secrets.JARVIS_TOKEN }}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | It is currently difficult to update the translations. To do this, you must go to the BO of a shop containing the module in order to export the translations and then retrieve the file to place in our module. This PR is used to introduce an automatic export of translations from the CI.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Sponsor company   | @PrestaShopCorp
| How to test?      | Just push something on dev branch with new translations inside files (like twig or php). You can see a new PR apear to add this translations.
