### PR TITLE
Removing the ability to save a channel archive without zip and xml

### DIFF
--- a/classes/UpgradePage.php
+++ b/classes/UpgradePage.php
@@ -337,6 +337,7 @@ class UpgradePage
                 'filesWillBeDeleted' => $translator->trans('These files will be deleted'),
                 'filesWillBeReplaced' => $translator->trans('These files will be replaced'),
                 'noXmlSelected' => $translator->trans('No XML file has been selected.'),
+                'noArchiveAndXmlSelected' => $translator->trans('No archive and no XML file have been selected.'),
             ],
         ];
     }

--- a/js/upgrade.js
+++ b/js/upgrade.js
@@ -55,6 +55,7 @@ if (typeof input === 'undefined') {
       filesWillBeDeleted: "These files will be deleted",
       filesWillBeReplaced: "These files will be replaced",
       noXmlSelected: "No XML file has been selected.",
+      noArchiveAndXmlSelected: "No archive and no XML file have been selected.",
     }
   };
 }
@@ -803,11 +804,13 @@ $(document).ready(function() {
       } else if ($newChannel === "archive") {
         var archive_prestashop = $("select[name=archive_prestashop]").val();
         var archive_xml = $("select[name=archive_xml]").val();
-        if (archive_prestashop == "") {
+        if (!archive_prestashop && !archive_xml) {
+          showConfigResult(input.translation.noArchiveAndXmlSelected, "error");
+          return false;
+        } else if (!archive_prestashop) {
           showConfigResult(input.translation.noArchiveSelected, "error");
           return false;
-        }
-        if (archive_xml == "") {
+        } else if (!archive_xml) {
           showConfigResult(input.translation.noXmlSelected, "error");
           return false;
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Removing the ability to save a channel archive without zip and xml
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | -
| How to test?      | Save archive config without zip and xml
