### PR TITLE
fix: remove unnecessary check before deleting files

### DIFF
--- a/classes/Task/Upgrade/UpgradeFiles.php
+++ b/classes/Task/Upgrade/UpgradeFiles.php
@@ -180,9 +180,7 @@ class UpgradeFiles extends AbstractTask
 
             return true;
         } elseif (is_dir($dest)) {
-            if (strpos($dest, DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR) === false) {
-                FilesystemAdapter::deleteDirectory($dest);
-            }
+            FilesystemAdapter::deleteDirectory($dest);
             $this->logger->debug(sprintf('removed dir %1$s.', $file));
 
             return true;


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | remove unnecessary check before deleting files because we doing the list before.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/28492
| Sponsor company   | @PrestaShopCorp
| How to test?      | Try another update from 1.7.7.8 to 1.7.8.6
