### PR TITLE
Avoid UI tests to be run 2 times on local branches with PRs

### DIFF
--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -1,7 +1,7 @@
 name: UI Tests
 on:
   ## Check each PR
-  push:
+  # push:
   pull_request:
   ## Manual execution on branch
   workflow_dispatch:

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -1,7 +1,10 @@
 name: UI Tests
 on:
   ## Check each PR
-  # push:
+  push:
+    branches:
+      - dev
+      - master
   pull_request:
   ## Manual execution on branch
   workflow_dispatch:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When a pull-request in opened with another branch of this repository as Head, some workflows are executed several times (pull-request and push). The UI tests can take a lot of time, so let's run it only one time.<br/>The main concerned pull-requests are related to translations (i.e https://github.com/PrestaShop/autoupgrade/pull/787).
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Nothing change for pull-requests, the UI tests remain executed.