### PR TITLE
fix: translator to match to xlf format files

### DIFF
--- a/classes/UpgradeTools/Translator.php
+++ b/classes/UpgradeTools/Translator.php
@@ -44,8 +44,10 @@ class Translator
     private function loadXlfFile($filePath)
     {
         $xml = new SimpleXMLElement(file_get_contents($filePath));
-        foreach ($xml->file->body->{'trans-unit'} as $unit) {
-            $this->translations[(string) $unit->source] = (string) $unit->target;
+        foreach ($xml->file as $file) {
+            foreach ($file->body->{'trans-unit'} as $unit) {
+                $this->translations[(string) $unit->source] = (string) $unit->target;
+            }
         }
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The auto export translation change XLF files structure we have to update the translator class to match it.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     |  no
| Fixed ticket?     | --
| Sponsor company   | @PrestaShopCorp
| How to test?      | See if we got translations in Czechia or French (not all translations in French just somes)
