### PR TITLE
Improvement for new v9 context

### DIFF
--- a/controllers/admin/AdminSelfUpgradeController.php
+++ b/controllers/admin/AdminSelfUpgradeController.php
@@ -295,6 +295,12 @@ class AdminSelfUpgradeController extends ModuleAdminController
             parent::init();
         }
 
+        // V9 context security
+        // After an upgrade we disconnect the user from the session, and the employee context is null.
+        if (!$this->context->employee->id) {
+            return;
+        }
+
         // For later use, let's set up prodRootDir and adminDir
         // This way it will be easier to upgrade a different path if needed
         $this->prodRootDir = _PS_ROOT_DIR_;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Quick fix on a controller display on V9 after an upgrade. A new context mechanism is present on v9, and on old controllers the constructor is called before the listenners to avoid context overload (https://github.com/PrestaShop/PrestaShop/blob/f55bf596ba0a12e22846d706ac0834be8ebf0e45/src/PrestaShopBundle/Routing/LegacyRouterChecker.php#L117). After an upgrade we disconnect the user from the session, and the employee context is null. Before 9 we were redirected before arriving at the controller, but in v9 we call the constructor and the init method to initialize the context on LegacyRouterChecker, and we have an error because the init method calls Cookie::create(context- >employee->id, context->language->iso_code)
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #https://github.com/PrestaShop/PrestaShop/issues/36642
| Sponsor company   | -
| How to test?      | -
