### PR TITLE
Make sure only the errors by merchants are sent to Sentry to avoid noise from the rest happening on the BO

### DIFF
--- a/classes/UpgradePage.php
+++ b/classes/UpgradePage.php
@@ -293,6 +293,9 @@ class UpgradePage
             'currentIndex' => $this->currentIndex,
             'tab' => 'AdminSelfUpgrade',
             'channel' => $this->config->get('channel'),
+            'autoupgrade' => [
+                'version' => $this->upgradeSelfCheck->getModuleVersion(),
+            ],
             'translation' => [
                 'confirmDeleteBackup' => $translator->trans('Are you sure you want to delete this backup?'),
                 'delete' => $translator->trans('Delete'),

--- a/js/sentry.js
+++ b/js/sentry.js
@@ -28,17 +28,17 @@ Sentry.init({
     release: input.autoupgrade.version,
     beforeSend(event, hint) {
         // Only the one we handle via the feedback modal must be sent.
-        if (!event.tag?.source || event.tag.source !== 'feedbackModal') {
+        if (!event.tags?.source || event.tags.source !== 'feedbackModal') {
             return null;
         }
         event.request.url = maskSensitiveInfoInUrl(event.request.url, input.adminUrl);
 
-        hint.attachments = [{ filename: "log.txt", data: readLogPanel() }];
+        hint.attachments = [
+            { filename: "log.txt", data: readLogPanel('quickInfo') },
+            { filename: "error.txt", data: readLogPanel('infoError') },
+        ];
 
         return event;
-    },
-    afterSend() {
-        Sentry.setTag('source', '');
     },
 });
 
@@ -68,8 +68,10 @@ document.getElementById("submitErrorReport").addEventListener("click", function 
             comments: errorDescription.value,
         });
 
+        // Clean-up
         userEmail.value = "";
         errorDescription.value = "";
+        Sentry.setTag('source', '');
 
         $('#errorModal').modal('hide')
     }
@@ -83,6 +85,6 @@ function maskSensitiveInfoInUrl(url, adminFolder) {
     return url.replace(regex, 'token=********');
 }
 
-function readLogPanel() {
-    return document.getElementById("quickInfo").innerText;
+function readLogPanel(targetPanel) {
+    return document.getElementById(targetPanel).innerText;
 }

--- a/js/sentry.js
+++ b/js/sentry.js
@@ -25,9 +25,17 @@
 
 Sentry.init({
     dsn: "https://eae192966a8d79509154c65c317a7e5d@o298402.ingest.us.sentry.io/4507254110552064",
+    release: input.autoupgrade.version,
     beforeSend(event) {
+        // Only the one we handle via the feedback modal must be sent.
+        if (!event.tag?.source || event.tag.source !== 'feedbackModal') {
+            return null;
+        }
         event.request.url = maskSensitiveInfoInUrl(event.request.url, input.adminUrl);
         return event;
+    },
+    afterSend() {
+        Sentry.setTag('source', '');
     },
 });
 
@@ -45,6 +53,7 @@ document.getElementById("submitErrorReport").addEventListener("click", function 
         const url = maskSensitiveInfoInUrl(window.location.href, input.adminUrl);
 
         Sentry.setTag("url", url);
+        Sentry.setTag('source', 'feedbackModal');
 
         const eventId = Sentry.captureMessage(messages, "error");
         const userEmail = document.getElementById("userEmail");

--- a/js/sentry.js
+++ b/js/sentry.js
@@ -25,7 +25,7 @@
 
 Sentry.init({
     dsn: "https://eae192966a8d79509154c65c317a7e5d@o298402.ingest.us.sentry.io/4507254110552064",
-    release: input.autoupgrade.version,
+    release: 'v' + input.autoupgrade.version,
     beforeSend(event, hint) {
         // Only the one we handle via the feedback modal must be sent.
         if (!event.tags?.source || event.tags.source !== 'feedbackModal') {

--- a/js/sentry.js
+++ b/js/sentry.js
@@ -26,12 +26,15 @@
 Sentry.init({
     dsn: "https://eae192966a8d79509154c65c317a7e5d@o298402.ingest.us.sentry.io/4507254110552064",
     release: input.autoupgrade.version,
-    beforeSend(event) {
+    beforeSend(event, hint) {
         // Only the one we handle via the feedback modal must be sent.
         if (!event.tag?.source || event.tag.source !== 'feedbackModal') {
             return null;
         }
         event.request.url = maskSensitiveInfoInUrl(event.request.url, input.adminUrl);
+
+        hint.attachments = [{ filename: "log.txt", data: readLogPanel() }];
+
         return event;
     },
     afterSend() {
@@ -78,4 +81,8 @@ function maskSensitiveInfoInUrl(url, adminFolder) {
 
     regex = new RegExp( "token=[^&]*", "i");
     return url.replace(regex, 'token=********');
+}
+
+function readLogPanel() {
+    return document.getElementById("quickInfo").innerText;
 }


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | From the first tests, it appears anything reported on the backoffice when on the upgrade page can be sent to our Sentry project. This PR filters the errors that only triggered from the feedback modal and add useful informations for triage and debug.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Try manually sending an error to Sentry (or with `Sentry.captureMessage()`). It won't be taken in account.

* Add the concerned release of the module
* Add attachments: Contents of logs panel + Contents of error panel