### PR TITLE
enchancement: update extract translation to only push on one branch

### DIFF
--- a/.github/workflows/extract-translations.yml
+++ b/.github/workflows/extract-translations.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout module-translation-tool
         uses: actions/checkout@v4
         with:
-          repository: ga-devfront/module-translation-tool
+          repository: PrestaShopCorp/module-translation-tool
           ref: main
       - name: Create config for module-translation-tool
         run: |


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Currently we got multiple PR then we have new translation (possibly with same content), we fix this by pushing only changes in one branche named 'translation-extraction'
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Sponsor company   | @PrestaShopCorp
| How to test?      | Add translations and merge multiple PR on dev and check if we got one or many PR.
