### PR TITLE
Implement common methods for controllers to make sure basics are set

### DIFF
--- a/controllers/admin/self-managed/AbstractPageController.php
+++ b/controllers/admin/self-managed/AbstractPageController.php
@@ -33,9 +33,6 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 
 abstract class AbstractPageController extends AbstractGlobalController
 {
-    const CURRENT_PAGE = '';
-    const CURRENT_ROUTE = '';
-
     protected function getPsVersion(): string
     {
         return $this->upgradeContainer->getProperty($this->upgradeContainer::PS_VERSION);
@@ -96,17 +93,37 @@ abstract class AbstractPageController extends AbstractGlobalController
             return AjaxResponseBuilder::hydrationResponse(
                 PageSelectors::PAGE_PARENT_ID,
                 $this->renderPageContent(
-                    $this::CURRENT_PAGE,
+                    $this->getPageTemplate(),
                     $this->getParams()
                 ),
-                $this::CURRENT_ROUTE
+                $this->displayRouteInUrl()
             );
         }
 
         return $this->renderPage(
-            $this::CURRENT_PAGE,
+            $this->getPageTemplate(),
             $this->getParams()
         );
+    }
+
+    /**
+     * Relative path from the templates folder of the twig file
+     * to load when opening or reloading the page while being on the controller.
+     * Omit "pages/" and ".html.twig" from the value.
+     *
+     * @see index()
+     */
+    abstract protected function getPageTemplate(): string;
+
+    /**
+     * Provide another route to display in the address bar when this controller
+     * is called from an ajax request.
+     *
+     * @return Routes::*|void
+     */
+    protected function displayRouteInUrl(): ?string
+    {
+        return null;
     }
 
     /**

--- a/controllers/admin/self-managed/HomePageController.php
+++ b/controllers/admin/self-managed/HomePageController.php
@@ -33,8 +33,6 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 
 class HomePageController extends AbstractPageController
 {
-    const CURRENT_PAGE = 'home';
-    const CURRENT_ROUTE = Routes::HOME_PAGE;
     const FORM_FIELDS = [
         'route_choice' => 'route_choice',
     ];
@@ -42,6 +40,16 @@ class HomePageController extends AbstractPageController
         'update_value' => 'update',
         'restore_value' => 'restore',
     ];
+
+    protected function getPageTemplate(): string
+    {
+        return 'home';
+    }
+
+    protected function displayRouteInUrl(): ?string
+    {
+        return Routes::HOME_PAGE;
+    }
 
     public function submit(): JsonResponse
     {

--- a/controllers/admin/self-managed/UpdatePageBackupController.php
+++ b/controllers/admin/self-managed/UpdatePageBackupController.php
@@ -28,28 +28,19 @@
 namespace PrestaShop\Module\AutoUpgrade\Controller;
 
 use PrestaShop\Module\AutoUpgrade\Twig\UpdateSteps;
-use Twig\Error\LoaderError;
-use Twig\Error\RuntimeError;
-use Twig\Error\SyntaxError;
 
-class UpdatePageBackupController extends AbstractPageController
+class UpdatePageBackupController extends AbstractPageWithStepController
 {
     const CURRENT_STEP = UpdateSteps::STEP_BACKUP;
-    const CURRENT_PAGE = 'update';
 
-    /**
-     * @return string
-     *
-     * @throws LoaderError
-     * @throws RuntimeError
-     * @throws SyntaxError
-     */
-    public function step(): string
+    protected function getPageTemplate(): string
     {
-        return $this->getTwig()->render(
-            '@ModuleAutoUpgrade/steps/backup.html.twig',
-            $this->getParams()
-        );
+        return 'update';
+    }
+
+    protected function getStepTemplate(): string
+    {
+        return self::CURRENT_STEP;
     }
 
     /**

--- a/controllers/admin/self-managed/UpdatePagePostUpdateController.php
+++ b/controllers/admin/self-managed/UpdatePagePostUpdateController.php
@@ -28,28 +28,20 @@
 namespace PrestaShop\Module\AutoUpgrade\Controller;
 
 use PrestaShop\Module\AutoUpgrade\Twig\UpdateSteps;
-use Twig\Error\LoaderError;
-use Twig\Error\RuntimeError;
-use Twig\Error\SyntaxError;
 
-class UpdatePagePostUpdateController extends AbstractPageController
+class UpdatePagePostUpdateController extends AbstractPageWithStepController
 {
     const CURRENT_STEP = UpdateSteps::STEP_POST_UPDATE;
     const CURRENT_PAGE = 'update';
 
-    /**
-     * @return string
-     *
-     * @throws LoaderError
-     * @throws RuntimeError
-     * @throws SyntaxError
-     */
-    public function step(): string
+    protected function getPageTemplate(): string
     {
-        return $this->getTwig()->render(
-            '@ModuleAutoUpgrade/steps/post-update.html.twig',
-            $this->getParams()
-        );
+        return 'update';
+    }
+
+    protected function getStepTemplate(): string
+    {
+        return self::CURRENT_STEP;
     }
 
     /**

--- a/controllers/admin/self-managed/UpdatePageUpdateController.php
+++ b/controllers/admin/self-managed/UpdatePageUpdateController.php
@@ -30,11 +30,8 @@ namespace PrestaShop\Module\AutoUpgrade\Controller;
 use PrestaShop\Module\AutoUpgrade\Router\Routes;
 use PrestaShop\Module\AutoUpgrade\Twig\UpdateSteps;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Twig\Error\LoaderError;
-use Twig\Error\RuntimeError;
-use Twig\Error\SyntaxError;
 
-class UpdatePageUpdateController extends AbstractPageController
+class UpdatePageUpdateController extends AbstractPageWithStepController
 {
     const CURRENT_STEP = UpdateSteps::STEP_UPDATE;
     const CURRENT_PAGE = 'update';
@@ -44,19 +41,14 @@ class UpdatePageUpdateController extends AbstractPageController
         return $this->redirectTo(Routes::UPDATE_PAGE_BACKUP);
     }
 
-    /**
-     * @return string
-     *
-     * @throws LoaderError
-     * @throws RuntimeError
-     * @throws SyntaxError
-     */
-    public function step(): string
+    protected function getPageTemplate(): string
     {
-        return $this->getTwig()->render(
-            '@ModuleAutoUpgrade/steps/update.html.twig',
-            $this->getParams()
-        );
+        return 'update';
+    }
+
+    protected function getStepTemplate(): string
+    {
+        return self::CURRENT_STEP;
     }
 
     /**

--- a/controllers/admin/self-managed/UpdatePageVersionChoiceController.php
+++ b/controllers/admin/self-managed/UpdatePageVersionChoiceController.php
@@ -40,14 +40,9 @@ use PrestaShop\Module\AutoUpgrade\Upgrader;
 use PrestaShop\Module\AutoUpgrade\UpgradeSelfCheck;
 use PrestaShop\Module\AutoUpgrade\VersionUtils;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Twig\Error\LoaderError;
-use Twig\Error\RuntimeError;
-use Twig\Error\SyntaxError;
 
 class UpdatePageVersionChoiceController extends AbstractPageController
 {
-    const CURRENT_PAGE = 'update';
-    const CURRENT_ROUTE = Routes::UPDATE_PAGE_VERSION_CHOICE;
     const CURRENT_STEP = UpdateSteps::STEP_VERSION_CHOICE;
     const FORM_NAME = 'version_choice';
     const FORM_FIELDS = [
@@ -60,19 +55,19 @@ class UpdatePageVersionChoiceController extends AbstractPageController
         'local_value' => Upgrader::CHANNEL_LOCAL,
     ];
 
-    /**
-     * @return string
-     *
-     * @throws LoaderError
-     * @throws RuntimeError
-     * @throws SyntaxError
-     */
-    public function step(): string
+    protected function getPageTemplate(): string
     {
-        return $this->getTwig()->render(
-            '@ModuleAutoUpgrade/steps/version-choice.html.twig',
-            $this->getParams()
-        );
+        return 'update';
+    }
+
+    protected function getStepTemplate(): string
+    {
+        return self::CURRENT_STEP;
+    }
+
+    protected function displayRouteInUrl(): ?string
+    {
+        return Routes::UPDATE_PAGE_VERSION_CHOICE;
     }
 
     /**
@@ -232,8 +227,6 @@ class UpdatePageVersionChoiceController extends AbstractPageController
     public function submit(): JsonResponse
     {
         /* we dont check again because the button is only accessible if check are ok */
-        return new JsonResponse([
-            'next_route' => Routes::UPDATE_STEP_UPDATE_OPTIONS,
-        ]);
+        return AjaxResponseBuilder::nextRouteResponse(Routes::UPDATE_STEP_UPDATE_OPTIONS);
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Change the way some data are set on the controllers level, to trigger errors when a mandatory one is forgotten. This PR also enables the update options page.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | /
| How to test?      | Loading the existing pages still works, and the page displaying the update options is reachable.