### PR TITLE
UI tests - Add PS versions from 1.7.3.0 ~ 1.7.3.4 to 1.7.8.11 (minor) on php 7.1 

### DIFF
--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -86,8 +86,8 @@ jobs:
 
       - name: Update
         run: |
-         docker exec -t prestashop php modules/autoupgrade/bin/console update:start --config-file-path=modules/autoupgrade/config.json --channel=${{ matrix.UPGRADE_CHANNEL }} admin-dev
-         docker exec -t prestashop chmod 777 -R /var/www/html/var
+          docker exec -t prestashop php modules/autoupgrade/bin/console update:start --config-file-path=modules/autoupgrade/config.json --channel=${{ matrix.UPGRADE_CHANNEL }} admin-dev
+          docker exec -t prestashop chmod 777 -R /var/www/html/var
 
       - name: Install dependencies
         working-directory: tests/UI/
@@ -109,8 +109,9 @@ jobs:
 
       - name: Rollback
         run: |
-         backupName=$(docker exec -t prestashop bash -c "ls -td -- /var/www/html/admin-dev/autoupgrade/backup/*/ | head -n 1 | cut -d'/' -f8 | tr -d '\n'")
-         docker exec -t prestashop php modules/autoupgrade/bin/console backup:restore --backup=$backupName admin-dev
+          backupName=$(docker exec -t prestashop bash -c "ls -td -- /var/www/html/admin-dev/autoupgrade/backup/*/ | head -n 1 | cut -d'/' -f8 | tr -d '\n'")
+          docker exec -t prestashop php modules/autoupgrade/bin/console backup:restore --backup=$backupName admin-dev
+          docker exec -t prestashop chmod 777 -R /var/www/html/app
 
       - name: Run Sanity tests
         working-directory: tests/UI/

--- a/.github/workflows/ui-test/nightly.json
+++ b/.github/workflows/ui-test/nightly.json
@@ -1,6 +1,39 @@
 {
   "include": [
     {
+      "comment": "1.7.3.0 ~ 1.7.3.4 -> 1.7.8.11 PHP 7.1"
+    },
+    {
+      "PS_VERSION_START": "1.7.3.0",
+      "PS_VERSION_END": "1.7.8.11",
+      "PHP_VERSION": "7.1",
+      "UPGRADE_CHANNEL": "online"
+    },
+    {
+      "PS_VERSION_START": "1.7.3.1",
+      "PS_VERSION_END": "1.7.8.11",
+      "PHP_VERSION": "7.1",
+      "UPGRADE_CHANNEL": "online"
+    },
+    {
+      "PS_VERSION_START": "1.7.3.2",
+      "PS_VERSION_END": "1.7.8.11",
+      "PHP_VERSION": "7.1",
+      "UPGRADE_CHANNEL": "online"
+    },
+    {
+      "PS_VERSION_START": "1.7.3.3",
+      "PS_VERSION_END": "1.7.8.11",
+      "PHP_VERSION": "7.1",
+      "UPGRADE_CHANNEL": "online"
+    },
+    {
+      "PS_VERSION_START": "1.7.3.4",
+      "PS_VERSION_END": "1.7.8.11",
+      "PHP_VERSION": "7.1",
+      "UPGRADE_CHANNEL": "online"
+    },
+    {
       "comment": "1.7.4.0 ~ 1.7.4.4 -> 1.7.8.11 PHP 7.1"
     },
     {
@@ -8,32 +41,32 @@
       "PS_VERSION_START": "1.7.4.0",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "comment": "https://github.com/PrestaShop/docker/issues/399",
       "PS_VERSION_START": "1.7.4.1",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.4.2",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.4.3",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.4.4",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "comment": "1.7.5.0 ~ 1.7.5.2 -> 1.7.8.11 PHP 7.1"
@@ -42,19 +75,19 @@
       "PS_VERSION_START": "1.7.5.0",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.5.1",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.5.2",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "comment": "1.7.5.0 ~ 1.7.5.2 -> 8.2.0 PHP 7.2"
@@ -63,19 +96,19 @@
       "PS_VERSION_START": "1.7.5.0",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.5.1",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.5.2",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "comment": "1.7.6.0 ~ 1.7.6.9 -> 1.7.8.11 PHP 7.1"
@@ -84,61 +117,61 @@
       "PS_VERSION_START": "1.7.6.0",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.6.1",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.6.2",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.6.3",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.6.4",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.6.5",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.6.6",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.6.7",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.6.8",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.6.9",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "comment": "1.7.6.0 ~ 1.7.6.9 -> 8.2.0 PHP 7.2"
@@ -147,61 +180,61 @@
       "PS_VERSION_START": "1.7.6.0",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.6.1",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.6.2",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.6.3",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.6.4",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.6.5",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.6.6",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.6.7",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.6.8",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.6.9",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "comment": "1.7.7.0 ~ 1.7.7.8 -> 1.7.8.11 PHP 7.1"
@@ -210,55 +243,55 @@
       "PS_VERSION_START": "1.7.7.0",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.7.1",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.7.2",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.7.3",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.7.4",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.7.5",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.7.6",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.7.7",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.7.8",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "comment": "1.7.7.0 ~ 1.7.7.8 -> 8.2.0 PHP 7.2 ~ 7.3"
@@ -267,109 +300,109 @@
       "PS_VERSION_START": "1.7.7.0",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.7.0",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.7.1",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.7.1",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.7.2",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.7.2",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.7.3",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.7.3",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.7.4",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.7.4",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.7.5",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.7.5",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.7.6",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.7.6",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.7.7",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.7.7",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.7.8",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.7.8",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "comment": "1.7.8.0 ~ 1.7.8.10 -> 1.7.8.11 PHP 7.1"
@@ -378,67 +411,67 @@
       "PS_VERSION_START": "1.7.8.0",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.1",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.2",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.3",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.4",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.5",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.6",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.7",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.8",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.9",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.10",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "comment": "1.7.8.0 ~ 1.7.8.11 -> 8.2.0 PHP 7.2 ~ 7.4"
@@ -447,217 +480,217 @@
       "PS_VERSION_START": "1.7.8.0",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.0",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.0",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.4",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.1",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.1",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.1",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.4",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.2",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.2",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.2",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.4",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.3",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.3",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.3",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.4",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.4",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.4",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.4",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.4",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.5",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.5",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.5",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.4",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.6",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.6",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.6",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.4",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.7",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.7",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.7",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.4",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.8",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.8",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.8",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.4",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.9",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.9",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.9",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.4",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.10",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.10",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.10",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.4",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.11",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.11",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "1.7.8.11",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.4",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "comment": "8.0.0 ~ 8.0.5 -> 8.2.0 PHP 7.2 ~ 8.1"
@@ -666,181 +699,181 @@
       "PS_VERSION_START": "8.0.0",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.0.0",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.0.0",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.4",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.0.0",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "8.0",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.0.0",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "8.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.0.1",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.0.1",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.0.1",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.4",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.0.1",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "8.0",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.0.1",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "8.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.0.2",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.0.2",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.0.2",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.4",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.0.2",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "8.0",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.0.2",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "8.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.0.3",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.0.3",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.0.3",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.4",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.0.3",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "8.0",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.0.3",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "8.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.0.4",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.0.4",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.0.4",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.4",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.0.4",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "8.0",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.0.4",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "8.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.0.5",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.0.5",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.0.5",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.4",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.0.5",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "8.0",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.0.5",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "8.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "comment": "8.1.0 ~ 8.1.7 -> 8.2.0 PHP 7.2 ~ 8.1"
@@ -849,241 +882,241 @@
       "PS_VERSION_START": "8.1.0",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.0",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.0",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.4",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.0",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "8.0",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.0",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "8.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.1",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.1",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.1",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.4",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.1",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "8.0",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.1",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "8.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.2",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.2",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.2",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.4",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.2",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "8.0",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.2",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "8.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.3",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.3",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.3",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.4",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.3",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "8.0",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.3",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "8.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.4",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.4",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.4",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.4",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.4",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "8.0",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.4",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "8.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.5",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.5",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.5",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.4",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.5",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "8.0",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.5",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "8.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.6",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.6",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.6",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.4",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.6",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "8.0",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.6",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "8.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.7",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.7",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.7",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.4",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.7",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "8.0",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "PS_VERSION_START": "8.1.7",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "8.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     }
   ]
 }

--- a/.github/workflows/ui-test/sanity.json
+++ b/.github/workflows/ui-test/sanity.json
@@ -1,39 +1,6 @@
 {
   "include": [
     {
-      "comment": "1.7.3 ~ minor PHP 7.1"
-    },
-    {
-      "PS_VERSION_START": "1.7.3.0",
-      "PS_VERSION_END": "1.7.8.11",
-      "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL": "online"
-    },
-    {
-      "PS_VERSION_START": "1.7.3.1",
-      "PS_VERSION_END": "1.7.8.11",
-      "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL": "online"
-    },
-    {
-      "PS_VERSION_START": "1.7.3.2",
-      "PS_VERSION_END": "1.7.8.11",
-      "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL": "online"
-    },
-    {
-      "PS_VERSION_START": "1.7.3.3",
-      "PS_VERSION_END": "1.7.8.11",
-      "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL": "online"
-    },
-    {
-      "PS_VERSION_START": "1.7.3.4",
-      "PS_VERSION_END": "1.7.8.11",
-      "UPGRADE_CHANNEL": "online",
-      "PHP_VERSION": "7.1"
-    },
-    {
       "comment": "1.7.6.0 -> 1.7.8.11 PHP 7.1 online"
     },
     {
@@ -49,7 +16,7 @@
       "PS_VERSION_START": "1.7.6.9",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "comment": "1.7.7.0 -> 1.7.8.11 PHP 7.1 online"
@@ -58,7 +25,7 @@
       "PS_VERSION_START": "1.7.7.0",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "comment": "1.7.7.8 -> 8.2.0 PHP 7.3 online"
@@ -67,7 +34,7 @@
       "PS_VERSION_START": "1.7.7.8",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "comment": "1.7.8.10 -> 1.7.8.11 PHP 7.1 online"
@@ -76,7 +43,7 @@
       "PS_VERSION_START": "1.7.8.10",
       "PS_VERSION_END": "1.7.8.11",
       "PHP_VERSION": "7.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "comment": "1.7.8.11 -> 8.2.0 PHP 7.4 online"
@@ -85,7 +52,7 @@
       "PS_VERSION_START": "1.7.8.11",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "7.4",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "comment": "8.0.5 -> 8.2.0 PHP 8.1 online"
@@ -94,7 +61,7 @@
       "PS_VERSION_START": "8.0.5",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "8.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "comment": "8.1.7 -> 8.2.0 PHP 8.1 online"
@@ -103,7 +70,7 @@
       "PS_VERSION_START": "8.1.7",
       "PS_VERSION_END": "8.2.0",
       "PHP_VERSION": "8.1",
-      "UPGRADE_CHANNEL":  "online"
+      "UPGRADE_CHANNEL": "online"
     },
     {
       "comment": "1.7.8.0 -> 1.7.8.10 PHP 7.2 local"
@@ -112,7 +79,7 @@
       "PS_VERSION_START": "1.7.8.0",
       "PS_VERSION_END": "1.7.8.10",
       "PHP_VERSION": "7.2",
-      "UPGRADE_CHANNEL":  "local"
+      "UPGRADE_CHANNEL": "local"
     },
     {
       "comment": "8.0.0 -> 8.0.5 PHP 7.3 local"
@@ -121,7 +88,7 @@
       "PS_VERSION_START": "8.0.0",
       "PS_VERSION_END": "8.0.5",
       "PHP_VERSION": "7.3",
-      "UPGRADE_CHANNEL":  "local"
+      "UPGRADE_CHANNEL": "local"
     },
     {
       "comment": "8.0.0 -> 8.1.7 PHP 7.4 local"
@@ -130,7 +97,7 @@
       "PS_VERSION_START": "8.0.0",
       "PS_VERSION_END": "8.1.7",
       "PHP_VERSION": "7.4",
-      "UPGRADE_CHANNEL":  "local"
+      "UPGRADE_CHANNEL": "local"
     }
   ]
 }

--- a/.github/workflows/ui-test/sanity.json
+++ b/.github/workflows/ui-test/sanity.json
@@ -1,6 +1,39 @@
 {
   "include": [
     {
+      "comment": "1.7.3 ~ minor PHP 7.1"
+    },
+    {
+      "PS_VERSION_START": "1.7.3.0",
+      "PS_VERSION_END": "1.7.8.11",
+      "PHP_VERSION": "7.1",
+      "UPGRADE_CHANNEL": "online"
+    },
+    {
+      "PS_VERSION_START": "1.7.3.1",
+      "PS_VERSION_END": "1.7.8.11",
+      "PHP_VERSION": "7.1",
+      "UPGRADE_CHANNEL": "online"
+    },
+    {
+      "PS_VERSION_START": "1.7.3.2",
+      "PS_VERSION_END": "1.7.8.11",
+      "PHP_VERSION": "7.1",
+      "UPGRADE_CHANNEL": "online"
+    },
+    {
+      "PS_VERSION_START": "1.7.3.3",
+      "PS_VERSION_END": "1.7.8.11",
+      "PHP_VERSION": "7.1",
+      "UPGRADE_CHANNEL": "online"
+    },
+    {
+      "PS_VERSION_START": "1.7.3.4",
+      "PS_VERSION_END": "1.7.8.11",
+      "UPGRADE_CHANNEL": "online",
+      "PHP_VERSION": "7.1"
+    },
+    {
       "comment": "1.7.6.0 -> 1.7.8.11 PHP 7.1 online"
     },
     {

--- a/tests/UI/campaigns/sanity/02_productsBO/01_filterProducts.spec.ts
+++ b/tests/UI/campaigns/sanity/02_productsBO/01_filterProducts.spec.ts
@@ -227,7 +227,7 @@ test.describe('BO - Catalog - Products : Filter the products table by ID, Name, 
 
       test(`should reset filter by '${tst.args.filterBy}'`, async () => {
         await utilsTest.addContextItem(test.info(), 'testIdentifier', `resetFilter${tst.args.identifier}`, baseContext);
-        
+
         const numberOfProductsAfterReset = await boProductsPage.resetAndGetNumberOfLines(page);
         expect(numberOfProductsAfterReset).toEqual(numberOfProducts);
       });

--- a/tests/UI/campaigns/sanity/04_cartFO/01_editCheckCart.spec.ts
+++ b/tests/UI/campaigns/sanity/04_cartFO/01_editCheckCart.spec.ts
@@ -12,9 +12,9 @@ import {
 import {
   test, expect, Page, BrowserContext,
 } from '@playwright/test';
+import semver from 'semver';
 
 const baseContext: string = 'sanity_cartFO_editCheckCart';
-import semver from 'semver';
 
 const psVersion = utilsTest.getPSVersion();
 
@@ -160,6 +160,7 @@ test.describe('FO - Cart : Check Cart in FO', async () => {
     expect(totalPrice).toBeGreaterThan(totalATI);
 
     let productsNumber: number = 0;
+
     if (semver.gte(psVersion, '7.8.0')) {
       productsNumber = await foClassicCartPage.getCartNotificationsNumber(page);
     } else {

--- a/tests/UI/docker-compose.yml
+++ b/tests/UI/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     depends_on:
       - mysql
     environment:
-      - PS_DEV_MODE=0
+      - PS_DEV_MODE=1
       - PS_DOMAIN=localhost
       - PS_LANGUAGE=en
       - PS_COUNTRY=fr

--- a/tests/UI/docker-compose.yml
+++ b/tests/UI/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     depends_on:
       - mysql
     environment:
-      - PS_DEV_MODE=1
+      - PS_DEV_MODE=0
       - PS_DOMAIN=localhost
       - PS_LANGUAGE=en
       - PS_COUNTRY=fr

--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -412,14 +412,14 @@
       }
     },
     "node_modules/@keycloak/keycloak-admin-client": {
-      "version": "22.0.1",
-      "resolved": "https://registry.npmjs.org/@keycloak/keycloak-admin-client/-/keycloak-admin-client-22.0.1.tgz",
-      "integrity": "sha512-/eKzNzT2hW/tRQd8/33dX1dfRU4xBsd3/30bL2OFF5+J+1UUmRYM2klYcFhdIkFX3P9/ptqH+vHpqCusdMcSCw==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@keycloak/keycloak-admin-client/-/keycloak-admin-client-26.0.0.tgz",
+      "integrity": "sha512-fKWJ71hQKPG/vyT1YSLxjZBJ0c1CvXIQh3mssciG8uuavApbmxBMF+zZLx3gZ9VZPS24YqU/uzj/Im+AnbXStw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "camelize-ts": "^3.0.0",
-        "lodash-es": "^4.17.21",
         "url-join": "^5.0.0",
-        "url-template": "^3.1.0"
+        "url-template": "^3.1.1"
       },
       "engines": {
         "node": ">=18"
@@ -497,13 +497,13 @@
     },
     "node_modules/@prestashop-core/ui-testing": {
       "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#31c0af4bf1761fa32e0384f0935826098cc896ca",
+      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#49a1a110e5b399f24225a3e8ccaf59161d2a9c05",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^9.0.3",
         "@playwright/test": "^1.48.1",
-        "@s3pweb/keycloak-admin-client-cjs": "^22.0.1",
-        "@xmldom/xmldom": "^0.8.10",
+        "@s3pweb/keycloak-admin-client-cjs": "^26.0.0",
+        "@xmldom/xmldom": "^0.9.5",
         "csv-writer": "^1.6.0",
         "fast-xml-parser": "^4.4.0",
         "gunzip-file": "^0.1.1",
@@ -518,11 +518,12 @@
       }
     },
     "node_modules/@s3pweb/keycloak-admin-client-cjs": {
-      "version": "22.0.1",
-      "resolved": "https://registry.npmjs.org/@s3pweb/keycloak-admin-client-cjs/-/keycloak-admin-client-cjs-22.0.1.tgz",
-      "integrity": "sha512-F8zr13/rR3QcDzKEty541rXaubU6+Yn/5aMzmSy6in5TeUL3FLqF0QmuW3g1xrgABywcGopew2sEq0X3qJfRUw==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@s3pweb/keycloak-admin-client-cjs/-/keycloak-admin-client-cjs-26.0.0.tgz",
+      "integrity": "sha512-NluHJWOQ5D91S6J0qk7F4QS950yKhOu4TMT0jh3RBAa4kUHjwMw/38gTs0nl/+zdoaax4P0B89i2RWO0vFUoXQ==",
+      "license": "MIT",
       "dependencies": {
-        "@keycloak/keycloak-admin-client": "22.0.1"
+        "@keycloak/keycloak-admin-client": "26.0.0"
       }
     },
     "node_modules/@socket.io/component-emitter": {
@@ -769,11 +770,12 @@
       "dev": true
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
-      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.5.tgz",
+      "integrity": "sha512-6g1EwSs8cr8JhP1iBxzyVAWM6BIDvx9Y3FZRIQiMDzgG43Pxi8YkWOZ0nQj2NHgNzgXDZbJewFx/n+YAvMZrfg==",
+      "license": "MIT",
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.6"
       }
     },
     "node_modules/abab": {
@@ -1259,6 +1261,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/camelize-ts/-/camelize-ts-3.0.0.tgz",
       "integrity": "sha512-cgRwKKavoDKLTjO4FQTs3dRBePZp/2Y9Xpud0FhuCOTE86M2cniKN4CCXgRnsyXNMmQMifVHcv6SPaMtTx6ofQ==",
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
@@ -4005,11 +4008,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
-    },
     "node_modules/lodash.isfunction": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
@@ -5976,6 +5974,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
       "integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
@@ -5993,6 +5992,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/url-template/-/url-template-3.1.1.tgz",
       "integrity": "sha512-4oszoaEKE/mQOtAmdMWqIRHmkxWkUZMnXFnjQ5i01CuRSK3uluxcH1MRVVVWmhlnzT1SCDfKxxficm2G37qzCA==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
@@ -6664,14 +6664,13 @@
       }
     },
     "@keycloak/keycloak-admin-client": {
-      "version": "22.0.1",
-      "resolved": "https://registry.npmjs.org/@keycloak/keycloak-admin-client/-/keycloak-admin-client-22.0.1.tgz",
-      "integrity": "sha512-/eKzNzT2hW/tRQd8/33dX1dfRU4xBsd3/30bL2OFF5+J+1UUmRYM2klYcFhdIkFX3P9/ptqH+vHpqCusdMcSCw==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@keycloak/keycloak-admin-client/-/keycloak-admin-client-26.0.0.tgz",
+      "integrity": "sha512-fKWJ71hQKPG/vyT1YSLxjZBJ0c1CvXIQh3mssciG8uuavApbmxBMF+zZLx3gZ9VZPS24YqU/uzj/Im+AnbXStw==",
       "requires": {
         "camelize-ts": "^3.0.0",
-        "lodash-es": "^4.17.21",
         "url-join": "^5.0.0",
-        "url-template": "^3.1.0"
+        "url-template": "^3.1.1"
       }
     },
     "@mapbox/node-pre-gyp": {
@@ -6726,13 +6725,13 @@
       }
     },
     "@prestashop-core/ui-testing": {
-      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#31c0af4bf1761fa32e0384f0935826098cc896ca",
+      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#49a1a110e5b399f24225a3e8ccaf59161d2a9c05",
       "from": "@prestashop-core/ui-testing@https://github.com/PrestaShop/ui-testing-library#main",
       "requires": {
         "@faker-js/faker": "^9.0.3",
         "@playwright/test": "^1.48.1",
-        "@s3pweb/keycloak-admin-client-cjs": "^22.0.1",
-        "@xmldom/xmldom": "^0.8.10",
+        "@s3pweb/keycloak-admin-client-cjs": "^26.0.0",
+        "@xmldom/xmldom": "^0.9.5",
         "csv-writer": "^1.6.0",
         "fast-xml-parser": "^4.4.0",
         "gunzip-file": "^0.1.1",
@@ -6747,11 +6746,11 @@
       }
     },
     "@s3pweb/keycloak-admin-client-cjs": {
-      "version": "22.0.1",
-      "resolved": "https://registry.npmjs.org/@s3pweb/keycloak-admin-client-cjs/-/keycloak-admin-client-cjs-22.0.1.tgz",
-      "integrity": "sha512-F8zr13/rR3QcDzKEty541rXaubU6+Yn/5aMzmSy6in5TeUL3FLqF0QmuW3g1xrgABywcGopew2sEq0X3qJfRUw==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@s3pweb/keycloak-admin-client-cjs/-/keycloak-admin-client-cjs-26.0.0.tgz",
+      "integrity": "sha512-NluHJWOQ5D91S6J0qk7F4QS950yKhOu4TMT0jh3RBAa4kUHjwMw/38gTs0nl/+zdoaax4P0B89i2RWO0vFUoXQ==",
       "requires": {
-        "@keycloak/keycloak-admin-client": "22.0.1"
+        "@keycloak/keycloak-admin-client": "26.0.0"
       }
     },
     "@socket.io/component-emitter": {
@@ -6906,9 +6905,9 @@
       "dev": true
     },
     "@xmldom/xmldom": {
-      "version": "0.8.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
-      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw=="
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.5.tgz",
+      "integrity": "sha512-6g1EwSs8cr8JhP1iBxzyVAWM6BIDvx9Y3FZRIQiMDzgG43Pxi8YkWOZ0nQj2NHgNzgXDZbJewFx/n+YAvMZrfg=="
     },
     "abab": {
       "version": "2.0.6",
@@ -9277,11 +9276,6 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
-    },
-    "lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash.isfunction": {
       "version": "3.0.9",


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add PS versions from 1.7.3.0 ~ 1.7.3.4 to 1.7.8.11 (minor) on php 7.1 
| Type?             | improvement
| Sponsor company   | @PrestaShopCorp
| How to test?      | CI is :green_apple: 
