### PR TITLE
Fix sentry logs

### DIFF
--- a/js/sentry.js
+++ b/js/sentry.js
@@ -36,8 +36,8 @@ document.getElementById("submitErrorReport").addEventListener("click", function 
     if (errorsElements) {
         const childNodes = errorsElements.childNodes;
         let messages = '';
-        childNodes.forEach((node, index) => {
-            if (node.nodeType === Node.TEXT_NODE && index > 0) {
+        childNodes.forEach((node) => {
+            if (node.nodeType === Node.TEXT_NODE) {
                 messages += node.textContent.trim() + '\n';
             }
         });


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The sentry logs were empty.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | -
| How to test?      | Simulate an error. The sentry label is no longer empty when sending the error
