### PR TITLE
Removing patch version when comparing php version for destination version

### DIFF
--- a/classes/Twig/Block/UpgradeChecklist.php
+++ b/classes/Twig/Block/UpgradeChecklist.php
@@ -104,7 +104,7 @@ class UpgradeChecklist
             'token' => $this->token,
             'cachingIsDisabled' => $this->selfCheck->isCacheDisabled(),
             'maxExecutionTime' => $this->selfCheck->getMaxExecutionTime(),
-            'phpRequirementsState' => $this->selfCheck->getPhpRequirementsState(),
+            'phpRequirementsState' => $this->selfCheck->getPhpRequirementsState(PHP_VERSION_ID),
             'phpCompatibilityRange' => $this->selfCheck->getPhpCompatibilityRange(),
             'checkApacheModRewrite' => $this->selfCheck->isApacheModRewriteEnabled(),
             'notLoadedPhpExtensions' => $this->selfCheck->getNotLoadedPhpExtensions(),

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -343,7 +343,7 @@ class UpgradeSelfCheck
             && ($this->isShopDeactivated() || $this->isLocalEnvironment())
             && $this->isCacheDisabled()
             && $this->isModuleVersionLatest()
-            && $this->getPhpRequirementsState() !== $this::PHP_REQUIREMENTS_INVALID
+            && $this->getPhpRequirementsState(PHP_VERSION_ID) !== $this::PHP_REQUIREMENTS_INVALID
             && $this->isShopVersionMatchingVersionInDatabase()
             && $this->isApacheModRewriteEnabled()
             && $this->checkKeyGeneration()
@@ -457,9 +457,11 @@ class UpgradeSelfCheck
     }
 
     /**
+     * @param int $currentVersionId
+     *
      * @return self::PHP_REQUIREMENTS_*
      */
-    public function getPhpRequirementsState(): int
+    public function getPhpRequirementsState($currentVersionId): int
     {
         $phpCompatibilityRange = $this->getPhpCompatibilityRange();
 
@@ -469,9 +471,13 @@ class UpgradeSelfCheck
 
         $versionMin = VersionUtils::getPhpVersionId($phpCompatibilityRange['php_min_version']);
         $versionMax = VersionUtils::getPhpVersionId($phpCompatibilityRange['php_max_version']);
-        $currentVersion = VersionUtils::getPhpMajorMinorVersionId();
 
-        if ($currentVersion >= $versionMin && $currentVersion <= $versionMax) {
+        $versionMinWithoutPatch = VersionUtils::getPhpMajorMinorVersionId($versionMin);
+        $versionMaxWithoutPatch = VersionUtils::getPhpMajorMinorVersionId($versionMax);
+
+        $currentVersion = VersionUtils::getPhpMajorMinorVersionId($currentVersionId);
+
+        if ($currentVersion >= $versionMinWithoutPatch && $currentVersion <= $versionMaxWithoutPatch) {
             return self::PHP_REQUIREMENTS_VALID;
         }
 

--- a/classes/VersionUtils.php
+++ b/classes/VersionUtils.php
@@ -92,12 +92,12 @@ class VersionUtils
     }
 
     /**
+     * @param int $phpVersionId
+     *
      * @return int
      */
-    public static function getPhpMajorMinorVersionId()
+    public static function getPhpMajorMinorVersionId($phpVersionId)
     {
-        $phpVersionId = PHP_VERSION_ID;
-
         $major = (int) ($phpVersionId / 10000);
         $minor = (int) (($phpVersionId % 10000) / 100);
 

--- a/tests/unit/UpgradeSelfCheckTest.php
+++ b/tests/unit/UpgradeSelfCheckTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+namespace unit;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\Module\AutoUpgrade\UpgradeSelfCheck;
+
+class UpgradeSelfCheckTest extends TestCase
+{
+    /** @var UpgradeSelfCheck */
+    private $upgradeSelfCheck;
+
+    public function setUp()
+    {
+        if (PHP_VERSION_ID >= 80000) {
+            $this->markTestSkipped('An issue with this version of PHPUnit and PHP 8+ prevents this test to run.');
+        }
+
+        $this->upgradeSelfCheck = $this->getMockBuilder(UpgradeSelfCheck::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getPhpCompatibilityRange'])
+            ->getMock();
+    }
+
+    public function testInvalidCompatibilityRange()
+    {
+        $this->upgradeSelfCheck->method('getPhpCompatibilityRange')
+            ->willReturn(['php_min_version' => '7.1.0', 'php_max_version' => '7.4.0']);
+
+        $this->assertEquals(UpgradeSelfCheck::PHP_REQUIREMENTS_INVALID, $this->upgradeSelfCheck->getPhpRequirementsState(80000));
+    }
+
+    public function testValidCompatibilityRange()
+    {
+        $this->upgradeSelfCheck->method('getPhpCompatibilityRange')
+            ->willReturn(['php_min_version' => '7.1.0', 'php_max_version' => '7.4.0']);
+
+        $this->assertEquals(UpgradeSelfCheck::PHP_REQUIREMENTS_VALID, $this->upgradeSelfCheck->getPhpRequirementsState(70300));
+
+        $this->upgradeSelfCheck->method('getPhpCompatibilityRange')
+            ->willReturn(['php_min_version' => '7.2.5', 'php_max_version' => '8.1']);
+
+        $this->assertEquals(UpgradeSelfCheck::PHP_REQUIREMENTS_VALID, $this->upgradeSelfCheck->getPhpRequirementsState(70213));
+    }
+
+    public function testUnknownCompatibilityRange()
+    {
+        $this->upgradeSelfCheck->method('getPhpCompatibilityRange')
+            ->willReturn(null);
+
+        $this->assertEquals(UpgradeSelfCheck::PHP_REQUIREMENTS_UNKNOWN, $this->upgradeSelfCheck->getPhpRequirementsState(70300));
+    }
+}

--- a/tests/unit/VersionUtilsTest.php
+++ b/tests/unit/VersionUtilsTest.php
@@ -73,6 +73,14 @@ class VersionUtilsTest extends TestCase
         $version = VersionUtils::getPhpVersionId('7.1');
 
         $this->assertSame(70100, $version);
+
+        $version = VersionUtils::getPhpVersionId('7.2.18');
+
+        $this->assertSame(70218, $version);
+
+        $version = VersionUtils::getPhpVersionId('7.2.5');
+
+        $this->assertSame(70205, $version);
     }
 
     public function testGetPhpVersionIdFailForBadType()
@@ -98,9 +106,9 @@ class VersionUtilsTest extends TestCase
 
     public function testGetPhpMajorMinorVersionId()
     {
-        $version = VersionUtils::getPhpMajorMinorVersionId();
+        $version = VersionUtils::getPhpMajorMinorVersionId(70218);
 
-        $this->assertSame(PHP_MAJOR_VERSION * 10000 + PHP_MINOR_VERSION * 100, $version);
+        $this->assertSame(70200, $version);
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Removing patch version when comparing php version for destination version
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | -
| How to test?      | try to update to Prestashop 8.1.7 (php requirement 7.2.5) with php 7.2.1x
