### PR TITLE
UI tests - Add PS versions from 1.7.8~ (Minor & major) - PHP 7.4

### DIFF
--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -22,6 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - # 1.7.8 ~ minor-major PHP 7.4
           - PS_VERSION_START: 1.7.8.0
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: major
@@ -126,10 +127,11 @@ jobs:
             PS_VERSION_END: 8.0.5
             UPGRADE_CHANNEL: minor
             PHP_VERSION: 7.2
-          - PS_VERSION_START: 8.0.5
-            PS_VERSION_END: 8.1.7
-            UPGRADE_CHANNEL: major
-            PHP_VERSION: 7.2
+          # @todo https://github.com/PrestaShop/PrestaShop/issues/36439
+          #- PS_VERSION_START: 8.0.5
+          #  PS_VERSION_END: 8.1.7
+          #  UPGRADE_CHANNEL: major
+          #  PHP_VERSION: 7.2
           - PS_VERSION_START: 8.1.0
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: minor

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -22,6 +22,102 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - PS_VERSION_START: 1.7.8.0
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: major
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 1.7.8.0
+            PS_VERSION_END: 1.7.8.11
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 1.7.8.1
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: major
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 1.7.8.1
+            PS_VERSION_END: 1.7.8.11
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 1.7.8.2
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: major
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 1.7.8.2
+            PS_VERSION_END: 1.7.8.11
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 1.7.8.3
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: major
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 1.7.8.3
+            PS_VERSION_END: 1.7.8.11
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 1.7.8.4
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: major
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 1.7.8.4
+            PS_VERSION_END: 1.7.8.11
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 1.7.8.4
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: major
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 1.7.8.4
+            PS_VERSION_END: 1.7.8.11
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 1.7.8.5
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: major
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 1.7.8.5
+            PS_VERSION_END: 1.7.8.11
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 1.7.8.6
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: major
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 1.7.8.6
+            PS_VERSION_END: 1.7.8.11
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 1.7.8.7
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: major
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 1.7.8.7
+            PS_VERSION_END: 1.7.8.11
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 1.7.8.8
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: major
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 1.7.8.8
+            PS_VERSION_END: 1.7.8.11
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 1.7.8.9
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: major
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 1.7.8.9
+            PS_VERSION_END: 1.7.8.11
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 1.7.8.10
+            PS_VERSION_END: 8.1.7
+            UPGRADE_CHANNEL: major
+            PHP_VERSION: 7.4
+          - PS_VERSION_START: 1.7.8.10
+            PS_VERSION_END: 1.7.8.11
+            UPGRADE_CHANNEL: minor
+            PHP_VERSION: 7.4
           - PS_VERSION_START: 1.7.8.11
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: major

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - # 1.7.8 ~ minor-major PHP 7.4
+            # 1.7.8 ~ minor-major PHP 7.4
           - PS_VERSION_START: 1.7.8.0
             PS_VERSION_END: 8.1.7
             UPGRADE_CHANNEL: major


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | UI tests - Add PS versions from 1.7.8~ (Minor & major) - PHP 7.4
| Type?             | new feature
| Sponsor company   | @PrestaShopCorps
| How to test?      | CI is :green_apple: 
