### PR TITLE
UI tests - Add PS versions from 1.7.8.0 ~ 1.7.8.11 to 8.1.7 (Major) on PHP 7.2 ~ 7.4

### DIFF
--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -100,7 +100,7 @@ jobs:
   nightly:
     name: Nightly Report
     if: ${{ github.event_name == 'schedule' }}
-    needs: 
+    needs:
       - ui_test_matrix
       - ui_test
     runs-on: ubuntu-latest

--- a/.github/workflows/ui-test/sanity.json
+++ b/.github/workflows/ui-test/sanity.json
@@ -13,6 +13,216 @@
       "comment": "1.7.8 ~ major PHP 7.2 ~ 7.4"
     },
     {
+      "PS_VERSION_START": "1.7.8.0",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.0",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.0",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.4"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.1",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.1",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.1",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.4"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.2",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.2",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.2",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.4"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.3",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.3",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.3",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.4"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.4",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.4",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.4",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.4"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.5",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.5",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.5",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.4"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.6",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.6",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.6",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.4"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.7",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.7",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.7",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.4"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.8",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.8",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.8",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.4"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.9",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.9",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.9",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.4"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.10",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.10",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.10",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.4"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.11",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.11",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
       "PS_VERSION_START": "1.7.8.11",
       "PS_VERSION_END": "8.1.7",
       "UPGRADE_CHANNEL": "major",


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | UI tests - Add PS versions from 1.7.8 ~ Major PHP 7.4
| Type?             | refactor
| Sponsor company   | @PrestaShopCorp
| How to test?      | CI is :green_apple: 
