### PR TITLE
Drop "isPhpSessionsValid" requirement

### DIFF
--- a/classes/Twig/Block/UpgradeChecklist.php
+++ b/classes/Twig/Block/UpgradeChecklist.php
@@ -112,7 +112,6 @@ class UpgradeChecklist
             'checkMemoryLimit' => $this->selfCheck->isMemoryLimitValid(),
             'checkFileUploads' => $this->selfCheck->isPhpFileUploadsConfigurationEnabled(),
             'notExistsPhpFunctions' => $this->selfCheck->getNotExistsPhpFunctions(),
-            'checkPhpSessions' => $this->selfCheck->isPhpSessionsValid(),
             'notWritingDirectories' => $this->selfCheck->getNotWritingDirectories(),
         ];
     }

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -622,11 +622,6 @@ class UpgradeSelfCheck
         return (bool) ConfigurationTest::test_upload();
     }
 
-    public function isPhpSessionsValid(): bool
-    {
-        return in_array(session_status(), [PHP_SESSION_ACTIVE, PHP_SESSION_NONE], true);
-    }
-
     /**
      * @return array<string>
      */

--- a/views/templates/block/checklist.html.twig
+++ b/views/templates/block/checklist.html.twig
@@ -180,12 +180,6 @@
                         <td>{{ icons.nok(psBaseUri) }}</td>
                     </tr>
                 {% endif %}
-                {% if not checkPhpSessions %}
-                    <tr>
-                        <td>{{ 'It\'s not possible to create a PHP session.'|trans({}) }}</td>
-                        <td>{{ icons.nok(psBaseUri) }}</td>
-                    </tr>
-                {% endif %}
                 {% if not checkKeyGeneration %}
                   <tr>
                     <td>{{ 'Unable to generate private keys using openssl_pkey_new. Check your OpenSSL configuration, especially the path to openssl.cafile.'|trans({}) }}</td>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Withdrawal of the requirement. We decided to remove it because the user will inevitably have errors before arriving on the module configuration page. The Prestashop back office requires PHP sessions, 
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | -
| How to test?      | -
