### PR TITLE
UI tests - Add the upgrade of 178 to major php 7.2 ~ 7.4 to the nightly

### DIFF
--- a/.github/workflows/ui-test/nightly.json
+++ b/.github/workflows/ui-test/nightly.json
@@ -31,13 +31,13 @@
       "PS_VERSION_START": "1.7.8.1",
       "PS_VERSION_END": "1.7.8.11",
       "UPGRADE_CHANNEL": "minor",
-      "PHP_VERSION": "7.4"
+      "PHP_VERSION": "7.3"
     },
     {
       "PS_VERSION_START": "1.7.8.1",
       "PS_VERSION_END": "1.7.8.11",
       "UPGRADE_CHANNEL": "minor",
-      "PHP_VERSION": "7.3"
+      "PHP_VERSION": "7.4"
     },
     {
       "PS_VERSION_START": "1.7.8.2",
@@ -49,10 +49,22 @@
       "PS_VERSION_START": "1.7.8.2",
       "PS_VERSION_END": "1.7.8.11",
       "UPGRADE_CHANNEL": "minor",
-      "PHP_VERSION": "7.4"
+      "PHP_VERSION": "7.3"
     },
     {
       "PS_VERSION_START": "1.7.8.2",
+      "PS_VERSION_END": "1.7.8.11",
+      "UPGRADE_CHANNEL": "minor",
+      "PHP_VERSION": "7.4"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.3",
+      "PS_VERSION_END": "1.7.8.11",
+      "UPGRADE_CHANNEL": "minor",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.3",
       "PS_VERSION_END": "1.7.8.11",
       "UPGRADE_CHANNEL": "minor",
       "PHP_VERSION": "7.3"
@@ -191,6 +203,234 @@
     },
     {
       "comment": "1.7.8 ~ major PHP 7.2 ~ 7.4"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.0",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.0",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.0",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.4"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.1",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.1",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.1",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.4"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.2",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.2",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.2",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.4"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.3",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.3",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.3",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.4"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.4",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.4",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.4",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.4"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.4",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.4",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.4",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.4"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.5",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.5",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.5",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.4"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.6",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.6",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.6",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.4"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.7",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.7",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.7",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.4"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.8",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.8",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.8",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.4"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.9",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.9",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.9",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.4"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.10",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.10",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.10",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.4"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.11",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.2"
+    },
+    {
+      "PS_VERSION_START": "1.7.8.11",
+      "PS_VERSION_END": "8.1.7",
+      "UPGRADE_CHANNEL": "major",
+      "PHP_VERSION": "7.3"
     },
     {
       "PS_VERSION_START": "1.7.8.11",

--- a/.github/workflows/ui-test/sanity.json
+++ b/.github/workflows/ui-test/sanity.json
@@ -1,7 +1,7 @@
 {
   "include": [
     {
-      "comment": "1.7.8 ~ minor PHP 7.2 ~ 7.4"
+      "comment": "1.7.8 ~ minor PHP 7.4"
     },
     {
       "PS_VERSION_START": "1.7.8.10",
@@ -10,7 +10,7 @@
       "PHP_VERSION": "7.4"
     },
     {
-      "comment": "1.7.8 ~ major PHP 7.2 ~ 7.4"
+      "comment": "1.7.8 ~ major PHP 7.4"
     },
     {
       "PS_VERSION_START": "1.7.8.11",
@@ -19,7 +19,7 @@
       "PHP_VERSION": "7.4"
     },
     {
-      "comment": "8.0.5 ~ minor PHP 7.2 ~ 8.1"
+      "comment": "8.0.5 ~ minor PHP 8.1"
     },
     {
       "PS_VERSION_START": "8.0.5",
@@ -28,7 +28,7 @@
       "PHP_VERSION": "8.1"
     },
     {
-      "comment": "8.1.6 ~ minor PHP 7.2 ~ 8.1"
+      "comment": "8.1.6 ~ minor PHP 8.1"
     },
     {
       "PS_VERSION_START": "8.1.6",


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the upgrade of 178 to major php 7.2 ~ 7.4 to the nightly
| Type?             | improvement
| Sponsor company   | @PrestaShopCorp
| How to test?      | CI is :green_apple: 
