### PR TITLE
Bring back twig in project dependencies

### DIFF
--- a/ajax-upgradetab.php
+++ b/ajax-upgradetab.php
@@ -37,8 +37,6 @@ use Symfony\Component\HttpFoundation\Request;
  * Calling it from the module/autoupgrade folder will have unwanted consequences on the upgrade and your shop.
  */
 require_once realpath(dirname(__FILE__) . '/../../modules/autoupgrade') . '/ajax-upgradetabconfig.php';
-// TODO: We need to remove this in the future and add Twig into the module dependencies.
-require_once realpath(dirname(__FILE__) . '/../../vendor/autoload.php');
 $container = autoupgrade_init_container(dirname(__FILE__));
 
 (new \PrestaShop\Module\AutoUpgrade\ErrorHandler($container->getLogger()))->enable();

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "segmentio/analytics-php": "^1.8",
     "symfony/dotenv": "^4.4",
     "symfony/http-foundation": "^4.4",
-    "symfony/console": "^3.4"
+    "symfony/console": "^3.4",
+    "twig/twig": "^2.16"
   },
   "require-dev": {
     "phpunit/phpunit": "^5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5e287e34b825fd6ec168fa6cb6a7b7af",
+    "content-hash": "c4418b969136594f9333075587c615dd",
     "packages": [
         {
             "name": "doctrine/collections",
@@ -1084,6 +1084,86 @@
                 }
             ],
             "time": "2024-05-31T15:07:36+00:00"
+        },
+        {
+            "name": "twig/twig",
+            "version": "v2.16.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twigphp/Twig.git",
+                "reference": "19185947ec75d433a3ac650af32fc05649b95ee1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/19185947ec75d433a3ac650af32fc05649b95ee1",
+                "reference": "19185947ec75d433a3ac650af32fc05649b95ee1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-mbstring": "^1.3",
+                "symfony/polyfill-php72": "^1.8"
+            },
+            "require-dev": {
+                "psr/container": "^1.0",
+                "symfony/phpunit-bridge": "^5.4.9|^6.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.16-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Twig_": "lib/"
+                },
+                "psr-4": {
+                    "Twig\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Twig Team",
+                    "role": "Contributors"
+                },
+                {
+                    "name": "Armin Ronacher",
+                    "email": "armin.ronacher@active-4.com",
+                    "role": "Project Founder"
+                }
+            ],
+            "description": "Twig, the flexible, fast, and secure template language for PHP",
+            "homepage": "https://twig.symfony.com",
+            "keywords": [
+                "templating"
+            ],
+            "support": {
+                "issues": "https://github.com/twigphp/Twig/issues",
+                "source": "https://github.com/twigphp/Twig/tree/v2.16.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/twig/twig",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T17:53:56+00:00"
         }
     ],
     "packages-dev": [

--- a/tests/phpstan/forceAutoload.php
+++ b/tests/phpstan/forceAutoload.php
@@ -11,3 +11,19 @@
 use Symfony\Component\Console\Output\Output;
 
 class_exists(Output::class);
+
+// We load Twig classes to avoid conflicts with old versions of PrestaShop providing old versions of the library.
+// Avoid Reflection error: Circular reference to class "Twig_Environment"
+require_once __DIR__ . '/../../vendor/twig/twig/src/Environment.php';
+
+// Avoid Reflection error: Circular reference to class "Twig\Error\Error"
+require_once __DIR__ . '/../../vendor/twig/twig/src/Error/Error.php';
+
+// Avoid Reflection error: Circular reference to class "Twig_ExtensionInterface"
+require_once __DIR__ . '/../../vendor/twig/twig/src/Extension/ExtensionInterface.php';
+require_once __DIR__ . '/../../vendor/twig/twig/src/Extension/AbstractExtension.php';
+
+// Avoid Reflection error: Circular reference to class "Twig_LoaderInterface"
+require_once __DIR__ . '/../../vendor/twig/twig/src/Loader/LoaderInterface.php';
+require_once __DIR__ . '/../../vendor/twig/twig/src/Loader/ExistsLoaderInterface.php';
+require_once __DIR__ . '/../../vendor/twig/twig/src/Loader/SourceContextLoaderInterface.php';

--- a/tests/phpstan/phpstan-8.0.0.neon
+++ b/tests/phpstan/phpstan-8.0.0.neon
@@ -11,7 +11,6 @@ parameters:
 		- '#Method PrestaShop\\Module\\AutoUpgrade\\UpgradeTools\\SymfonyAdapter::initKernel\(\) has invalid return type AdminKernel.#'
 		- '#Instantiated class AdminKernel not found\.#'
 		- "#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(int\\)\\: mixed\\)\\|null, 'add_quotes' given\\.$#"
-		- '#Call to method render\(\) on an unknown class Twig_Environment#'
 		-
 			identifier: booleanAnd.rightAlwaysTrue
 			path: ./../../classes/UpgradeSelfCheck.php

--- a/tests/phpstan/phpstan-latest.neon
+++ b/tests/phpstan/phpstan-latest.neon
@@ -11,7 +11,6 @@ parameters:
 		- '#Method PrestaShop\\Module\\AutoUpgrade\\UpgradeTools\\SymfonyAdapter::initKernel\(\) has invalid return type AdminKernel.#'
 		- '#Instantiated class AdminKernel not found\.#'
 		- "#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(int\\)\\: mixed\\)\\|null, 'add_quotes' given\\.$#"
-		- '#Call to method render\(\) on an unknown class Twig_Environment#'
 		-
 			identifier: booleanAnd.rightAlwaysTrue
 			path: ./../../classes/UpgradeSelfCheck.php


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | In order to fix an issue happening while upgrading to PS 9 on the Upgrade Files step, we must remove a require of the Core autoloader that was temporarily put in the project. Instead, we require Twig in our dependencies as we will highly rely on it with the new UI.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | /
| How to test?      | New UI still works, and upgrade to PrestaShop 9 succeeds again.

![Capture d’écran du 2024-10-01 18-47-37](https://github.com/user-attachments/assets/695b44b5-2bdb-4bf8-9c5b-2d1348fd8f9c)

