### PR TITLE
enchancement: Change the logger to throw exception and silent mkdir

### DIFF
--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -595,7 +595,6 @@ class UpgradeContainer
         }
 
         $this->workspace = new Workspace(
-            $this->getLogger(),
             $this->getTranslator(),
             $paths
         );

--- a/classes/Workspace.php
+++ b/classes/Workspace.php
@@ -27,17 +27,11 @@
 
 namespace PrestaShop\Module\AutoUpgrade;
 
-use PrestaShop\Module\AutoUpgrade\Log\LoggerInterface;
-use PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator;
 use Exception;
+use PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator;
 
 class Workspace
 {
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
-
     /**
      * @var Translator
      */
@@ -51,9 +45,8 @@ class Workspace
     /**
      * @param string[] $paths
      */
-    public function __construct(LoggerInterface $logger, Translator $translator, array $paths)
+    public function __construct(Translator $translator, array $paths)
     {
-        $this->logger = $logger;
         $this->translator = $translator;
         $this->paths = $paths;
     }

--- a/classes/Workspace.php
+++ b/classes/Workspace.php
@@ -29,6 +29,7 @@ namespace PrestaShop\Module\AutoUpgrade;
 
 use PrestaShop\Module\AutoUpgrade\Log\LoggerInterface;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator;
+use Exception;
 
 class Workspace
 {
@@ -60,11 +61,11 @@ class Workspace
     public function createFolders(): void
     {
         foreach ($this->paths as $path) {
-            if (!file_exists($path) && !mkdir($path)) {
-                $this->logger->error($this->translator->trans('Unable to create directory %s', [$path]));
+            if (!file_exists($path) && !@mkdir($path)) {
+                throw new Exception($this->translator->trans('Unable to create directory %s', [$path]));
             }
             if (!is_writable($path)) {
-                $this->logger->error($this->translator->trans('Unable to write in the directory "%s"', [$path]));
+                throw new Exception($this->translator->trans('Cannot write to the directory. Please ensure you have the necessary write permissions on "%s".', [$path]));
             }
         }
     }


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Change the logger to throw exception and silent `mkdir` to throw understandable error. Related to this issue https://github.com/PrestaShop/PrestaShop/issues/36530 because in this case we don't know wich folder cause the issue. It's not a fix of the problem but and improvement to understand it.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | --
| Sponsor company   | @PrestaShopCorp
| How to test?      | You can set chmod 000 on /%admin_folder_name%/autoupgrade to see the right error then you access AutoUpgrade page.
