### PR TITLE
UI tests - Add PS versions from 1.7.7.0 ~ 1.7.7.8 to 8.1.7 (Major) on PHP 7.1 ~ 7.3

### DIFF
--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Upgrade
         run: |
          docker exec -t prestashop php modules/autoupgrade/cli-upgrade.php --dir=admin-dev --channel=${{ matrix.UPGRADE_CHANNEL }}
-         docker exec -t prestashop chmod 777 -R /var/www/html/var/cache/dev
+         docker exec -t prestashop chmod 777 -R /var/www/html/var/cache/
 
       - name: Install dependencies
         working-directory: tests/UI/

--- a/.github/workflows/ui-test/sanity.json
+++ b/.github/workflows/ui-test/sanity.json
@@ -1,7 +1,7 @@
 {
   "include": [
     {
-      "comment": "1.7.8 ~ major PHP 7.2 ~ 7.3"
+      "comment": "1.7.7 ~ major PHP 7.2 ~ 7.3"
     },
     {
       "PS_VERSION_START": "1.7.7.0",
@@ -112,7 +112,6 @@
       "PHP_VERSION": "7.3"
     },
     {
-      "comment": "1.7.8 ~ minor PHP 7.2 ~ 7.4"
       "comment": "1.7.8 ~ minor PHP 7.4"
     },
     {

--- a/.github/workflows/ui-test/sanity.json
+++ b/.github/workflows/ui-test/sanity.json
@@ -1,7 +1,7 @@
 {
   "include": [
     {
-      "comment": "1.7.7 ~ major PHP 7.2 ~ 7.3"
+      "comment": "1.7.7 ~ major PHP 7.2 - 7.3"
     },
     {
       "PS_VERSION_START": "1.7.7.0",

--- a/.github/workflows/ui-test/sanity.json
+++ b/.github/workflows/ui-test/sanity.json
@@ -1,6 +1,118 @@
 {
   "include": [
     {
+      "comment": "1.7.8 ~ major PHP 7.2 ~ 7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.7.0",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.7.0",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.7.1",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.7.1",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.7.2",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.7.2",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.7.3",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.7.3",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.7.4",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.7.4",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.7.5",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.7.5",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.7.6",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.7.6",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.7.7",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.7.7",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.7.8",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.7.8",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "comment": "1.7.8 ~ minor PHP 7.2 ~ 7.4"
       "comment": "1.7.8 ~ minor PHP 7.4"
     },
     {

--- a/tests/UI/campaigns/sanity/02_productsBO/03_CRUDProductWithCombinations.spec.ts
+++ b/tests/UI/campaigns/sanity/02_productsBO/03_CRUDProductWithCombinations.spec.ts
@@ -60,7 +60,7 @@ test.describe('BO - Catalog - Products : CRUD product with combinations', async 
     attributes: [
       {
         name: 'color',
-        values: ['Gray', 'Taupe', 'Red'],
+        values: ['Gray', 'Grey','Taupe', 'Red'],
       },
       {
         name: 'size',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add PS versions from 1.7.7.0 ~ 1.7.7.8 to 8.1.7 (Major) on PHP 7.1 ~ 7.3
| Type?             | improvement
| Sponsor company   | @PrestaShopCorp
| How to test?      | CI is :green_apple: 
