### PR TITLE
Fix: module migration method on fly

### DIFF
--- a/classes/Task/Update/UpdateModules.php
+++ b/classes/Task/Update/UpdateModules.php
@@ -69,7 +69,7 @@ class UpdateModules extends AbstractTask
         $moduleSourceList = new ModuleSourceAggregate($this->container->getModuleSourceProviders());
         $moduleDownloader = new ModuleDownloader($this->translator, $this->logger, $this->container->getProperty(UpgradeContainer::TMP_PATH));
         $moduleUnzipper = new ModuleUnzipper($this->translator, $this->container->getZipAction(), $modulesPath);
-        $moduleMigration = new ModuleMigration($this->translator, $this->logger);
+        $moduleMigration = new ModuleMigration($this->translator, $this->logger, $this->container->getProperty(UpgradeContainer::TMP_PATH));
 
         if ($listModules->getRemainingTotal()) {
             $moduleInfos = $listModules->getNext();

--- a/classes/UpgradeTools/Module/ModuleMigration.php
+++ b/classes/UpgradeTools/Module/ModuleMigration.php
@@ -143,7 +143,7 @@ class ModuleMigration
      *
      * @throws UpgradeException
      */
-    private function loadAndCallFunction(string $file, string $methodName,\Module $moduleInstance): void
+    private function loadAndCallFunction(string $file, string $methodName, \Module $moduleInstance): void
     {
         include_once $file;
 

--- a/classes/UpgradeTools/Module/ModuleMigration.php
+++ b/classes/UpgradeTools/Module/ModuleMigration.php
@@ -155,14 +155,14 @@ class ModuleMigration
 
         $fileContent = str_replace($methodName, $uniqueMethodName, $fileContent);
 
-        return (function () use ($fileContent, $methodName, $moduleInstance) {
+        return (function () use ($fileContent, $uniqueMethodName, $moduleInstance) {
             eval($fileContent);
 
-            if (!function_exists($methodName)) {
+            if (!function_exists($uniqueMethodName)) {
                 throw new UpgradeException(sprintf('[WARNING] Method %s does not exist in evaluated file.', $methodName));
             }
 
-            return call_user_func($methodName, $moduleInstance);
+            return call_user_func($uniqueMethodName, $moduleInstance);
         })();
     }
 }

--- a/classes/UpgradeTools/Module/ModuleMigration.php
+++ b/classes/UpgradeTools/Module/ModuleMigration.php
@@ -154,6 +154,7 @@ class ModuleMigration
         }
 
         $fileContent = str_replace($methodName, $uniqueMethodName, $fileContent);
+        $fileContent = str_replace(['<?php', '?>'], '', $fileContent);
 
         return (function () use ($fileContent, $uniqueMethodName, $moduleMigrationContext) {
             eval($fileContent);

--- a/classes/UpgradeTools/Module/ModuleMigration.php
+++ b/classes/UpgradeTools/Module/ModuleMigration.php
@@ -159,7 +159,7 @@ class ModuleMigration
             eval($fileContent);
 
             if (!function_exists($uniqueMethodName)) {
-                throw new UpgradeException(sprintf('[WARNING] Method %s does not exist in evaluated file.', $methodName));
+                throw new UpgradeException(sprintf('[WARNING] Method %s does not exist in evaluated file.', $uniqueMethodName));
             }
 
             return call_user_func($uniqueMethodName, $moduleInstance);

--- a/classes/UpgradeTools/Module/ModuleMigration.php
+++ b/classes/UpgradeTools/Module/ModuleMigration.php
@@ -145,13 +145,17 @@ class ModuleMigration
      */
     private function loadAndCallFunction(string $filePath, string $methodName, \Module $moduleInstance): bool
     {
+        $uniqueMethodName = $moduleInstance->getModuleName() . '_' . $methodName;
+
         $fileContent = file_get_contents($filePath);
 
         if ($fileContent === false) {
             throw new UpgradeException(sprintf('[WARNING] Could not read file %s.', $filePath));
         }
 
-        return (function() use ($fileContent, $methodName, $moduleInstance) {
+        $fileContent = str_replace($methodName, $uniqueMethodName, $fileContent);
+
+        return (function () use ($fileContent, $methodName, $moduleInstance) {
             eval($fileContent);
 
             if (!function_exists($methodName)) {

--- a/classes/UpgradeTools/Module/ModuleMigration.php
+++ b/classes/UpgradeTools/Module/ModuleMigration.php
@@ -145,8 +145,8 @@ class ModuleMigration
      */
     private function loadAndCallFunction(string $file, string $methodName, \Module $moduleInstance): void
     {
-        $migrationFunction = (function() use ($file, $methodName) {
-            include $file;
+        $migrationFunction = (function () use ($file, $methodName) {
+            include_once $file;
 
             if (function_exists($methodName)) {
                 return $methodName;

--- a/tests/unit/UpgradeTools/Module/ModuleMigrationTest.php
+++ b/tests/unit/UpgradeTools/Module/ModuleMigrationTest.php
@@ -42,6 +42,14 @@ class ModuleMigrationTest extends TestCase
      */
     private $moduleMigration;
 
+    private static $fixtureFolder;
+
+    public static function setUpBeforeClass()
+    {
+        self::$fixtureFolder = sys_get_temp_dir() . '/fakeMigrationFilesDestination';
+        @mkdir(self::$fixtureFolder);
+    }
+
     protected function setUp(): void
     {
         if (!defined('_PS_MODULE_DIR_')) {
@@ -58,7 +66,7 @@ class ModuleMigrationTest extends TestCase
             });
 
         $this->logger = $this->createMock(Logger::class);
-        $this->moduleMigration = new ModuleMigration($translator, $this->logger);
+        $this->moduleMigration = new ModuleMigration($translator, $this->logger, self::$fixtureFolder);
     }
 
     public function testNeedMigrationWithSameVersion()
@@ -179,22 +187,6 @@ class ModuleMigrationTest extends TestCase
         $this->moduleMigration->runMigration($moduleMigrationContext);
     }
 
-    public function testRunMigrationWithSameInstanceThrowDuplicateMethod()
-    {
-        $mymodule = new \fixtures\mymodule\mymodule();
-        $mymodule->version = '1.1.1';
-        $dbVersion = '0.0.9';
-
-        $moduleMigrationContext = new ModuleMigrationContext($mymodule, $dbVersion);
-
-        $this->moduleMigration->needMigration($moduleMigrationContext);
-
-        $this->expectException(\PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException::class);
-        $this->expectExceptionMessage('[WARNING] Method upgrade_module_1 already exists. Migration for module mymodule aborted, you can try again later on the module manager. Module mymodule disabled.');
-
-        $this->moduleMigration->runMigration($moduleMigrationContext);
-    }
-
     public function testRunMigrationWithBadUpgradeMethodName()
     {
         $mymodule = new \fixtures\mymodule\mymodule();
@@ -206,7 +198,7 @@ class ModuleMigrationTest extends TestCase
         $this->moduleMigration->needMigration($moduleMigrationContext);
 
         $this->expectException(\PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException::class);
-        $this->expectExceptionMessage('[WARNING] Method upgrade_module_1_2_0 does not exist. Module mymodule disabled.');
+        $this->expectExceptionMessage('[WARNING] Method mymodule_upgrade_module_1_2_0 does not exist. Module mymodule disabled.');
 
         $this->moduleMigration->runMigration($moduleMigrationContext);
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Currently we can't run 2 migration methods with the same name for multiple different modules. This PR fixes this issue by creating a class on the fly that uses the requested migration method.
| Type?             | bug fix / improvement
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/36958
| Sponsor company   | @PrestaShopCorp
| How to test?      | Try update !
