### PR TITLE
[NEW UI] Auto height logs container on update page

### DIFF
--- a/_dev/src/scss/_mixins.scss
+++ b/_dev/src/scss/_mixins.scss
@@ -5,6 +5,6 @@
   }
 
   to {
-    transform: rotate(360deg);
+    transform: rotate(-360deg);
   }
 }

--- a/_dev/src/scss/_variables.scss
+++ b/_dev/src/scss/_variables.scss
@@ -47,6 +47,19 @@ $cdk-prefix: "cdk-";
     --#{$cdk-prefix}font-family-material-icons,
     "Material Icons"
   );
+  --#{$ua-prefix}header-offset: 10rem;
+  --#{$ua-prefix}bo-background-color: var(--#{$ua-prefix}primary-200);
+}
+
+// Update variable at body level
+body {
+  &:has(.v1-7-8-0) {
+    --#{$ua-prefix}bo-background-color: #eff1f2;
+  }
+
+  &:has(.v1-7-3-0) {
+    --#{$ua-prefix}bo-background-color: #eff1f2;
+  }
 }
 
 /* 1.7.8.0 */

--- a/_dev/src/scss/components/_logs.scss
+++ b/_dev/src/scss/components/_logs.scss
@@ -15,26 +15,31 @@ $e: ".logs";
     background-color: var(--#{$ua-prefix}logs-background-color);
     border-radius: var(--#{$ua-prefix}border-radius);
 
-    &__scroll {
+    &__inner {
       display: flex;
       flex-direction: column;
       flex-grow: 1;
       flex-shrink: 1;
       gap: 1rem;
       height: 100%;
-      overflow-y: auto;
     }
 
     &__buttons {
       flex-shrink: 0;
     }
 
+    &__scroll {
+      flex-grow: 1;
+      min-height: var(--#{$ua-prefix}logs-height);
+      overflow-y: scroll;
+      scroll-behavior: smooth;
+    }
+
     &__list {
       display: flex;
       flex-direction: column;
       gap: 0.5rem;
-      max-height: 14rem;
-      overflow-y: auto;
+      max-height: 100%;
     }
 
     &__line {
@@ -44,6 +49,7 @@ $e: ".logs";
       background-size: 1.5rem 1.5rem;
       font-size: 0.875rem;
       line-height: 1.4;
+      word-break: break-word;
 
       &--success {
         background-image: url("../../img/check.svg");

--- a/_dev/src/scss/layouts/_index.scss
+++ b/_dev/src/scss/layouts/_index.scss
@@ -1,5 +1,6 @@
 @use "backup";
 @use "layout";
+@use "logs-pages";
 @use "page";
 @use "version-choice";
 @use "welcome";

--- a/_dev/src/scss/layouts/_logs-pages.scss
+++ b/_dev/src/scss/layouts/_logs-pages.scss
@@ -1,54 +1,54 @@
 @use "../variables" as *;
 
 // Auto size logs section to use available height
-@at-root {
-  html {
-    &:has(#{$ua-id}) {
-      // Need class use in #ua_step_content to make it work
-      &:has(.update-page) {
-        container-type: size;
-        container-name: html-height;
+html {
+  &:has(#{$ua-id}) {
+    // Need class use in #ua_step_content to make it work
+    &:has(.update-page) {
+      container-type: size;
+      container-name: html-height;
 
-        body {
-          background-color: var(--#{$ua-prefix}bo-background-color);
+      body {
+        background-color: var(--#{$ua-prefix}bo-background-color);
+      }
+
+      #main {
+        padding-block-end: 0;
+      }
+
+      #content {
+        background-color: var(--#{$ua-prefix}bo-background-color);
+      }
+
+      // Logs adjustments
+      .logs {
+        flex-grow: 1;
+
+        &__scroll {
+          container-type: size;
         }
+      }
 
-        #main {
-          padding-block-end: 0;
-        }
+      // Page adjustments
+      @container html-height (min-width: 0) {
+        #{$ua-id} {
+          display: grid;
+          grid-template-columns: minmax(0, 1fr);
+          min-height: calc(100cqh - var(--#{$ua-prefix}header-offset));
 
-        #content {
-          background-color: var(--#{$ua-prefix}bo-background-color);
-        }
-
-        .logs {
-          flex-grow: 1;
-          
-          &__scroll {
-            container-type: size;
+          #ua_container {
+            flex-grow: 1;
           }
-        }
 
-        @container html-height (min-width: 0) {
-          #{$ua-id} {
-            display: grid;
-            grid-template-columns: minmax(0, 1fr);
-            min-height: calc(100cqh - var(--#{$ua-prefix}header-offset));
+          #ua_step_content {
+            height: 100%;
+          }
 
-            #ua_container {
+          .page {
+            &__content {
+              display: flex;
+              flex-direction: column;
               flex-grow: 1;
-            }
-
-            #ua_step_content {
-              height: 100%;
-            }
-
-            .page {
-              &__content {
-                display: flex;
-                flex-direction: column;
-                flex-grow: 1;
-              }
             }
           }
         }

--- a/_dev/src/scss/layouts/_logs-pages.scss
+++ b/_dev/src/scss/layouts/_logs-pages.scss
@@ -1,0 +1,58 @@
+@use "../variables" as *;
+
+// Auto size logs section to use available height
+@at-root {
+  html {
+    &:has(#{$ua-id}) {
+      // Need class use in #ua_step_content to make it work
+      &:has(.update-page) {
+        container-type: size;
+        container-name: html-height;
+
+        body {
+          background-color: var(--#{$ua-prefix}bo-background-color);
+        }
+
+        #main {
+          padding-block-end: 0;
+        }
+
+        #content {
+          background-color: var(--#{$ua-prefix}bo-background-color);
+        }
+
+        .logs {
+          flex-grow: 1;
+          
+          &__scroll {
+            container-type: size;
+          }
+        }
+
+        @container html-height (min-width: 0) {
+          #{$ua-id} {
+            display: grid;
+            grid-template-columns: minmax(0, 1fr);
+            min-height: calc(100cqh - var(--#{$ua-prefix}header-offset));
+
+            #ua_container {
+              flex-grow: 1;
+            }
+
+            #ua_step_content {
+              height: 100%;
+            }
+
+            .page {
+              &__content {
+                display: flex;
+                flex-direction: column;
+                flex-grow: 1;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/storybook/stories/components/Logs.stories.js
+++ b/storybook/stories/components/Logs.stories.js
@@ -185,20 +185,20 @@ document.addEventListener("DOMContentLoaded", () => {
 
       const targetId = this.getAttribute("href").substring(1);
       const targetElement = document.getElementById(targetId);
-      const logsScroll = document.querySelector(".logs__scroll");
+      const logsList = document.querySelector(".logs__list");
 
-      if (logsScroll && targetElement) {
+      if (logsList && targetElement) {
         const targetRect = targetElement.getBoundingClientRect();
-        const containerRect = logsScroll.getBoundingClientRect();
-        const offsetTop = targetRect.top - containerRect.top + logsScroll.scrollTop;
+        const containerRect = logsList.getBoundingClientRect();
+        const offsetTop = targetRect.top - containerRect.top + logsList.scrollTop;
 
-        logsScroll.scrollTo({
+        logsList.scrollTo({
           top: offsetTop,
           behavior: "smooth"
         });
       } else {
         console.error("Element not found:", {
-          logsScroll: logsScroll,
+          logsList: logsList,
           targetElement: targetElement
         });
       }

--- a/views/templates/components/logs.html.twig
+++ b/views/templates/components/logs.html.twig
@@ -1,13 +1,15 @@
 {% if logs %}
   <div class="logs">
-    <div class="logs__scroll">
-      <div class="logs__list">
-        {% for log in logs %}
-          <div class="logs__line logs__line--{{ log.status }}"
-            {% if log.id is defined %}id="{{ log.id }}"{% endif %}>
-            {{ log.message }}
-          </div>
-        {% endfor %}
+    <div class="logs__inner">
+      <div class="logs__scroll">
+        <div class="logs__list">
+          {% for log in logs %}
+            <div class="logs__line logs__line--{{ log.status }}"
+              {% if log.id is defined %}id="{{ log.id }}"{% endif %}>
+              {{ log.message }}
+            </div>
+          {% endfor %}
+        </div>
       </div>
 
       {% if logsSummaryWarning or logsSummaryError %}

--- a/views/templates/steps/update.html.twig
+++ b/views/templates/steps/update.html.twig
@@ -1,5 +1,7 @@
 {% extends "@ModuleAutoUpgrade/layouts/step-content.html.twig" %}
 
+{% block page_class %}update-page{% endblock %}
+
 {% block title %}
   <h2>{{ step.title }}</h2>
 {% endblock %}
@@ -131,6 +133,26 @@
       {
         status: "success",
         message: "src/Core/Domain/Product/Pack/Query/GetPackedProducts.php added to archive. 13114 files left.",
+      },
+    ],
+    logsSummaryWarning: [
+      {
+        message: "src/Core/Domain/Product/Pack/Query/GetPackedProducts.php added to archive. 13114 files left.",
+        anchor: "warning_1",
+      },
+      {
+        message: "src/Core/Domain/Product/Pack/Query/GetPackedProducts.php added to archive. 13114 files left.",
+        anchor: "warning_2",
+      },
+    ],
+    logsSummaryError: [
+      {
+        message: "src/Core/Domain/Product/Pack/Query/GetPackedProducts.php added to archive. 13114 files left.",
+        anchor: "error_1",
+      },
+      {
+        message: "src/Core/Domain/Product/Pack/Query/GetPackedProducts.php added to archive. 13114 files left.",
+        anchor: "error_2",
       },
     ],
   } %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Automatically adjust the height of the logs container on the update page to occupy all available space and display more logs at once.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | @PrestaShopCorp
| How to test?      | [NEW UI] No QA is needed at the moment
