### PR TITLE
Update build of storybook container for permission issues

### DIFF
--- a/storybook/.docker/Dockerfile
+++ b/storybook/.docker/Dockerfile
@@ -1,20 +1,5 @@
-FROM php:8.2-fpm
+# Storybook container requires both Node and PHP
+# Using Node as base to avoid permission issues while running Storybook
+FROM node:20
 
-RUN apt-get update && apt-get install -y \
-    libpq-dev \
-    libxml2-dev
-
-RUN docker-php-ext-install dom xml
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y nodejs
-
-RUN node --version
-RUN npm --version
-
-RUN curl -1sLf 'https://dl.cloudsmith.io/public/symfony/stable/setup.deb.sh' | bash
-RUN apt-get install -y symfony-cli
-
-WORKDIR /var/www/html
+RUN apt update && apt install -y php8.2 php-dom

--- a/storybook/README.md
+++ b/storybook/README.md
@@ -50,33 +50,15 @@ Once started, you can access Storybook at: http://localhost:6006/
 
 ## Build and start environment with docker
 
-### Install Project Dependencies with Docker
-
-**Install PHP Dependencies**
-
-Run the following command to install PHP dependencies via Docker:
+A Compose file is provided in the `storybook/` folder. It is responsible in installing the dependencies before running PHP and Storybook.
+To start Storybook via Docker, use the following command:
 
 ```shell
-$ docker run -u 1000:1000 --rm --interactive --tty -v "$PWD"/../:/app -w /app/storybook composer install
+$ cd storybook/
+$ THE_UID="$(id -u)" THE_GID="$(id -g)" docker compose up
 ```
 
-**Install Node dependencies**
-
-Run the following command to install Node.js dependencies via Docker:
-
-```shell
-$ docker compose run storybook-js npm install
-```
-
-### Start Docker environment
-
-**Start Symfony Server and Storybook**
-
-To start the Symfony server and Storybook via Docker, use the following command:
-
-```shell
-$ docker compose up
-```
+Providing user and group ids allows the files created during the build to be set with the proper permissions.
 
 Once started, you can access Storybook at: http://localhost:6006/
 

--- a/storybook/README.md
+++ b/storybook/README.md
@@ -50,11 +50,11 @@ Once started, you can access Storybook at: http://localhost:6006/
 
 ## Build and start environment with docker
 
-A Compose file is provided in the `storybook/` folder. It is responsible in installing the dependencies before running PHP and Storybook.
+A Docker Compose file is provided in the `storybook/` folder. It is responsible in installing the dependencies before running PHP and Storybook.
 To start Storybook via Docker, use the following command:
 
 ```shell
-$ cd storybook/
+# From the storybook/ folder
 $ THE_UID="$(id -u)" THE_GID="$(id -g)" docker compose up
 ```
 

--- a/storybook/docker-compose.yml
+++ b/storybook/docker-compose.yml
@@ -1,20 +1,41 @@
 services:
+  composer-root:
+    image: composer
+    command: install
+    user: "${THE_UID}:${THE_GID}"
+    volumes:
+      - ./../:/autoupgrade
+    working_dir: /autoupgrade
+
+  composer-storybook:
+    image: composer
+    command: install
+    user: "${THE_UID}:${THE_GID}"
+    volumes:
+      - ./../:/autoupgrade
+    working_dir: /autoupgrade/storybook
+
   storybook-php:
-    build:
-      context: .
-      dockerfile: ./.docker/Dockerfile
-    command: symfony server:start
+    image: prestashop/base:8.2-apache
+    command: php -S 0.0.0.0:8000 -t public/
+    user: "${THE_UID}:${THE_GID}"
     volumes:
       - ./../:/autoupgrade
     working_dir: /autoupgrade/storybook
     ports:
       - "8003:8000"
+    depends_on:
+      composer-root:
+        condition: service_completed_successfully
+      composer-storybook:
+        condition: service_completed_successfully
 
   storybook-js:
     build:
       context: .
       dockerfile: ./.docker/Dockerfile
-    command: npm run storybook
+    command: bash -c "npm install && npm run storybook"
+    user: "${THE_UID}:${THE_GID}"
     environment:
       IS_IN_DOCKER: true
     volumes:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | QA checks have reported issues while starting Storybook on Docker, because of files with bad user or permission. This PR changes the way containers are created, by requesting the user ID, and downloading all dependencies at startup.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | From a fresh clone of this repository with the branch, starting Storybook with Docker by foillowing the readme will avoid issues with files created as root.