### PR TITLE
Cast explicitely percentage as integer

### DIFF
--- a/classes/Progress/CompletionCalculator.php
+++ b/classes/Progress/CompletionCalculator.php
@@ -116,6 +116,7 @@ class CompletionCalculator
             return $currentBaseProgress + ($nextBaseProgress - $currentBaseProgress);
         }
 
-        return $currentBaseProgress + (($nextBaseProgress - $currentBaseProgress) * ($backlog->getInitialTotal() - $backlog->getRemainingTotal()) / $backlog->getInitialTotal());
+        // Casting as integer is equivalent to using floor(), and we want to round down.
+        return (int) ($currentBaseProgress + (($nextBaseProgress - $currentBaseProgress) * ($backlog->getInitialTotal() - $backlog->getRemainingTotal()) / $backlog->getInitialTotal()));
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | While upgrading, we see some notices about a implicit float cast as integer. This PR fixes the issue.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | There is no more notices in the logs when running steps like UpgradeFiles or BackupFiles
