### PR TITLE
Make redirection easier to call

### DIFF
--- a/classes/Router/Router.php
+++ b/classes/Router/Router.php
@@ -123,6 +123,6 @@ class Router
 
         $method = $route['method'];
 
-        return (new $route['controller']($this->upgradeContainer))->$method($request);
+        return (new $route['controller']($this->upgradeContainer, $request))->$method($request);
     }
 }

--- a/classes/Router/Router.php
+++ b/classes/Router/Router.php
@@ -123,6 +123,6 @@ class Router
 
         $method = $route['method'];
 
-        return (new $route['controller']($this->upgradeContainer, $request))->$method($request);
+        return (new $route['controller']($this->upgradeContainer, $request))->$method();
     }
 }

--- a/controllers/admin/self-managed/AbstractGlobalController.php
+++ b/controllers/admin/self-managed/AbstractGlobalController.php
@@ -28,10 +28,12 @@
 namespace PrestaShop\Module\AutoUpgrade\Controller;
 
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Twig\Environment;
 use Twig_Environment;
 
-class AbstractGlobalController
+abstract class AbstractGlobalController
 {
     /** @var UpgradeContainer */
     protected $upgradeContainer;
@@ -39,9 +41,22 @@ class AbstractGlobalController
     /** @var Environment|Twig_Environment */
     protected $twig;
 
-    public function __construct(UpgradeContainer $upgradeContainer)
+    /** @var Request */
+    protected $request;
+
+    public function __construct(UpgradeContainer $upgradeContainer, Request $request)
     {
         $this->upgradeContainer = $upgradeContainer;
         $this->twig = $this->upgradeContainer->getTwig();
+        $this->request = $request;
+    }
+
+    protected function redirectTo(string $destinationRoute): RedirectResponse
+    {
+        $params = [];
+        parse_str($this->request->server->get('QUERY_STRING'), $params);
+        $nextQueryParams = http_build_query(array_merge($params, ['route' => $destinationRoute]));
+
+        return new RedirectResponse($this->request->getSchemeAndHttpHost() . $this->request->getBaseUrl() . $this->request->getPathInfo() . '?' . $nextQueryParams);
     }
 }

--- a/controllers/admin/self-managed/AbstractPageController.php
+++ b/controllers/admin/self-managed/AbstractPageController.php
@@ -30,7 +30,6 @@ namespace PrestaShop\Module\AutoUpgrade\Controller;
 use PrestaShop\Module\AutoUpgrade\Twig\PageSelectors;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Request;
 
 abstract class AbstractPageController extends AbstractGlobalController
 {
@@ -87,34 +86,32 @@ abstract class AbstractPageController extends AbstractGlobalController
     }
 
     /**
-     * @param Request $request
-     *
      * @return RedirectResponse|string
      *
      * @throws \Exception
      */
-    public function index(Request $request)
+    public function index()
     {
-        if ($request->isXmlHttpRequest()) {
+        if ($this->request->isXmlHttpRequest()) {
             return new JsonResponse([
                 'hydration' => true,
                 'new_route' => $this::CURRENT_ROUTE,
                 'parent_to_update' => PageSelectors::PAGE_PARENT_ID,
                 'new_content' => $this->renderPageContent(
                     $this::CURRENT_PAGE,
-                    $this->getParams($request)
+                    $this->getParams()
                 ),
             ]);
         }
 
         return $this->renderPage(
             $this::CURRENT_PAGE,
-            $this->getParams($request)
+            $this->getParams()
         );
     }
 
     /**
      * @return array
      */
-    abstract protected function getParams(Request $request): array;
+    abstract protected function getParams(): array;
 }

--- a/controllers/admin/self-managed/HomePageController.php
+++ b/controllers/admin/self-managed/HomePageController.php
@@ -29,7 +29,6 @@ namespace PrestaShop\Module\AutoUpgrade\Controller;
 
 use PrestaShop\Module\AutoUpgrade\Router\Routes;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Request;
 
 class HomePageController extends AbstractPageController
 {
@@ -43,9 +42,9 @@ class HomePageController extends AbstractPageController
         'restore_value' => 'restore',
     ];
 
-    public function submit(Request $request): JsonResponse
+    public function submit(): JsonResponse
     {
-        $routeChoice = $request->request->get(self::FORM_FIELDS['route_choice']);
+        $routeChoice = $this->request->request->get(self::FORM_FIELDS['route_choice']);
 
         if ($routeChoice === self::FORM_OPTIONS['update_value']) {
             return new JsonResponse([
@@ -54,7 +53,7 @@ class HomePageController extends AbstractPageController
         }
 
         // if is not update is restore
-        if ($this->getParams($request)['empty_backup']) {
+        if ($this->getParams()['empty_backup']) {
             return new JsonResponse([
                 'error' => 'You can\'t acced this route because you haven\'t backup.',
             ], 401);
@@ -70,7 +69,7 @@ class HomePageController extends AbstractPageController
      *
      * @throws \Exception
      */
-    protected function getParams(Request $request): array
+    protected function getParams(): array
     {
         $backupFinder = $this->upgradeContainer->getBackupFinder();
 

--- a/controllers/admin/self-managed/UpdatePageBackupController.php
+++ b/controllers/admin/self-managed/UpdatePageBackupController.php
@@ -28,7 +28,6 @@
 namespace PrestaShop\Module\AutoUpgrade\Controller;
 
 use PrestaShop\Module\AutoUpgrade\Twig\UpdateSteps;
-use Symfony\Component\HttpFoundation\Request;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
@@ -39,15 +38,13 @@ class UpdatePageBackupController extends AbstractPageController
     const CURRENT_PAGE = 'update';
 
     /**
-     * @param Request $request
-     *
      * @return string
      *
      * @throws LoaderError
      * @throws RuntimeError
      * @throws SyntaxError
      */
-    public function step(Request $request): string
+    public function step(): string
     {
         return $this->twig->render(
             '@ModuleAutoUpgrade/steps/backup.html.twig',
@@ -60,7 +57,7 @@ class UpdatePageBackupController extends AbstractPageController
      *
      * @throws \Exception
      */
-    protected function getParams(Request $request): array
+    protected function getParams(): array
     {
         $updateSteps = new UpdateSteps($this->upgradeContainer->getTranslator());
 

--- a/controllers/admin/self-managed/UpdatePagePostUpdateController.php
+++ b/controllers/admin/self-managed/UpdatePagePostUpdateController.php
@@ -28,7 +28,6 @@
 namespace PrestaShop\Module\AutoUpgrade\Controller;
 
 use PrestaShop\Module\AutoUpgrade\Twig\UpdateSteps;
-use Symfony\Component\HttpFoundation\Request;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
@@ -39,15 +38,13 @@ class UpdatePagePostUpdateController extends AbstractPageController
     const CURRENT_PAGE = 'update';
 
     /**
-     * @param Request $request
-     *
      * @return string
      *
      * @throws LoaderError
      * @throws RuntimeError
      * @throws SyntaxError
      */
-    public function step(Request $request): string
+    public function step(): string
     {
         return $this->twig->render(
             '@ModuleAutoUpgrade/steps/post-update.html.twig',
@@ -60,7 +57,7 @@ class UpdatePagePostUpdateController extends AbstractPageController
      *
      * @throws \Exception
      */
-    protected function getParams(Request $request): array
+    protected function getParams(): array
     {
         $updateSteps = new UpdateSteps($this->upgradeContainer->getTranslator());
 

--- a/controllers/admin/self-managed/UpdatePageUpdateController.php
+++ b/controllers/admin/self-managed/UpdatePageUpdateController.php
@@ -42,9 +42,7 @@ class UpdatePageUpdateController extends AbstractPageController
 
     public function index(Request $request): RedirectResponse
     {
-        return new RedirectResponse(
-            str_replace(Routes::UPDATE_PAGE_UPDATE, Routes::UPDATE_PAGE_BACKUP, $request->getUri())
-        );
+        return $this->redirectTo(Routes::UPDATE_PAGE_BACKUP);
     }
 
     /**

--- a/controllers/admin/self-managed/UpdatePageUpdateController.php
+++ b/controllers/admin/self-managed/UpdatePageUpdateController.php
@@ -30,7 +30,6 @@ namespace PrestaShop\Module\AutoUpgrade\Controller;
 use PrestaShop\Module\AutoUpgrade\Router\Routes;
 use PrestaShop\Module\AutoUpgrade\Twig\UpdateSteps;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Request;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
@@ -40,21 +39,19 @@ class UpdatePageUpdateController extends AbstractPageController
     const CURRENT_STEP = UpdateSteps::STEP_UPDATE;
     const CURRENT_PAGE = 'update';
 
-    public function index(Request $request): RedirectResponse
+    public function index(): RedirectResponse
     {
         return $this->redirectTo(Routes::UPDATE_PAGE_BACKUP);
     }
 
     /**
-     * @param Request $request
-     *
      * @return string
      *
      * @throws LoaderError
      * @throws RuntimeError
      * @throws SyntaxError
      */
-    public function step(Request $request): string
+    public function step(): string
     {
         return $this->twig->render(
             '@ModuleAutoUpgrade/steps/update.html.twig',
@@ -67,7 +64,7 @@ class UpdatePageUpdateController extends AbstractPageController
      *
      * @throws \Exception
      */
-    protected function getParams(Request $request): array
+    protected function getParams(): array
     {
         $updateSteps = new UpdateSteps($this->upgradeContainer->getTranslator());
 

--- a/controllers/admin/self-managed/UpdatePageUpdateOptionsController.php
+++ b/controllers/admin/self-managed/UpdatePageUpdateOptionsController.php
@@ -28,7 +28,6 @@
 namespace PrestaShop\Module\AutoUpgrade\Controller;
 
 use PrestaShop\Module\AutoUpgrade\Twig\UpdateSteps;
-use Symfony\Component\HttpFoundation\Request;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
@@ -39,15 +38,13 @@ class UpdatePageUpdateOptionsController extends AbstractPageController
     const CURRENT_PAGE = 'update';
 
     /**
-     * @param Request $request
-     *
      * @return string
      *
      * @throws LoaderError
      * @throws RuntimeError
      * @throws SyntaxError
      */
-    public function step(Request $request): string
+    public function step(): string
     {
         return $this->twig->render(
             '@ModuleAutoUpgrade/steps/update-options.html.twig',
@@ -60,7 +57,7 @@ class UpdatePageUpdateOptionsController extends AbstractPageController
      *
      * @throws \Exception
      */
-    protected function getParams(Request $request): array
+    protected function getParams(): array
     {
         $updateSteps = new UpdateSteps($this->upgradeContainer->getTranslator());
 

--- a/controllers/admin/self-managed/UpdatePageVersionChoiceController.php
+++ b/controllers/admin/self-managed/UpdatePageVersionChoiceController.php
@@ -31,7 +31,6 @@ use PrestaShop\Module\AutoUpgrade\Router\Routes;
 use PrestaShop\Module\AutoUpgrade\Twig\UpdateSteps;
 use PrestaShop\Module\AutoUpgrade\VersionUtils;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Request;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
@@ -52,19 +51,17 @@ class UpdatePageVersionChoiceController extends AbstractPageController
     ];
 
     /**
-     * @param Request $request
-     *
      * @return string
      *
      * @throws LoaderError
      * @throws RuntimeError
      * @throws SyntaxError
      */
-    public function step(Request $request): string
+    public function step(): string
     {
         return $this->twig->render(
             '@ModuleAutoUpgrade/steps/version-choice.html.twig',
-            $this->getParams($request)
+            $this->getParams()
         );
     }
 
@@ -73,7 +70,7 @@ class UpdatePageVersionChoiceController extends AbstractPageController
      *
      * @throws \Exception
      */
-    protected function getParams(Request $request): array
+    protected function getParams(): array
     {
         $updateSteps = new UpdateSteps($this->upgradeContainer->getTranslator());
         $isLastVersion = $this->upgradeContainer->getUpgrader()->isLastVersion();
@@ -106,7 +103,7 @@ class UpdatePageVersionChoiceController extends AbstractPageController
             [
                 'up_to_date' => $isLastVersion,
                 'no_local_archive' => !$this->upgradeContainer->getLocalArchiveRepository()->hasLocalArchive(),
-                'assets_base_path' => $this->upgradeContainer->getAssetsEnvironment()->getAssetsBaseUrl($request),
+                'assets_base_path' => $this->upgradeContainer->getAssetsEnvironment()->getAssetsBaseUrl($this->request),
                 'current_prestashop_version' => $this->getPsVersion(),
                 'current_php_version' => VersionUtils::getHumanReadableVersionOf(PHP_VERSION_ID),
                 'local_archives' => [

--- a/tests/unit/Controller/AbstractGlobalControllerTest.php
+++ b/tests/unit/Controller/AbstractGlobalControllerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\Module\AutoUpgrade\Router\Router;
+use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
+use Symfony\Component\HttpFoundation\Request;
+
+class AbstractGlobalControllerTest extends TestCase
+{
+    public static function setUpBeforeClass()
+    {
+        require_once __DIR__ . '/DummyController.php';
+    }
+
+    /**
+     * @dataProvider redirectionTestsProvider
+     */
+    public function testRedirectTo($destination, $currentUrl, $expectedUrl)
+    {
+        $upgradeContainer = $this->getMockBuilder(UpgradeContainer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $server = [
+            'HTTP_HOST' => 'localhost',
+            'SERVER_PORT' => '80',
+            'QUERY_STRING' => $currentUrl,
+            'PHP_SELF' => '/hello-world/admin-wololo',
+            'SCRIPT_FILENAME' => '/yo/doge/index.php',
+            'REQUEST_URI' => 'hello-world/admin-wololo/index.php',
+        ];
+        $request = new Request([], [], [], [], [], $server);
+        $controller = new DummyController($upgradeContainer, $request);
+
+        $this->assertSame($expectedUrl, $controller->routeThatRedirectsTo($destination)->getTargetUrl());
+    }
+
+    public static function redirectionTestsProvider()
+    {
+        return [
+            [Router::HOME_PAGE, 'route=update-page-update', 'http://localhost/hello-world/admin-wololo/index.php?route=home-page'],
+            [Router::HOME_PAGE, '', 'http://localhost/hello-world/admin-wololo/index.php?route=home-page'],
+            [Router::HOME_PAGE, 'token=oh-no&route=oh-yes', 'http://localhost/hello-world/admin-wololo/index.php?token=oh-no&route=home-page'],
+        ];
+    }
+}

--- a/tests/unit/Controller/AbstractGlobalControllerTest.php
+++ b/tests/unit/Controller/AbstractGlobalControllerTest.php
@@ -12,6 +12,15 @@ class AbstractGlobalControllerTest extends TestCase
         require_once __DIR__ . '/DummyController.php';
     }
 
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (PHP_VERSION_ID >= 80000) {
+            $this->markTestSkipped('An issue with this version of PHPUnit and PHP 8+ prevents this test to run.');
+        }
+    }
+
     /**
      * @dataProvider redirectionTestsProvider
      */

--- a/tests/unit/Controller/DummyController.php
+++ b/tests/unit/Controller/DummyController.php
@@ -1,0 +1,11 @@
+<?php
+
+use PrestaShop\Module\AutoUpgrade\Controller\AbstractGlobalController;
+
+class DummyController extends AbstractGlobalController
+{
+    public function routeThatRedirectsTo($route)
+    {
+        return $this->redirectTo($route);
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | On the new UI, we need to redirect the user to another page in some cases. We had a first solution where we must provide the source in order to have the proper destination. We now have a method in the root controller allowing us to redirect to an route.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Reach the upgrade page directly, it should redirect to the backup page.