### PR TITLE
Return exit code on unhandled exceptions, and allow process to go on when upgrading a module fails

### DIFF
--- a/classes/ErrorHandler.php
+++ b/classes/ErrorHandler.php
@@ -70,7 +70,7 @@ class ErrorHandler
     {
         $message = get_class($e) . ': ' . $e->getMessage();
         $this->report($e->getFile(), $e->getLine(), Logger::CRITICAL, $message, $e->getTraceAsString(), true);
-        exit(64);
+        $this->terminate(64);
     }
 
     /**
@@ -158,5 +158,13 @@ class ErrorHandler
             fwrite($fd, $log);
             fclose($fd);
         }
+    }
+
+    /**
+     * @return never
+     */
+    public function terminate(int $code)
+    {
+        exit($code);
     }
 }

--- a/classes/ErrorHandler.php
+++ b/classes/ErrorHandler.php
@@ -70,6 +70,7 @@ class ErrorHandler
     {
         $message = get_class($e) . ': ' . $e->getMessage();
         $this->report($e->getFile(), $e->getLine(), Logger::CRITICAL, $message, $e->getTraceAsString(), true);
+        exit(64);
     }
 
     /**

--- a/classes/Exceptions/UpgradeException.php
+++ b/classes/Exceptions/UpgradeException.php
@@ -27,10 +27,9 @@
 
 namespace PrestaShop\Module\AutoUpgrade\Exceptions;
 
-/**
- * Todo: Should we create a UpgradeWarning class instead of setting the severity here?
- */
-class UpgradeException extends \Exception
+use Exception;
+
+class UpgradeException extends Exception
 {
     const SEVERITY_ERROR = 1;
     const SEVERITY_WARNING = 2;

--- a/classes/Exceptions/UpgradeException.php
+++ b/classes/Exceptions/UpgradeException.php
@@ -55,6 +55,7 @@ class UpgradeException extends Exception
                 $this->quickInfos
             );
         }
+
         return $this->quickInfos;
     }
 

--- a/classes/Exceptions/UpgradeException.php
+++ b/classes/Exceptions/UpgradeException.php
@@ -49,6 +49,12 @@ class UpgradeException extends Exception
      */
     public function getQuickInfos(): array
     {
+        if ($this->getPrevious()) {
+            return array_merge(
+                [(string) $this->getPrevious()],
+                $this->quickInfos
+            );
+        }
         return $this->quickInfos;
     }
 

--- a/classes/Task/Upgrade/UpgradeModules.php
+++ b/classes/Task/Upgrade/UpgradeModules.php
@@ -173,9 +173,6 @@ class UpgradeModules extends AbstractTask
 
     private function handleException(UpgradeException $e): void
     {
-        foreach ($e->getQuickInfos() as $log) {
-            $this->logger->debug($log);
-        }
         if ($e->getSeverity() === UpgradeException::SEVERITY_ERROR) {
             $this->next = 'error';
             $this->setErrorFlag();
@@ -183,6 +180,10 @@ class UpgradeModules extends AbstractTask
         }
         if ($e->getSeverity() === UpgradeException::SEVERITY_WARNING) {
             $this->logger->warning($e->getMessage());
+        }
+
+        foreach ($e->getQuickInfos() as $log) {
+            $this->logger->warning($log);
         }
     }
 }

--- a/classes/Task/Upgrade/UpgradeModules.php
+++ b/classes/Task/Upgrade/UpgradeModules.php
@@ -78,9 +78,9 @@ class UpgradeModules extends AbstractTask
             do {
                 $module_info = array_pop($listModules);
                 try {
-                    $this->logger->debug($this->translator->trans('Upgrading module %module%...', ['%module%' => $module_info['name']]));
+                    $this->logger->debug($this->translator->trans('Updating module %module%...', ['%module%' => $module_info['name']]));
                     $this->container->getModuleAdapter()->upgradeModule($module_info['id'], $module_info['name'], !empty($module_info['is_local']));
-                    $this->logger->debug($this->translator->trans('The files of module %s have been upgraded.', [$module_info['name']]));
+                    $this->logger->info($this->translator->trans('The module %s has been updated.', [$module_info['name']]));
                 } catch (UpgradeException $e) {
                     $this->handleException($e);
                     if ($e->getSeverity() === UpgradeException::SEVERITY_ERROR) {

--- a/classes/UpgradeTools/ModuleAdapter.php
+++ b/classes/UpgradeTools/ModuleAdapter.php
@@ -33,6 +33,7 @@ use PrestaShop\Module\AutoUpgrade\ZipAction;
 use PrestaShop\PrestaShop\Adapter\Module\Repository\ModuleRepository;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
+use Throwable;
 
 class ModuleAdapter
 {
@@ -221,12 +222,12 @@ class ModuleAdapter
             // file_get_contents can return false if https is not supported (or warning)
             $content = Tools14::file_get_contents($addons_url, false, $context);
             if (empty($content) || substr($content, 5) == '<?xml') {
-                $msg = '<strong>' . $this->translator->trans('[ERROR] No response from Addons server.') . '</strong>';
+                $msg = $this->translator->trans('[ERROR] No response from Addons server.');
                 throw new UpgradeException($msg);
             }
 
             if (false === (bool) file_put_contents($zip_fullpath, $content)) {
-                $msg = '<strong>' . $this->translator->trans('[ERROR] Unable to write module %s\'s zip file in temporary directory.', [$name]) . '</strong>';
+                $msg = $this->translator->trans('[ERROR] Unable to write module %s\'s zip file in temporary directory.', [$name]);
                 throw new UpgradeException($msg);
             }
         }
@@ -236,15 +237,13 @@ class ModuleAdapter
         }
         // unzip in modules/[mod name] old files will be conserved
         if (!$this->zipAction->extract($zip_fullpath, $this->modulesPath)) {
-            throw (new UpgradeException('<strong>' . $this->translator->trans('[WARNING] Error when trying to extract module %s.', [$name]) . '</strong>'))->setSeverity(UpgradeException::SEVERITY_WARNING);
+            throw (new UpgradeException($this->translator->trans('[WARNING] Error when trying to extract module %s.', [$name])))->setSeverity(UpgradeException::SEVERITY_WARNING);
         }
         if (file_exists($zip_fullpath)) {
             unlink($zip_fullpath);
         }
 
-        if (!$this->doUpgradeModule($name)) {
-            throw (new UpgradeException('<strong>' . $this->translator->trans('[WARNING] Error when trying to upgrade module %s.', [$name]) . '</strong>'))->setSeverity(UpgradeException::SEVERITY_WARNING)->setQuickInfos(\Module::getInstanceByName($name)->getErrors());
-        }
+        $this->doUpgradeModule($name);
     }
 
     private function getLocalModuleZip(string $name): ?string
@@ -259,24 +258,33 @@ class ModuleAdapter
         return null;
     }
 
-    private function doUpgradeModule(string $name): bool
+    private function doUpgradeModule(string $name): void
     {
         $version = \Db::getInstance()->getValue(
             'SELECT version FROM `' . _DB_PREFIX_ . 'module` WHERE name = "' . $name . '"'
         );
         $module = \Module::getInstanceByName($name);
-        if ($module instanceof \Module) {
-            $module->installed = !empty($version);
-            $module->database_version = $version ?: 0;
+        if (!($module instanceof \Module)) {
+            return;
+        }
+        $module->installed = !empty($version);
+        $module->database_version = $version ?: 0;
 
-            if (\Module::initUpgradeModule($module)) {
-                $module->runUpgradeModule();
-                \Module::upgradeModuleVersion($name, $module->version);
-
-                return !count($module->getErrors());
+        try {
+            if (!\Module::initUpgradeModule($module)) {
+                return;
             }
+
+            $module->runUpgradeModule();
+            \Module::upgradeModuleVersion($name, $module->version);
+        } catch (Throwable $t) {
+            throw (new UpgradeException($this->translator->trans('[WARNING] Error when trying to upgrade module %s.', [$name]), 0, $t))->setSeverity(UpgradeException::SEVERITY_WARNING);
         }
 
-        return true;
+        $errorsList = $module->getErrors();
+
+        if (count($errorsList)) {
+            throw (new UpgradeException($this->translator->trans('[WARNING] Error when trying to upgrade module %s.', [$name])))->setSeverity(UpgradeException::SEVERITY_WARNING)->setQuickInfos($errorsList);
+        }
     }
 }

--- a/cli-rollback.php
+++ b/cli-rollback.php
@@ -24,6 +24,9 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
+
+use PrestaShop\Module\AutoUpgrade\ErrorHandler;
+
 if (PHP_SAPI !== 'cli') {
     echo 'This script must be called from CLI';
     exit(1);
@@ -32,7 +35,9 @@ if (PHP_SAPI !== 'cli') {
 require_once realpath(dirname(__FILE__) . '/../../modules/autoupgrade') . '/ajax-upgradetabconfig.php';
 $container = autoupgrade_init_container(dirname(__FILE__));
 
-$container->setLogger(new PrestaShop\Module\AutoUpgrade\Log\StreamedLogger());
+$logger = new PrestaShop\Module\AutoUpgrade\Log\StreamedLogger();
+$container->setLogger($logger);
+(new ErrorHandler($logger))->enable();
 $controller = new \PrestaShop\Module\AutoUpgrade\Task\Runner\AllRollbackTasks($container);
 $controller->setOptions(getopt('', ['backup::']));
 $controller->init();

--- a/cli-upgrade.php
+++ b/cli-upgrade.php
@@ -24,6 +24,9 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
+
+use PrestaShop\Module\AutoUpgrade\ErrorHandler;
+
 if (PHP_SAPI !== 'cli') {
     echo 'This script must be called from CLI';
     exit(1);
@@ -40,6 +43,7 @@ $container = autoupgrade_init_container(dirname(__FILE__));
 
 $logger = new PrestaShop\Module\AutoUpgrade\Log\StreamedLogger();
 $container->setLogger($logger);
+(new ErrorHandler($logger))->enable();
 $controller = new \PrestaShop\Module\AutoUpgrade\Task\Runner\AllUpgradeTasks($container);
 $controller->setOptions(getopt('', ['action::', 'channel::', 'data::']));
 $controller->init();
@@ -54,7 +58,7 @@ if (isset($options['chain'])) {
 
 if ($chain && strpos($logger->getLastInfo(), 'cli-upgrade.php') !== false) {
     $new_string = str_replace('INFO - $ ', '', $logger->getLastInfo());
-    system('php ' . $new_string . '  2>&1', $exitCode);
+    system('php ' . $new_string, $exitCode);
 }
 
 exit($exitCode);

--- a/tests/unit/ErrorHandlerTest.php
+++ b/tests/unit/ErrorHandlerTest.php
@@ -37,7 +37,10 @@ class ErrorHandlerTest extends TestCase
     {
         parent::setUp();
         $this->logger = new LegacyLogger();
-        $this->errorHandler = new ErrorHandler($this->logger);
+        $this->errorHandler = $this->getMockBuilder(ErrorHandler::class)
+            ->setConstructorArgs([$this->logger])
+            ->setMethods(['terminate'])
+            ->getMock();
     }
 
     public function testDefaultContentIsEmpty()


### PR DESCRIPTION
:heavy_check_mark:  Waiting for #727 to be merged first

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | We found out in some workflow, an exception not handled would still return the error code 0, allowing the next steps to be run. This PR makes sure a non-zero code is returned.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | CI must be red if an issue is triggered by a module for instance.

PR contents:
* Returns a non zero code when an exception is not handled
* Remove html contents (displayed on CLI which is a non-sense)
* Allow process to continue on error during updates
* Display error details as warnings