### PR TITLE
Rework UpdateFiles warmup

### DIFF
--- a/classes/Analytics.php
+++ b/classes/Analytics.php
@@ -119,8 +119,8 @@ class Analytics
                 break;
             case self::WITH_UPDATE_PROPERTIES:
                 $additionalProperties = [
-                    'from_ps_version' => $this->state->getOriginVersion(),
-                    'to_ps_version' => $this->state->getInstallVersion(),
+                    'from_ps_version' => $this->state->getCurrentVersion(),
+                    'to_ps_version' => $this->state->getDestinationVersion(),
                     'upgrade_channel' => $this->upgradeConfiguration->getChannel(),
                     'disable_non_native_modules' => $this->upgradeConfiguration->shouldDeactivateCustomModules(),
                     'switch_to_default_theme' => $this->upgradeConfiguration->shouldSwitchToDefaultTheme(),

--- a/classes/Commands/AbstractCommand.php
+++ b/classes/Commands/AbstractCommand.php
@@ -28,10 +28,10 @@
 namespace PrestaShop\Module\AutoUpgrade\Commands;
 
 use Exception;
+use InvalidArgumentException;
 use PrestaShop\Module\AutoUpgrade\ErrorHandler;
 use PrestaShop\Module\AutoUpgrade\Log\CliLogger;
 use PrestaShop\Module\AutoUpgrade\Log\Logger;
-use PrestaShop\Module\AutoUpgrade\Task\ExitCode;
 use PrestaShop\Module\AutoUpgrade\Task\Miscellaneous\UpdateConfig;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 use Symfony\Component\Console\Command\Command;
@@ -94,17 +94,13 @@ abstract class AbstractCommand extends Command
             $this->logger->debug('Loading configuration from ' . $configPath);
             $configFile = file_get_contents($configPath);
             if (!$configFile) {
-                $this->logger->error('Configuration file not found a location ' . $configPath);
-
-                return ExitCode::FAIL;
+                throw new InvalidArgumentException('Configuration file not found a location ' . $configPath);
             }
 
             $inputData = json_decode($configFile, true);
 
             if (!$inputData) {
-                $this->logger->error('An error occurred during the json decode process, please check the content and syntax of the file content');
-
-                return ExitCode::FAIL;
+                throw new InvalidArgumentException('An error occurred during the json decode process, please check the content and syntax of the file content');
             }
 
             $this->logger->debug('Configuration file content: ' . json_encode($inputData));

--- a/classes/Commands/CheckRequirementsCommand.php
+++ b/classes/Commands/CheckRequirementsCommand.php
@@ -81,7 +81,7 @@ class CheckRequirementsCommand extends AbstractCommand
         $phpVersionResolverService = new PhpVersionResolverService(
             $distributionApiService,
             $this->upgradeContainer->getFileLoader(),
-            $this->upgradeContainer->getState()->getOriginVersion()
+            $this->upgradeContainer->getState()->getCurrentVersion()
         );
 
         $this->upgradeSelfCheck = new UpgradeSelfCheck(
@@ -93,7 +93,7 @@ class CheckRequirementsCommand extends AbstractCommand
             _PS_ROOT_DIR_,
             _PS_ADMIN_DIR_,
             $moduleConfigPath,
-            $this->upgradeContainer->getState()->getOriginVersion()
+            $this->upgradeContainer->getState()->getCurrentVersion()
         );
 
         $output->writeln('Result of prerequisite checks:');

--- a/classes/Parameters/UpgradeFileNames.php
+++ b/classes/Parameters/UpgradeFileNames.php
@@ -76,15 +76,6 @@ class UpgradeFileNames
     const MODULES_TO_UPGRADE_LIST = 'modulesToUpgrade.list';
 
     /**
-     * during upgradeFiles process,
-     * this files contains the list of files left to upgrade in a serialized array.
-     * (this file is deleted in init() method if you reload the page).
-     *
-     * @var string
-     */
-    const FILES_DIFF_LIST = 'filesDiff.list';
-
-    /**
      * during backupFiles process,
      * this files contains the list of files left to save in a serialized array.
      * (this file is deleted in init() method if you reload the page).
@@ -166,7 +157,6 @@ class UpgradeFileNames
     public static $tmp_files = [
         'QUERIES_TO_UPGRADE_LIST', // used ?
         'FILES_TO_UPGRADE_LIST',
-        'FILES_DIFF_LIST',
         'FILES_TO_BACKUP_LIST',
         'DB_TABLES_TO_BACKUP_LIST',
         'QUERIES_TO_RESTORE_LIST',

--- a/classes/Task/AbstractTask.php
+++ b/classes/Task/AbstractTask.php
@@ -32,6 +32,7 @@ use PrestaShop\Module\AutoUpgrade\AjaxResponse;
 use PrestaShop\Module\AutoUpgrade\Analytics;
 use PrestaShop\Module\AutoUpgrade\Log\Logger;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
+use PrestaShop\Module\AutoUpgrade\Upgrader;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator;
 
 abstract class AbstractTask
@@ -184,6 +185,16 @@ abstract class AbstractTask
     public function init(): void
     {
         $this->container->initPrestaShopCore();
+
+        $isUpdateTask = self::TASK_TYPE === TaskType::TASK_TYPE_UPDATE;
+
+        if ($this->container->getUpgrader()->getChannel() === Upgrader::CHANNEL_LOCAL && $isUpdateTask) {
+            $archiveXml = $this->container->getUpgradeConfiguration()->getLocalChannelXml();
+            $this->container->getFileLoader()->addXmlMd5File($this->container->getUpgrader()->getDestinationVersion(), $this->container->getProperty(UpgradeContainer::DOWNLOAD_PATH) . DIRECTORY_SEPARATOR . $archiveXml);
+        }
+
+        $this->container->getState()->setInstallVersion($this->container->getUpgrader()->getDestinationVersion());
+        $this->container->getState()->setOriginVersion($this->container->getProperty(UpgradeContainer::PS_VERSION));
     }
 
     abstract public function run(): int;

--- a/classes/Task/Miscellaneous/CompareReleases.php
+++ b/classes/Task/Miscellaneous/CompareReleases.php
@@ -28,7 +28,6 @@
 namespace PrestaShop\Module\AutoUpgrade\Task\Miscellaneous;
 
 use Exception;
-use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeFileNames;
 use PrestaShop\Module\AutoUpgrade\Task\AbstractTask;
 use PrestaShop\Module\AutoUpgrade\Task\ExitCode;
 use PrestaShop\Module\AutoUpgrade\Task\TaskName;
@@ -36,6 +35,8 @@ use PrestaShop\Module\AutoUpgrade\Task\TaskName;
 /**
  * This class gets the list of all modified and deleted files between current version
  * and target version (according to channel configuration).
+ *
+ * TODO Task to remove after removing the old UI
  */
 class CompareReleases extends AbstractTask
 {
@@ -57,7 +58,6 @@ class CompareReleases extends AbstractTask
             $this->nextParams['status'] = 'error';
             $this->nextParams['msg'] = sprintf('Unable to generate diff file list between %1$s and %2$s.', _PS_VERSION_, $version);
         } else {
-            $this->container->getFileConfigurationStorage()->save($diffFileList, UpgradeFileNames::FILES_DIFF_LIST);
             $this->nextParams['msg'] = $this->translator->trans(
                 '%modifiedfiles% files will be modified, %deletedfiles% files will be deleted (if they are found).',
                 [

--- a/classes/Task/Miscellaneous/UpdateConfig.php
+++ b/classes/Task/Miscellaneous/UpdateConfig.php
@@ -109,9 +109,6 @@ class UpdateConfig extends AbstractTask
             return ExitCode::FAIL;
         }
 
-        $this->container->getState()->setInstallVersion($this->container->getUpgrader()->getDestinationVersion());
-        $this->container->getState()->setOriginVersion($this->container->getProperty(UpgradeContainer::PS_VERSION));
-
         return ExitCode::SUCCESS;
     }
 

--- a/classes/Task/Miscellaneous/UpdateConfig.php
+++ b/classes/Task/Miscellaneous/UpdateConfig.php
@@ -172,4 +172,9 @@ class UpdateConfig extends AbstractTask
 
         return (new UpgradeConfigurationStorage($this->container->getProperty(UpgradeContainer::WORKSPACE_PATH) . DIRECTORY_SEPARATOR))->save($classConfig, UpgradeFileNames::CONFIG_FILENAME);
     }
+
+    public function init(): void
+    {
+        $this->container->initPrestaShopCore();
+    }
 }

--- a/classes/Task/Runner/AllBackupTasks.php
+++ b/classes/Task/Runner/AllBackupTasks.php
@@ -29,7 +29,6 @@ namespace PrestaShop\Module\AutoUpgrade\Task\Runner;
 
 use Exception;
 use PrestaShop\Module\AutoUpgrade\Task\TaskName;
-use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 
 /**
  * Execute the whole upgrade process in a single request.
@@ -52,7 +51,6 @@ class AllBackupTasks extends ChainedTasks
     {
         if ($this->step === self::initialTask) {
             parent::init();
-            $this->container->getState()->initDefault($this->container->getProperty(UpgradeContainer::PS_VERSION));
         }
     }
 

--- a/classes/Task/Runner/AllUpdateTasks.php
+++ b/classes/Task/Runner/AllUpdateTasks.php
@@ -30,7 +30,6 @@ namespace PrestaShop\Module\AutoUpgrade\Task\Runner;
 use Exception;
 use PrestaShop\Module\AutoUpgrade\AjaxResponse;
 use PrestaShop\Module\AutoUpgrade\Task\TaskName;
-use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 use UnexpectedValueException;
 
 /**
@@ -123,7 +122,6 @@ class AllUpdateTasks extends ChainedTasks
     {
         if ($this->step === self::initialTask) {
             parent::init();
-            $this->container->getState()->initDefault($this->container->getProperty(UpgradeContainer::PS_VERSION));
         }
     }
 }

--- a/classes/Task/Runner/SingleTask.php
+++ b/classes/Task/Runner/SingleTask.php
@@ -39,6 +39,10 @@ class SingleTask extends ChainedTasks
         if (!empty($options['action'])) {
             $this->step = $options['action'];
         }
+
+        if (!empty($options['data'])) {
+            $this->container->getState()->importFromEncodedData($options['data']);
+        }
     }
 
     protected function canContinue(): bool

--- a/classes/Task/Update/UpdateComplete.php
+++ b/classes/Task/Update/UpdateComplete.php
@@ -53,7 +53,7 @@ class UpdateComplete extends AbstractTask
             $this->container->getCompletionCalculator()->getBasePercentageOfTask(self::class)
         );
 
-        $destinationVersion = $this->container->getState()->getInstallVersion();
+        $destinationVersion = $this->container->getState()->getDestinationVersion();
 
         $this->logger->info($this->container->getState()->getWarningExists() ?
             $this->translator->trans('Shop updated to %s, but some warnings have been found.', [$destinationVersion]) :

--- a/classes/Task/Update/UpdateFiles.php
+++ b/classes/Task/Update/UpdateFiles.php
@@ -224,13 +224,14 @@ class UpdateFiles extends AbstractTask
             rename($newReleasePath . DIRECTORY_SEPARATOR . 'install-dev', $newReleasePath . DIRECTORY_SEPARATOR . 'install');
         }
 
-        $destinationVersion = $this->container->getState()->getInstallVersion();
-        $originVersion = $this->container->getState()->getOriginVersion();
+        $destinationVersion = $this->container->getState()->getDestinationVersion();
+        $originVersion = $this->container->getState()->getCurrentVersion();
         $this->logger->debug(sprintf('Generate diff file list between %s and %s.', $originVersion, $destinationVersion));
         $diffFileList = $this->container->getChecksumCompare()->getFilesDiffBetweenVersions($originVersion, $destinationVersion);
         if (!is_array($diffFileList)) {
             $this->logger->error($this->translator->trans('Unable to generate diff file list between %s and %s.', [$originVersion, $destinationVersion]));
             $this->next = TaskName::TASK_ERROR;
+            $this->setErrorFlag();
 
             return ExitCode::FAIL;
         }
@@ -281,6 +282,6 @@ class UpdateFiles extends AbstractTask
 
     public function init(): void
     {
-        // Do nothing. Overrides parent init for avoiding core to be loaded here.
+        $this->setupEnvironment();
     }
 }

--- a/classes/Task/Update/UpdateFiles.php
+++ b/classes/Task/Update/UpdateFiles.php
@@ -224,30 +224,31 @@ class UpdateFiles extends AbstractTask
             rename($newReleasePath . DIRECTORY_SEPARATOR . 'install-dev', $newReleasePath . DIRECTORY_SEPARATOR . 'install');
         }
 
-        // Now, we will get the list of changed and removed files between the versions. This was generated previously by
-        // CompareReleases task.
-        $filepath_list_diff = $this->container->getProperty(UpgradeContainer::WORKSPACE_PATH) . DIRECTORY_SEPARATOR . UpgradeFileNames::FILES_DIFF_LIST;
-        $list_files_diff = [];
+        $destinationVersion = $this->container->getState()->getInstallVersion();
+        $originVersion = $this->container->getState()->getOriginVersion();
+        $this->logger->debug(sprintf('Generate diff file list between %s and %s.', $originVersion, $destinationVersion));
+        $diffFileList = $this->container->getChecksumCompare()->getFilesDiffBetweenVersions($originVersion, $destinationVersion);
+        if (!is_array($diffFileList)) {
+            $this->logger->error($this->translator->trans('Unable to generate diff file list between %s and %s.', [$originVersion, $destinationVersion]));
+            $this->next = TaskName::TASK_ERROR;
 
-        // We check if that file exists first and load it
-        if (file_exists($filepath_list_diff)) {
-            $list_files_diff = $this->container->getFileConfigurationStorage()->load(UpgradeFileNames::FILES_DIFF_LIST);
-            // $list_files_diff now contains an array with a list of changed and deleted files.
-            // We only keep list of files to delete. The modified files will be listed in list_files_to_upgrade below.
-            $list_files_diff = $list_files_diff['deleted'];
+            return ExitCode::FAIL;
+        }
+        // $diffFileList now contains an array with a list of changed and deleted files.
+        // We only keep list of files to delete. The modified files will be listed in list_files_to_upgrade below.
+        $diffFileList = $diffFileList['deleted'];
 
-            // Admin folder name in this deleted files list is standard /admin/.
-            // We will need to change it to our own admin folder name.
-            $admin_dir = trim(str_replace($this->container->getProperty(UpgradeContainer::PS_ROOT_PATH), '', $this->container->getProperty(UpgradeContainer::PS_ADMIN_PATH)), DIRECTORY_SEPARATOR);
-            foreach ($list_files_diff as $k => $path) {
-                if (preg_match('#autoupgrade#', $path)) {
-                    unset($list_files_diff[$k]);
-                } elseif (substr($path, 0, 6) === '/admin') {
-                    // Please make sure that the condition to check if the string starts with /admin stays here, because it was replacing
-                    // admin even in the middle of a path, not deleting some files as a result.
-                    // Also, do not use DIRECTORY_SEPARATOR, keep forward slash, because the path come from the XML standardized.
-                    $list_files_diff[$k] = '/' . $admin_dir . substr($path, 6);
-                }
+        // Admin folder name in this deleted files list is standard /admin/.
+        // We will need to change it to our own admin folder name.
+        $admin_dir = trim(str_replace($this->container->getProperty(UpgradeContainer::PS_ROOT_PATH), '', $this->container->getProperty(UpgradeContainer::PS_ADMIN_PATH)), DIRECTORY_SEPARATOR);
+        foreach ($diffFileList as $k => $path) {
+            if (preg_match('#autoupgrade#', $path)) {
+                unset($diffFileList[$k]);
+            } elseif (substr($path, 0, 6) === '/admin') {
+                // Please make sure that the condition to check if the string starts with /admin stays here, because it was replacing
+                // admin even in the middle of a path, not deleting some files as a result.
+                // Also, do not use DIRECTORY_SEPARATOR, keep forward slash, because the path come from the XML standardized.
+                $diffFileList[$k] = '/' . $admin_dir . substr($path, 6);
             }
         }
 
@@ -257,7 +258,7 @@ class UpdateFiles extends AbstractTask
         );
 
         // Add our previously created list of deleted files
-        $list_files_to_upgrade = array_reverse(array_merge($list_files_diff, $list_files_to_upgrade));
+        $list_files_to_upgrade = array_reverse(array_merge($diffFileList, $list_files_to_upgrade));
 
         $total_files_to_upgrade = count($list_files_to_upgrade);
         $this->container->getFileConfigurationStorage()->save(

--- a/classes/Task/Update/UpdateInitialization.php
+++ b/classes/Task/Update/UpdateInitialization.php
@@ -54,7 +54,6 @@ class UpdateInitialization extends AbstractTask
         );
 
         $upgrader = $this->container->getUpgrader();
-
         if ($upgrader->isLastVersion()) {
             $this->next = TaskName::TASK_COMPLETE;
             $this->logger->info($this->translator->trans('Your shop is currently running the latest compatible version. No updates are needed at this time.'));
@@ -62,7 +61,7 @@ class UpdateInitialization extends AbstractTask
             return ExitCode::SUCCESS;
         }
 
-        $this->logger->info($this->translator->trans('Destination version: %s', [$upgrader->getDestinationVersion()]));
+        $this->logger->info($this->translator->trans('Destination version: %s', [$this->container->getState()->getDestinationVersion()]));
 
         switch ($upgrader->getChannel()) {
             case Upgrader::CHANNEL_LOCAL:

--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -453,14 +453,6 @@ class UpgradeContainer
             $currentPrestashopVersion
         );
 
-        $this->getState()->setInstallVersion($upgrader->getDestinationVersion());
-        $this->getState()->setOriginVersion($this->getProperty(self::PS_VERSION));
-
-        if ($upgrader->getChannel() === Upgrader::CHANNEL_LOCAL) {
-            $archiveXml = $this->getUpgradeConfiguration()->getLocalChannelXml();
-            $this->fileLoader->addXmlMd5File($upgrader->getDestinationVersion(), $this->getProperty(self::DOWNLOAD_PATH) . DIRECTORY_SEPARATOR . $archiveXml);
-        }
-
         $this->upgrader = $upgrader;
 
         return $this->upgrader;

--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -546,7 +546,7 @@ class UpgradeContainer
 
         $this->moduleSourceProviders = [
             new LocalSourceProvider($this->getProperty(self::WORKSPACE_PATH) . DIRECTORY_SEPARATOR . 'modules', $this->getFileConfigurationStorage()),
-            new MarketplaceSourceProvider($this->getState()->getInstallVersion(), $this->getProperty(self::PS_ROOT_PATH), $this->getFileLoader(), $this->getFileConfigurationStorage()),
+            new MarketplaceSourceProvider($this->getState()->getDestinationVersion(), $this->getProperty(self::PS_ROOT_PATH), $this->getFileLoader(), $this->getFileConfigurationStorage()),
             new ComposerSourceProvider($this->getProperty(self::LATEST_PATH), $this->getComposerService(), $this->getFileConfigurationStorage()),
             // Other providers
         ];

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -96,7 +96,7 @@ abstract class CoreUpgrader
         $this->container = $container;
         $this->logger = $logger;
         $this->filesystem = new Filesystem();
-        $this->destinationUpgradeVersion = $this->container->getState()->getInstallVersion();
+        $this->destinationUpgradeVersion = $this->container->getState()->getDestinationVersion();
         $this->pathToInstallFolder = realpath($this->container->getProperty(UpgradeContainer::LATEST_PATH) . DIRECTORY_SEPARATOR . 'install');
         $this->pathToUpgradeScripts = dirname(__DIR__, 3) . '/upgrade/';
         if (file_exists($this->pathToInstallFolder . DIRECTORY_SEPARATOR . 'autoload.php')) {
@@ -855,7 +855,7 @@ abstract class CoreUpgrader
     /**
      * @throws Exception
      */
-    protected function shouldClearCoreCache(): bool
+    public function shouldWarmupCoreCache(): bool
     {
         $destinationVersion = $this->container->getUpgrader()->getDestinationVersion();
 
@@ -865,18 +865,18 @@ abstract class CoreUpgrader
     /**
      * @throws Exception
      */
-    protected function clearCoreCache(): void
+    public function warmupCoreCache(): void
     {
         $rootPath = $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH);
-        $command = 'php ' . $rootPath . '/bin/console cache:warmup --env=prod';
+        $command = 'php ' . $rootPath . '/bin/console cache:warmup --no-interaction --env=prod';
         $output = [];
         $resultCode = 0;
 
         exec($command, $output, $resultCode);
 
         if ($resultCode !== 0) {
-            throw new UpgradeException("An error was raised when clearing the core cache: \n" . implode("\n", $output));
+            throw new UpgradeException("An error was raised when warming up the core cache: \n" . implode("\n", $output));
         }
-        $this->logger->debug('Core cache has been cleared to avoid dependency conflicts.');
+        $this->logger->debug('Core cache has been generated to avoid dependency conflicts.');
     }
 }

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader17.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader17.php
@@ -74,7 +74,7 @@ class CoreUpgrader17 extends CoreUpgrader
         // TODO: Update AdminTranslationsController::addNewTabs to install tabs translated
 
         // CLDR has been updated on PS 1.7.6.0. From this version, updates are not needed anymore.
-        if (version_compare($this->container->getState()->getInstallVersion(), '1.7.6.0', '<')) {
+        if (version_compare($this->container->getState()->getDestinationVersion(), '1.7.6.0', '<')) {
             $cldrUpdate = new \PrestaShop\PrestaShop\Core\Cldr\Update(_PS_TRANSLATIONS_DIR_);
             $cldrUpdate->fetchLocale(\Language::getLocaleByIso($isoCode));
         }

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
@@ -42,6 +42,10 @@ class CoreUpgrader80 extends CoreUpgrader
         $this->forceRemovingFiles();
         parent::initConstants();
 
+        if ($this->shouldClearCoreCache()) {
+            $this->clearCoreCache();
+        }
+
         // Container may be needed to run upgrade scripts
         $this->container->getSymfonyAdapter()->initKernel();
     }

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
@@ -41,11 +41,6 @@ class CoreUpgrader80 extends CoreUpgrader
     {
         $this->forceRemovingFiles();
         parent::initConstants();
-
-        if ($this->shouldClearCoreCache()) {
-            $this->clearCoreCache();
-        }
-
         // Container may be needed to run upgrade scripts
         $this->container->getSymfonyAdapter()->initKernel();
     }

--- a/controllers/admin/AdminSelfUpgradeController.php
+++ b/controllers/admin/AdminSelfUpgradeController.php
@@ -292,6 +292,13 @@ class AdminSelfUpgradeController extends ModuleAdminController
             empty($_REQUEST['params']) ? [] : $_REQUEST['params']
         );
 
+        if (!$this->upgradeContainer->getState()->isInitialized()) {
+            $this->upgradeContainer->getState()->initDefault(
+                $this->upgradeContainer->getProperty(UpgradeContainer::PS_VERSION),
+                $this->upgradeContainer->getUpgrader()->getDestinationVersion()
+            );
+        }
+
         // If you have defined this somewhere, you know what you do
         // load options from configuration if we're not in ajax mode
         if (!$this->ajax) {
@@ -300,9 +307,6 @@ class AdminSelfUpgradeController extends ModuleAdminController
                 $this->context->employee->id,
                 $this->context->language->iso_code
             );
-
-            $this->upgradeContainer->getState()->initDefault(
-                $this->upgradeContainer->getProperty(UpgradeContainer::PS_VERSION));
 
             if (isset($_GET['refreshCurrentVersion'])) {
                 $upgradeConfiguration = $this->upgradeContainer->getUpgradeConfiguration();
@@ -478,7 +482,7 @@ class AdminSelfUpgradeController extends ModuleAdminController
         $phpVersionResolverService = new PhpVersionResolverService(
             $distributionApiService,
             $this->upgradeContainer->getFileLoader(),
-            $this->upgradeContainer->getState()->getOriginVersion()
+            $this->upgradeContainer->getState()->getCurrentVersion()
         );
         $upgradeSelfCheck = new UpgradeSelfCheck(
             $upgrader,
@@ -489,7 +493,7 @@ class AdminSelfUpgradeController extends ModuleAdminController
             $this->prodRootDir,
             $this->adminDir,
             $this->autoupgradePath,
-            $this->upgradeContainer->getState()->getOriginVersion()
+            $this->upgradeContainer->getState()->getCurrentVersion()
         );
         $response = new AjaxResponse($this->upgradeContainer->getState(), $this->upgradeContainer->getLogger());
         $this->content = (new UpgradePage(

--- a/controllers/admin/self-managed/UpdatePageVersionChoiceController.php
+++ b/controllers/admin/self-managed/UpdatePageVersionChoiceController.php
@@ -162,7 +162,7 @@ class UpdatePageVersionChoiceController extends AbstractPageController
         $phpVersionResolverService = new PhpVersionResolverService(
             $distributionApiService,
             $this->upgradeContainer->getFileLoader(),
-            $this->upgradeContainer->getState()->getOriginVersion()
+            $this->upgradeContainer->getState()->getCurrentVersion()
         );
 
         $upgradeSelfCheck = new UpgradeSelfCheck(
@@ -174,7 +174,7 @@ class UpdatePageVersionChoiceController extends AbstractPageController
             _PS_ROOT_DIR_,
             _PS_ADMIN_DIR_,
             $this->upgradeContainer->getProperty(UpgradeContainer::WORKSPACE_PATH),
-            $this->upgradeContainer->getState()->getOriginVersion()
+            $this->upgradeContainer->getState()->getCurrentVersion()
         );
 
         $warnings = $upgradeSelfCheck->getWarnings();

--- a/tests/unit/AnalyticsTest.php
+++ b/tests/unit/AnalyticsTest.php
@@ -33,8 +33,8 @@ class AnalyticsTest extends TestCase
     public function testProperties()
     {
         $state = (new State())
-            ->setOriginVersion('8.8.8')
-            ->setInstallVersion('8.8.808')
+            ->setCurrentVersion('8.8.8')
+            ->setDestinationVersion('8.8.808')
             ->setRestoreName('V1.2.3_blablabla-🐶');
         $upgradeConfiguration = (new UpgradeConfiguration([
             'PS_AUTOUP_CUSTOM_MOD_DESACT' => 0,

--- a/tests/unit/UpgradeContainerTest.php
+++ b/tests/unit/UpgradeContainerTest.php
@@ -45,7 +45,7 @@ class UpgradeContainerTest extends TestCase
             ->setMethods(['getDb', 'getUpgrader'])
             ->getMock();
 
-        $container->getState()->setInstallVersion('1.7.1.0');
+        $container->getState()->setDestinationVersion('1.7.1.0');
         $actualClass = get_class(call_user_func([$container, $functionName]));
         $this->assertSame($actualClass, $expectedClass);
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Recovery of modified and deleted files for file updates is now done in the warmup of the "UpdateFile" task. The "CompareReleases" step becomes obsolete and will have to be removed after the drop of the old UI
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | -
| How to test?      | The update works the same as before. It is now possible to update to v9 on the CLI