### PR TITLE
Remove obsolete login hooks

### DIFF
--- a/upgrade/sql/9.0.0.sql
+++ b/upgrade/sql/9.0.0.sql
@@ -51,9 +51,22 @@ ALTER TABLE `PREFIX_orders` ADD INDEX `invoice_date` (`invoice_date`);
 DELETE FROM `PREFIX_configuration` WHERE `name` = 'PS_ALLOW_MOBILE_DEVICE';
 DELETE FROM `PREFIX_hook` WHERE `name` = 'actionBeforeEnableMobileModule';
 DELETE FROM `PREFIX_hook` WHERE `name` = 'actionBeforeDisableMobileModule';
+UPDATE `PREFIX_module_shop` SET `enable_device` = '7';
+
+/* Remove obsolete hooks and their references */
+DELETE FROM `PREFIX_hook` WHERE `name` IN (
+   'actionBeforeEnableMobileModule',
+   'actionBeforeDisableMobileModule',
+   'actionAdminLoginControllerBefore',
+   'actionAdminLoginControllerLoginBefore',
+   'actionAdminLoginControllerLoginAfter',
+   'actionAdminLoginControllerForgotBefore',
+   'actionAdminLoginControllerForgotAfter',
+   'actionAdminLoginControllerResetBefore',
+   'actionAdminLoginControllerResetAfter'
+);
 DELETE FROM `PREFIX_hook_module` WHERE `id_hook` NOT IN (SELECT id_hook FROM `PREFIX_hook`);
 DELETE FROM `PREFIX_hook_module_exceptions` WHERE `id_hook` NOT IN (SELECT id_hook FROM `PREFIX_hook`);
-UPDATE `PREFIX_module_shop` SET `enable_device` = '7';
 
 /* Allow cover configuration */
 /* https://github.com/PrestaShop/PrestaShop/pull/33363 */


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Remove obsolete login hooks
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Sponsor company   | ~
| How to test?      | After an upgrade check in the ps_hook table that the hooks related to login and added in this PR are correctly removed
