### PR TITLE
[NEW UI] Update options page

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Here is an example of the different fields that can be found in it:
   "archive_num": "8.0.0", // Release number, specific to the archive channel
   "PS_AUTOUP_CUSTOM_MOD_DESACT": 1, // Disable non-native modules
   "PS_AUTOUP_CHANGE_DEFAULT_THEME": 0, // Keep the current theme
-  "PS_AUTOUP_KEEP_MAILS": 0, // Retain customized email templates
+  "PS_AUTOUP_REGEN_EMAIL": 1, // Retain customized email templates
   "PS_AUTOUP_BACKUP": 0, // Do not create a store backup
   "PS_AUTOUP_KEEP_IMAGES": 1, // Retain images
   "PS_DISABLE_OVERRIDES": 1 // Disable all overrides

--- a/_dev/jest.setup.ts
+++ b/_dev/jest.setup.ts
@@ -1,8 +1,9 @@
-beforeAll(() => {
-  window.AutoUpgradeVariables = {
-    token: 'test-token',
-    admin_url: 'http://localhost',
-    admin_dir: '/admin_directory',
-    stepper_parent_id: 'stepper_content'
-  };
-});
+// We don't wait for the call to beforeAll to define window properties.
+window.AutoUpgradeVariables = {
+  token: 'test-token',
+  admin_url: 'http://localhost',
+  admin_dir: '/admin_directory',
+  stepper_parent_id: 'stepper_content'
+};
+
+beforeAll(() => {});

--- a/_dev/src/ts/pages/UpdatePageUpdateOptions.ts
+++ b/_dev/src/ts/pages/UpdatePageUpdateOptions.ts
@@ -3,28 +3,19 @@ import api from '../api/RequestHandler';
 
 export default class UpdatePageUpdateOptions extends UpdatePage {
   protected stepCode = 'update-options';
-  protected form: HTMLFormElement;
-  protected formFields: Element[] = [];
-
-  constructor() {
-    super();
-    this.form = this.assertAndGetForm();
-  }
 
   public mount() {
     this.initStepper();
-    this.initFormFields(this.form);
-    this.form.addEventListener('submit', this.onFormSubmit);
+    this.form.addEventListener('submit', this.onSubmit);
+    this.form.addEventListener('change', this.onChange);
   }
 
   public beforeDestroy() {
-    this.form.removeEventListener('submit', this.onFormSubmit);
-    this.formFields.forEach((element) => {
-      element.removeEventListener('change', this.onInputChange);
-    });
+    this.form.removeEventListener('submit', this.onSubmit);
+    this.form.removeEventListener('change', this.onChange);
   }
 
-  private assertAndGetForm(): HTMLFormElement {
+  private get form(): HTMLFormElement {
     const form = document.forms.namedItem('update-options-page-form');
     if (!form) {
       throw new Error('Form not found');
@@ -39,19 +30,7 @@ export default class UpdatePageUpdateOptions extends UpdatePage {
     return form;
   }
 
-  private initFormFields(form: HTMLFormElement): void {
-    Array.from(form.elements).forEach((element) => {
-      if (element.nodeName !== 'INPUT') {
-        return;
-      }
-
-      this.formFields.push(element);
-
-      element.addEventListener('change', this.onInputChange);
-    });
-  }
-
-  private onInputChange = (ev: Event) => {
+  private readonly onChange = (ev: Event) => {
     const optionInput = ev.target as HTMLInputElement;
 
     optionInput.setAttribute('disabled', 'true');
@@ -64,7 +43,7 @@ export default class UpdatePageUpdateOptions extends UpdatePage {
     optionInput.removeAttribute('disabled');
   };
 
-  private onFormSubmit = (event: Event) => {
+  private readonly onSubmit = (event: Event) => {
     event.preventDefault();
 
     api.post(this.form.dataset.routeToSubmit!, new FormData(this.form));

--- a/_dev/src/ts/pages/UpdatePageUpdateOptions.ts
+++ b/_dev/src/ts/pages/UpdatePageUpdateOptions.ts
@@ -41,7 +41,7 @@ export default class UpdatePageUpdateOptions extends UpdatePage {
 
   private initFormFields(form: HTMLFormElement): void {
     Array.from(form.elements).forEach((element) => {
-      if (element.nodeName !== "INPUT") {
+      if (element.nodeName !== 'INPUT') {
         return;
       }
 
@@ -52,17 +52,17 @@ export default class UpdatePageUpdateOptions extends UpdatePage {
   }
 
   private onInputChange = (ev: Event) => {
-    const optionInput = (ev.target as Element);
+    const optionInput = ev.target as HTMLInputElement;
 
     optionInput.setAttribute('disabled', 'true');
 
     const data = new FormData();
     data.append('name', optionInput.name);
-    data.append('value', optionInput.checked);
+    data.append('value', JSON.stringify(optionInput.checked));
     api.post(this.form.dataset.routeToSave!, data);
 
     optionInput.removeAttribute('disabled');
-  }
+  };
 
   private onFormSubmit = (event: Event) => {
     event.preventDefault();

--- a/_dev/src/ts/pages/UpdatePageUpdateOptions.ts
+++ b/_dev/src/ts/pages/UpdatePageUpdateOptions.ts
@@ -30,7 +30,7 @@ export default class UpdatePageUpdateOptions extends UpdatePage {
     return form;
   }
 
-  private readonly onChange = (ev: Event) => {
+  private readonly onChange = async (ev: Event) => {
     const optionInput = ev.target as HTMLInputElement;
 
     optionInput.setAttribute('disabled', 'true');
@@ -38,14 +38,14 @@ export default class UpdatePageUpdateOptions extends UpdatePage {
     const data = new FormData();
     data.append('name', optionInput.name);
     data.append('value', JSON.stringify(optionInput.checked));
-    api.post(this.form.dataset.routeToSave!, data);
+    await api.post(this.form.dataset.routeToSave!, data);
 
     optionInput.removeAttribute('disabled');
   };
 
-  private readonly onSubmit = (event: Event) => {
+  private readonly onSubmit = async (event: Event) => {
     event.preventDefault();
 
-    api.post(this.form.dataset.routeToSubmit!, new FormData(this.form));
+    await api.post(this.form.dataset.routeToSubmit!, new FormData(this.form));
   };
 }

--- a/_dev/src/ts/pages/UpdatePageUpdateOptions.ts
+++ b/_dev/src/ts/pages/UpdatePageUpdateOptions.ts
@@ -11,8 +11,12 @@ export default class UpdatePageUpdateOptions extends UpdatePage {
   }
 
   public beforeDestroy() {
-    this.form.removeEventListener('submit', this.onSubmit);
-    this.form.removeEventListener('change', this.onChange);
+    try {
+      this.form.removeEventListener('submit', this.onSubmit);
+      this.form.removeEventListener('change', this.onChange);
+    } catch {
+      // Do Nothing, page is likely removed from the DOM already
+    }
   }
 
   private get form(): HTMLFormElement {

--- a/_dev/src/ts/pages/UpdatePageUpdateOptions.ts
+++ b/_dev/src/ts/pages/UpdatePageUpdateOptions.ts
@@ -1,13 +1,72 @@
 import UpdatePage from './UpdatePage';
+import api from '../api/RequestHandler';
 
 export default class UpdatePageUpdateOptions extends UpdatePage {
   protected stepCode = 'update-options';
+  protected form: HTMLFormElement;
+  protected formFields: Element[] = [];
 
   constructor() {
     super();
+    this.form = this.assertAndGetForm();
   }
 
   public mount() {
     this.initStepper();
+    this.initFormFields(this.form);
+    this.form.addEventListener('submit', this.onFormSubmit);
   }
+
+  public beforeDestroy() {
+    this.form.removeEventListener('submit', this.onFormSubmit);
+    this.formFields.forEach((element) => {
+      element.removeEventListener('change', this.onInputChange);
+    });
+  }
+
+  private assertAndGetForm(): HTMLFormElement {
+    const form = document.forms.namedItem('update-options-page-form');
+    if (!form) {
+      throw new Error('Form not found');
+    }
+
+    ['routeToSave', 'routeToSubmit'].forEach((data) => {
+      if (!form.dataset[data]) {
+        throw new Error(`Missing data ${data} from form dataset.`);
+      }
+    });
+
+    return form;
+  }
+
+  private initFormFields(form: HTMLFormElement): void {
+    Array.from(form.elements).forEach((element) => {
+      if (element.nodeName !== "INPUT") {
+        return;
+      }
+
+      this.formFields.push(element);
+
+      element.addEventListener('change', this.onInputChange);
+    });
+  }
+
+  private onInputChange = (ev: Event) => {
+    const optionInput = (ev.target as Element);
+
+    optionInput.setAttribute('disabled', 'true');
+
+    const data = new FormData();
+    data.append('name', optionInput.name);
+    data.append('value', optionInput.checked);
+    api.post(this.form.dataset.routeToSave!, data);
+
+    optionInput.removeAttribute('disabled');
+  }
+
+  private onFormSubmit = (event: Event) => {
+    event.preventDefault();
+
+    api.post(this.form.dataset.routeToSubmit!, new FormData(this.form));
+  };
 }

--- a/_dev/src/ts/pages/UpdatePageUpdateOptions.ts
+++ b/_dev/src/ts/pages/UpdatePageUpdateOptions.ts
@@ -33,13 +33,9 @@ export default class UpdatePageUpdateOptions extends UpdatePage {
   private readonly onChange = async (ev: Event) => {
     const optionInput = ev.target as HTMLInputElement;
 
+    const data = new FormData(this.form);
     optionInput.setAttribute('disabled', 'true');
-
-    const data = new FormData();
-    data.append('name', optionInput.name);
-    data.append('value', JSON.stringify(optionInput.checked));
     await api.post(this.form.dataset.routeToSave!, data);
-
     optionInput.removeAttribute('disabled');
   };
 

--- a/classes/Analytics.php
+++ b/classes/Analytics.php
@@ -124,7 +124,7 @@ class Analytics
                     'upgrade_channel' => $this->upgradeConfiguration->getChannel(),
                     'disable_non_native_modules' => $this->upgradeConfiguration->shouldDeactivateCustomModules(),
                     'switch_to_default_theme' => $this->upgradeConfiguration->shouldSwitchToDefaultTheme(),
-                    'keep_customized_email_templates' => !$this->upgradeConfiguration->shouldRegenerateMailTemplates(),
+                    'regenerate_customized_email_templates' => $this->upgradeConfiguration->shouldRegenerateMailTemplates(),
                 ];
                 $upgradeProperties = $this->properties[self::WITH_UPDATE_PROPERTIES] ?? [];
                 $additionalProperties = array_merge($upgradeProperties, $additionalProperties);

--- a/classes/Analytics.php
+++ b/classes/Analytics.php
@@ -124,7 +124,7 @@ class Analytics
                     'upgrade_channel' => $this->upgradeConfiguration->getChannel(),
                     'disable_non_native_modules' => $this->upgradeConfiguration->shouldDeactivateCustomModules(),
                     'switch_to_default_theme' => $this->upgradeConfiguration->shouldSwitchToDefaultTheme(),
-                    'keep_customized_email_templates' => $this->upgradeConfiguration->shouldKeepMails(),
+                    'keep_customized_email_templates' => !$this->upgradeConfiguration->shouldRegenerateMailTemplates(),
                 ];
                 $upgradeProperties = $this->properties[self::WITH_UPDATE_PROPERTIES] ?? [];
                 $additionalProperties = array_merge($upgradeProperties, $additionalProperties);

--- a/classes/Parameters/ConfigurationValidator.php
+++ b/classes/Parameters/ConfigurationValidator.php
@@ -64,7 +64,7 @@ class ConfigurationValidator
                     $error = $this->validateArchiveXml($value, $isLocal);
                     break;
                 case UpgradeConfiguration::PS_AUTOUP_CUSTOM_MOD_DESACT:
-                case UpgradeConfiguration::PS_AUTOUP_KEEP_MAILS:
+                case UpgradeConfiguration::PS_AUTOUP_REGEN_EMAIL:
                 case UpgradeConfiguration::PS_AUTOUP_KEEP_IMAGES:
                 case UpgradeConfiguration::PS_DISABLE_OVERRIDES:
                     $error = $this->validateBool($value, $key);

--- a/classes/Parameters/ConfigurationValidator.php
+++ b/classes/Parameters/ConfigurationValidator.php
@@ -106,9 +106,12 @@ class ConfigurationValidator
         return null;
     }
 
-    private function validateBool(string $boolValue, string $key): ?string
+    /**
+     * @param string|bool $boolValue
+     */
+    private function validateBool($boolValue, string $key): ?string
     {
-        if ($boolValue === '' || filter_var($boolValue, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) === null) {
+        if (!is_bool($boolValue) && ($boolValue === '' || filter_var($boolValue, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) === null)) {
             return $this->translator->trans('Value must be a boolean for %s', [$key]);
         }
 

--- a/classes/Parameters/UpgradeConfiguration.php
+++ b/classes/Parameters/UpgradeConfiguration.php
@@ -41,7 +41,7 @@ class UpgradeConfiguration extends ArrayCollection
 {
     const PS_AUTOUP_CUSTOM_MOD_DESACT = 'PS_AUTOUP_CUSTOM_MOD_DESACT';
     const PS_AUTOUP_CHANGE_DEFAULT_THEME = 'PS_AUTOUP_CHANGE_DEFAULT_THEME';
-    const PS_AUTOUP_KEEP_MAILS = 'PS_AUTOUP_KEEP_MAILS';
+    const PS_AUTOUP_REGEN_EMAIL = 'PS_AUTOUP_REGEN_EMAIL';
     const PS_AUTOUP_BACKUP = 'PS_AUTOUP_BACKUP';
     const PS_AUTOUP_KEEP_IMAGES = 'PS_AUTOUP_KEEP_IMAGES';
     const PS_DISABLE_OVERRIDES = 'PS_DISABLE_OVERRIDES';
@@ -56,7 +56,7 @@ class UpgradeConfiguration extends ArrayCollection
     const UPGRADE_CONST_KEYS = [
         self::PS_AUTOUP_CUSTOM_MOD_DESACT,
         self::PS_AUTOUP_CHANGE_DEFAULT_THEME,
-        self::PS_AUTOUP_KEEP_MAILS,
+        self::PS_AUTOUP_REGEN_EMAIL,
         self::PS_AUTOUP_BACKUP,
         self::PS_AUTOUP_KEEP_IMAGES,
         self::PS_DISABLE_OVERRIDES,
@@ -69,7 +69,7 @@ class UpgradeConfiguration extends ArrayCollection
     const PS_CONST_DEFAULT_VALUE = [
         self::PS_AUTOUP_CUSTOM_MOD_DESACT => true,
         self::PS_AUTOUP_CHANGE_DEFAULT_THEME => false,
-        self::PS_AUTOUP_KEEP_MAILS => false,
+        self::PS_AUTOUP_REGEN_EMAIL => true,
         self::PS_AUTOUP_BACKUP => true,
         self::PS_AUTOUP_KEEP_IMAGES => true,
     ];
@@ -201,11 +201,11 @@ class UpgradeConfiguration extends ArrayCollection
     }
 
     /**
-     * @return bool true if we should keep the merchant emails untouched
+     * @return bool true if we should regenerate the merchant emails
      */
-    public function shouldKeepMails(): bool
+    public function shouldRegenerateMailTemplates(): bool
     {
-        return $this->computeBooleanConfiguration(self::PS_AUTOUP_KEEP_MAILS);
+        return $this->computeBooleanConfiguration(self::PS_AUTOUP_REGEN_EMAIL);
     }
 
     /**

--- a/classes/Parameters/UpgradeConfiguration.php
+++ b/classes/Parameters/UpgradeConfiguration.php
@@ -262,9 +262,7 @@ class UpgradeConfiguration extends ArrayCollection
     public function merge(array $array = []): void
     {
         foreach ($array as $key => $value) {
-            if (in_array($key, self::UPGRADE_CONST_KEYS)) {
-                $this->set($key, $value);
-            }
+            $this->set($key, $value);
         }
     }
 }

--- a/classes/Parameters/UpgradeConfiguration.php
+++ b/classes/Parameters/UpgradeConfiguration.php
@@ -232,7 +232,7 @@ class UpgradeConfiguration extends ArrayCollection
 
     public static function isOverrideAllowed(): bool
     {
-        return (bool) Configuration::get(self::PS_DISABLE_OVERRIDES);
+        return !Configuration::get(self::PS_DISABLE_OVERRIDES);
     }
 
     public static function updateDisabledOverride(bool $value, ?int $shopId = null): void

--- a/classes/Parameters/UpgradeConfiguration.php
+++ b/classes/Parameters/UpgradeConfiguration.php
@@ -262,7 +262,9 @@ class UpgradeConfiguration extends ArrayCollection
     public function merge(array $array = []): void
     {
         foreach ($array as $key => $value) {
-            $this->set($key, $value);
+            if (in_array($key, self::UPGRADE_CONST_KEYS)) {
+                $this->set($key, $value);
+            }
         }
     }
 }

--- a/classes/Router/Router.php
+++ b/classes/Router/Router.php
@@ -82,6 +82,14 @@ class Router
             'controller' => UpdatePageUpdateOptionsController::class,
             'method' => 'step',
         ],
+        Routes::UPDATE_STEP_UPDATE_OPTIONS_SAVE_OPTION => [
+            'controller' => UpdatePageUpdateOptionsController::class,
+            'method' => 'saveOption',
+        ],
+        Routes::UPDATE_STEP_UPDATE_OPTIONS_SUBMIT_FORM => [
+            'controller' => UpdatePageUpdateOptionsController::class,
+            'method' => 'submit',
+        ],
         Routes::UPDATE_PAGE_BACKUP => [
             'controller' => UpdatePageBackupController::class,
             'method' => 'index',

--- a/classes/Router/Routes.php
+++ b/classes/Router/Routes.php
@@ -18,6 +18,8 @@ class Routes
     /* step: update options */
     const UPDATE_PAGE_UPDATE_OPTIONS = 'update-page-update-options';
     const UPDATE_STEP_UPDATE_OPTIONS = 'update-step-update-options';
+    const UPDATE_STEP_UPDATE_OPTIONS_SAVE_OPTION = 'update-step-update-options-save-option';
+    const UPDATE_STEP_UPDATE_OPTIONS_SUBMIT_FORM = 'update-step-update-options-submit-form';
 
     /* step: backup */
     const UPDATE_PAGE_BACKUP = 'update-page-backup';

--- a/classes/Twig/Form/UpgradeOptionsForm.php
+++ b/classes/Twig/Form/UpgradeOptionsForm.php
@@ -79,13 +79,13 @@ class UpgradeOptionsForm
                 'desc' => $translator->trans('This will change your theme: your shop will then use the default theme of the version of PrestaShop you are upgrading to.'),
             ],
 
-            UpgradeConfiguration::PS_AUTOUP_KEEP_MAILS => [
-                'title' => $translator->trans('Keep the customized email templates'),
+            UpgradeConfiguration::PS_AUTOUP_REGEN_EMAIL => [
+                'title' => $translator->trans('Regenerate the customized email templates'),
                 'cast' => 'intval',
                 'validation' => 'isBool',
                 'type' => 'bool',
                 'desc' => $translator->trans('This will not upgrade the default PrestaShop e-mails.') . '<br />'
-                    . $translator->trans('If you customized the default PrestaShop e-mail templates, enabling this option will keep your modifications.'),
+                    . $translator->trans('If you customized the default PrestaShop e-mail templates, switching off this option will keep your modifications.'),
             ],
         ];
     }

--- a/classes/Twig/ValidatorToFormFormater.php
+++ b/classes/Twig/ValidatorToFormFormater.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace PrestaShop\Module\AutoUpgrade\Twig;
+
+abstract class ValidatorToFormFormater
+{
+    /**
+     * @param array<array{message:string, target?:string}> $errors
+     *
+     * @return array<'global'|string, string>
+     */
+    public static function format($errors): array
+    {
+        return array_column(
+            array_map(function ($error) {
+                return [
+                    'key' => $error['target'] ?? 'global',
+                    'value' => $error['message'],
+                ];
+            }, $errors),
+            'value',
+            'key'
+        );
+    }
+}

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -136,10 +136,10 @@ abstract class CoreUpgrader
         $this->cleanXmlFiles();
 
         if (UpgradeConfiguration::isOverrideAllowed()) {
+            $this->logger->info($this->container->getTranslator()->trans('Keeping overrides in place'));
+        } else {
             $this->logger->info($this->container->getTranslator()->trans('Disabling overrides'));
             $this->disableOverrides();
-        } else {
-            $this->logger->info($this->container->getTranslator()->trans('Keeping overrides in place'));
         }
 
         $this->updateTheme();

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader17.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader17.php
@@ -62,7 +62,7 @@ class CoreUpgrader17 extends CoreUpgrader
         $lang_pack = \Language::getLangDetails($isoCode);
         \Language::installSfLanguagePack($lang_pack['locale'], $errorsLanguage);
 
-        if (!$this->container->getUpgradeConfiguration()->shouldKeepMails()) {
+        if ($this->container->getUpgradeConfiguration()->shouldRegenerateMailTemplates()) {
             \Language::installEmailsLanguagePack($lang_pack, $errorsLanguage);
         }
 

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
@@ -87,7 +87,7 @@ class CoreUpgrader80 extends CoreUpgrader
         $lang_pack = \Language::getLangDetails($isoCode);
         \Language::installSfLanguagePack($lang_pack['locale'], $errorsLanguage);
 
-        if (!$this->container->getUpgradeConfiguration()->shouldKeepMails()) {
+        if ($this->container->getUpgradeConfiguration()->shouldRegenerateMailTemplates()) {
             $this->logger->debug($this->container->getTranslator()->trans('Generating mail templates for %lang%', ['%lang%' => $isoCode]));
             $mailTheme = \Configuration::get('PS_MAIL_THEME', null, null, null, 'modern');
 

--- a/controllers/admin/AdminSelfUpgradeController.php
+++ b/controllers/admin/AdminSelfUpgradeController.php
@@ -238,13 +238,13 @@ class AdminSelfUpgradeController extends ModuleAdminController
                 'type' => 'bool',
                 'desc' => $this->trans('This will change your theme: your shop will then use the default theme of the version of PrestaShop you are upgrading to.'),
             ],
-            UpgradeConfiguration::PS_AUTOUP_KEEP_MAILS => [
-                'title' => $this->trans('Keep the customized email templates'),
+            UpgradeConfiguration::PS_AUTOUP_REGEN_EMAIL => [
+                'title' => $this->trans('Regenerate the customized email templates'),
                 'cast' => 'intval',
                 'validation' => 'isBool',
                 'type' => 'bool',
                 'desc' => $this->trans('This will not upgrade the default PrestaShop e-mails.') . '<br />'
-                    . $this->trans('If you customized the default PrestaShop e-mail templates, enabling this option will keep your modifications.'),
+                    . $this->trans('If you customized the default PrestaShop e-mail templates, switching off this option will keep your modifications.'),
             ],
         ];
     }

--- a/controllers/admin/self-managed/AbstractPageWithStepController.php
+++ b/controllers/admin/self-managed/AbstractPageWithStepController.php
@@ -40,11 +40,18 @@ abstract class AbstractPageWithStepController extends AbstractPageController
             return new Response('Unexpected call to a step route outside an ajax call.', 404);
         }
 
+        // It may be tempting to move this line inside the parameters of the method
+        // `getTwig()->render()`. Please refrain to do so as this makes Twig
+        // called BEFORE the call to the function sent as parameters. Initiating it too early
+        // can be misleading when rendering the templates as more autoloaders can be loaded
+        // in the meantime (i.e the core).
+        $params = $this->getParams();
+
         return AjaxResponseBuilder::hydrationResponse(
             PageSelectors::STEP_PARENT_ID,
             $this->getTwig()->render(
                 '@ModuleAutoUpgrade/steps/' . $this->getStepTemplate() . '.html.twig',
-                $this->getParams()
+                $params
             ),
             $this->displayRouteInUrl()
         );

--- a/controllers/admin/self-managed/UpdatePageUpdateOptionsController.php
+++ b/controllers/admin/self-managed/UpdatePageUpdateOptionsController.php
@@ -33,6 +33,7 @@ use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeFileNames;
 use PrestaShop\Module\AutoUpgrade\Router\Routes;
 use PrestaShop\Module\AutoUpgrade\Twig\PageSelectors;
 use PrestaShop\Module\AutoUpgrade\Twig\UpdateSteps;
+use PrestaShop\Module\AutoUpgrade\Twig\ValidatorToFormFormater;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 class UpdatePageUpdateOptionsController extends AbstractPageWithStepController
@@ -65,9 +66,9 @@ class UpdatePageUpdateOptionsController extends AbstractPageWithStepController
             $name => $this->request->request->get('value'),
         ];
 
-        $error = $this->upgradeContainer->getConfigurationValidator()->validate($config);
+        $errors = $this->upgradeContainer->getConfigurationValidator()->validate($config);
 
-        if (empty($error)) {
+        if (empty($errors)) {
             if ($name === 'PS_DISABLE_OVERRIDES') {
                 $this->upgradeContainer->initPrestaShopCore();
                 UpgradeConfiguration::updatePSDisableOverrides($this->request->request->getBoolean('value'));
@@ -77,7 +78,10 @@ class UpdatePageUpdateOptionsController extends AbstractPageWithStepController
             }
         }
 
-        return $this->getRefreshOfForm(array_merge($this->getParams(), ['error' => $error]));
+        return $this->getRefreshOfForm(array_merge(
+            $this->getParams(),
+            ['errors' => ValidatorToFormFormater::format($errors)]
+        ));
     }
 
     public function submit(): JsonResponse

--- a/controllers/admin/self-managed/UpdatePageUpdateOptionsController.php
+++ b/controllers/admin/self-managed/UpdatePageUpdateOptionsController.php
@@ -60,22 +60,21 @@ class UpdatePageUpdateOptionsController extends AbstractPageWithStepController
         $upgradeConfiguration = $this->upgradeContainer->getUpgradeConfiguration();
         $upgradeConfigurationStorage = $this->upgradeContainer->getUpgradeConfigurationStorage();
 
-        $name = $this->request->request->get('name');
-
         $config = [
-            $name => $this->request->request->get('value'),
+            UpgradeConfiguration::PS_AUTOUP_CUSTOM_MOD_DESACT => $this->request->request->getBoolean(UpgradeConfiguration::PS_AUTOUP_CUSTOM_MOD_DESACT, false),
+            UpgradeConfiguration::PS_AUTOUP_REGEN_EMAIL => $this->request->request->getBoolean(UpgradeConfiguration::PS_AUTOUP_REGEN_EMAIL, false),
+            UpgradeConfiguration::PS_DISABLE_OVERRIDES => $this->request->request->getBoolean(UpgradeConfiguration::PS_DISABLE_OVERRIDES, false),
         ];
 
         $errors = $this->upgradeContainer->getConfigurationValidator()->validate($config);
 
         if (empty($errors)) {
-            if ($name === UpgradeConfiguration::PS_DISABLE_OVERRIDES) {
+            if (isset($config[UpgradeConfiguration::PS_DISABLE_OVERRIDES])) {
                 $this->upgradeContainer->initPrestaShopCore();
-                UpgradeConfiguration::updatePSDisableOverrides($this->request->request->getBoolean('value'));
-            } else {
-                $upgradeConfiguration->merge($config);
-                $upgradeConfigurationStorage->save($upgradeConfiguration, UpgradeFileNames::CONFIG_FILENAME);
+                UpgradeConfiguration::updatePSDisableOverrides($config[UpgradeConfiguration::PS_DISABLE_OVERRIDES]);
             }
+            $upgradeConfiguration->merge($config);
+            $upgradeConfigurationStorage->save($upgradeConfiguration, UpgradeFileNames::CONFIG_FILENAME);
         }
 
         return $this->getRefreshOfForm(array_merge(

--- a/controllers/admin/self-managed/UpdatePageUpdateOptionsController.php
+++ b/controllers/admin/self-managed/UpdatePageUpdateOptionsController.php
@@ -62,14 +62,10 @@ class UpdatePageUpdateOptionsController extends AbstractPageWithStepController
         $name = $this->request->request->get('name');
 
         $config = [
-            $name => $this->request->request->getBoolean('value'),
+            $name => $this->request->request->get('value'),
         ];
 
-        // TODO: Remove after rebase
-        $upgradeConfiguration->validate($config);
-        $error = null;
-        // TODO: Uncomment after rebase
-        // $error = $this->upgradeContainer->getConfigurationValidator()->validate($config);
+        $error = $this->upgradeContainer->getConfigurationValidator()->validate($config);
 
         if (empty($error)) {
             if ($name === 'PS_DISABLE_OVERRIDES') {

--- a/controllers/admin/self-managed/UpdatePageUpdateOptionsController.php
+++ b/controllers/admin/self-managed/UpdatePageUpdateOptionsController.php
@@ -69,7 +69,7 @@ class UpdatePageUpdateOptionsController extends AbstractPageWithStepController
         $errors = $this->upgradeContainer->getConfigurationValidator()->validate($config);
 
         if (empty($errors)) {
-            if ($name === 'PS_DISABLE_OVERRIDES') {
+            if ($name === UpgradeConfiguration::PS_DISABLE_OVERRIDES) {
                 $this->upgradeContainer->initPrestaShopCore();
                 UpgradeConfiguration::updatePSDisableOverrides($this->request->request->getBoolean('value'));
             } else {
@@ -108,15 +108,15 @@ class UpdatePageUpdateOptionsController extends AbstractPageWithStepController
 
                 'form_fields' => [
                     'deactive_non_native_modules' => [
-                        'field' => 'PS_AUTOUP_CUSTOM_MOD_DESACT',
+                        'field' => UpgradeConfiguration::PS_AUTOUP_CUSTOM_MOD_DESACT,
                         'value' => $upgradeConfiguration->shouldDeactivateCustomModules(),
                     ],
                     'regenerate_email_templates' => [
-                        'field' => 'PS_AUTOUP_REGEN_EMAIL',
+                        'field' => UpgradeConfiguration::PS_AUTOUP_REGEN_EMAIL,
                         'value' => $upgradeConfiguration->shouldRegenerateMailTemplates(),
                     ],
                     'disable_all_overrides' => [
-                        'field' => 'PS_DISABLE_OVERRIDES',
+                        'field' => UpgradeConfiguration::PS_DISABLE_OVERRIDES,
                         'value' => !$upgradeConfiguration->isOverrideAllowed(),
                     ],
                 ],

--- a/controllers/admin/self-managed/UpdatePageUpdateOptionsController.php
+++ b/controllers/admin/self-managed/UpdatePageUpdateOptionsController.php
@@ -57,7 +57,9 @@ class UpdatePageUpdateOptionsController extends AbstractPageWithStepController
     {
         $name = $this->request->request->get('name');
         if ($name === 'PS_DISABLE_OVERRIDES') {
-            UpgradeConfiguration::updatePSDisableOverrides((bool) $this->request->request->get('value'));
+            $this->upgradeContainer->initPrestaShopCore();
+            UpgradeConfiguration::updatePSDisableOverrides($this->request->request->getBoolean('value'));
+            return new JsonResponse(['success' => true]);
         }
 
         $upgradeConfiguration = $this->upgradeContainer->getUpgradeConfiguration();
@@ -66,7 +68,7 @@ class UpdatePageUpdateOptionsController extends AbstractPageWithStepController
         // TODO: Call the validator
 
         $upgradeConfiguration->merge([
-            $name => $this->request->request->get('value'),
+            $name => $this->request->request->getBoolean('value'),
         ]);
 
         $success = $upgradeConfigurationStorage->save($upgradeConfiguration, UpgradeFileNames::CONFIG_FILENAME);

--- a/controllers/admin/self-managed/UpdatePageVersionChoiceController.php
+++ b/controllers/admin/self-managed/UpdatePageVersionChoiceController.php
@@ -41,7 +41,7 @@ use PrestaShop\Module\AutoUpgrade\UpgradeSelfCheck;
 use PrestaShop\Module\AutoUpgrade\VersionUtils;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
-class UpdatePageVersionChoiceController extends AbstractPageController
+class UpdatePageVersionChoiceController extends AbstractPageWithStepController
 {
     const CURRENT_STEP = UpdateSteps::STEP_VERSION_CHOICE;
     const FORM_NAME = 'version_choice';

--- a/controllers/admin/self-managed/UpdatePageVersionChoiceController.php
+++ b/controllers/admin/self-managed/UpdatePageVersionChoiceController.php
@@ -36,6 +36,7 @@ use PrestaShop\Module\AutoUpgrade\Services\DistributionApiService;
 use PrestaShop\Module\AutoUpgrade\Services\PhpVersionResolverService;
 use PrestaShop\Module\AutoUpgrade\Twig\PageSelectors;
 use PrestaShop\Module\AutoUpgrade\Twig\UpdateSteps;
+use PrestaShop\Module\AutoUpgrade\Twig\ValidatorToFormFormater;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 use PrestaShop\Module\AutoUpgrade\UpgradeSelfCheck;
 use PrestaShop\Module\AutoUpgrade\VersionUtils;
@@ -222,24 +223,13 @@ class UpdatePageVersionChoiceController extends AbstractPageWithStepController
             if ($channel !== null) {
                 $params[$channel . '_requirements'] = $this->getRequirements();
             }
-        } else {
-            $errors = array_column(
-                array_map(function ($error) {
-                    return [
-                        'key' => $error['target'] ?? 'global',
-                        'value' => $error['message'],
-                    ];
-                }, $errors),
-                'value',
-                'key'
-            );
         }
 
         $params = array_merge(
             $params,
             [
                 'current_values' => $requestConfig,
-                'errors' => $errors,
+                'errors' => ValidatorToFormFormater::format($errors),
             ]
         );
 

--- a/storybook/stories/pages/UpdateOptions.stories.js
+++ b/storybook/stories/pages/UpdateOptions.stories.js
@@ -39,12 +39,30 @@ export const UpdateOptions = {
       code: "update-options",
       title: "Update options",
     },
-    default_deactive_non_native_modules: true,
-    default_regenerate_email_templates: true,
-    switch_the_theme: 1,
-    disable_all_overrides: false,
+    form_fields: {
+      deactive_non_native_modules: {
+          field: 'PS_AUTOUP_CUSTOM_MOD_DESACT',
+          value: true,
+      },
+      regenerate_email_templates: {
+          field: 'PS_AUTOUP_REGEN_EMAIL',
+          value: true,
+      },
+      disable_all_overrides: {
+          field: 'PS_DISABLE_OVERRIDES',
+          value: false,
+      },
+    },
     step_parent_id: "ua_container",
     stepper_parent_id: "stepper_content",
+
+    form_route_to_save: "update-step-update-options-save-option",
+    form_route_to_submit: "update-step-update-options-submit-form",
+
+    error: {
+      'PS_AUTOUP_REGEN_EMAIL': 'Example of an error that occured when switching the value!',
+    },
+
     // Stepper
     ...Stepper.args,
   },

--- a/tests/unit/AnalyticsTest.php
+++ b/tests/unit/AnalyticsTest.php
@@ -97,7 +97,7 @@ class AnalyticsTest extends TestCase
                     'upgrade_channel' => 'major',
                     'disable_non_native_modules' => false,
                     'switch_to_default_theme' => true,
-                    'keep_customized_email_templates' => false,
+                    'regenerate_customized_email_templates' => true,
                     'regenerate_rtl_stylesheet' => false,
                 ],
             ],

--- a/tests/unit/AnalyticsTest.php
+++ b/tests/unit/AnalyticsTest.php
@@ -43,7 +43,7 @@ class AnalyticsTest extends TestCase
         $upgradeConfiguration = (new UpgradeConfiguration([
             UpgradeConfiguration::PS_AUTOUP_CUSTOM_MOD_DESACT => 0,
             UpgradeConfiguration::PS_AUTOUP_CHANGE_DEFAULT_THEME => 1,
-            UpgradeConfiguration::PS_AUTOUP_KEEP_MAILS => 0,
+            UpgradeConfiguration::PS_AUTOUP_REGEN_EMAIL => 1,
             UpgradeConfiguration::PS_AUTOUP_BACKUP => 1,
             UpgradeConfiguration::PS_AUTOUP_KEEP_IMAGES => 0,
             UpgradeConfiguration::CHANNEL => 'major',

--- a/tests/unit/Parameters/ConfigurationValidatorTest.php
+++ b/tests/unit/Parameters/ConfigurationValidatorTest.php
@@ -117,7 +117,7 @@ class ConfigurationValidatorTest extends TestCase
 
     public function testValidateBoolSuccess()
     {
-        $validValues = ['1', '0', 'true', 'false', 'on', 'off'];
+        $validValues = ['1', '0', 'true', 'false', 'on', 'off', true, false];
 
         foreach ($validValues as $value) {
             $result = $this->validator->validate([UpgradeConfiguration::PS_AUTOUP_CUSTOM_MOD_DESACT => $value]);

--- a/views/templates/steps/update-options.html.twig
+++ b/views/templates/steps/update-options.html.twig
@@ -16,30 +16,33 @@
     name="update-options-page-form"
   >
     {% include "@ModuleAutoUpgrade/components/render-switch.html.twig" with {
-      id: "PS_AUTOUP_CUSTOM_MOD_DESACT",
-      name: "PS_AUTOUP_CUSTOM_MOD_DESACT",
+      id: form_fields.deactive_non_native_modules.field,
+      name: form_fields.deactive_non_native_modules.field,
       title: "Deactivate non-native modules",
       description: "All the modules installed after creating your store are considered non-native modules. They might be " ~
         "incompatible with the new version of PrestaShop. We recommend deactivating them during the update.",
-      value: default_deactive_non_native_modules
+      value: form_fields.deactive_non_native_modules.value,
+      error_message: error[form_fields.deactive_non_native_modules.field],
     } %}
 
     {% include "@ModuleAutoUpgrade/components/render-switch.html.twig" with {
-      id: "PS_AUTOUP_REGEN_EMAIL",
-      name: "PS_AUTOUP_REGEN_EMAIL",
+      id: form_fields.regenerate_email_templates.field,
+      name: form_fields.regenerate_email_templates.field,
       title: "Regenerate email templates",
       description: "If you've customized email templates, your changes will be lost if you activate this option.",
-      value: default_regenerate_email_templates
+      value: form_fields.regenerate_email_templates.value,
+      error_message: error[form_fields.regenerate_email_templates.field],
     } %}
 
     {% include "@ModuleAutoUpgrade/components/render-switch.html.twig" with {
-      id: "PS_AUTOUP_DISABLE_OVERRIDE",
-      name: "PS_AUTOUP_DISABLE_OVERRIDE",
+      id: form_fields.disable_all_overrides.field,
+      name: form_fields.disable_all_overrides.field,
       title: "Disable all overrides",
       description: "Overriding is a way to replace business behaviors (class files and controller files) to target only " ~
         "one method or as many as you need. This option disables all classes & controllers overrides, allowing " ~
         "you to avoid conflicts during and after updates.",
-      value: disable_all_overrides
+      value: form_fields.disable_all_overrides.value,
+      error_message: error[form_fields.disable_all_overrides.field],
     } %}
   </form>
 {% endblock %}

--- a/views/templates/steps/update-options.html.twig
+++ b/views/templates/steps/update-options.html.twig
@@ -22,7 +22,7 @@
       description: "All the modules installed after creating your store are considered non-native modules. They might be " ~
         "incompatible with the new version of PrestaShop. We recommend deactivating them during the update.",
       value: form_fields.deactive_non_native_modules.value,
-      error_message: error[form_fields.deactive_non_native_modules.field],
+      error_message: error[form_fields.deactive_non_native_modules.field] is defined ? error[form_fields.deactive_non_native_modules.field] : null,
     } %}
 
     {% include "@ModuleAutoUpgrade/components/render-switch.html.twig" with {
@@ -31,7 +31,7 @@
       title: "Regenerate email templates",
       description: "If you've customized email templates, your changes will be lost if you activate this option.",
       value: form_fields.regenerate_email_templates.value,
-      error_message: error[form_fields.regenerate_email_templates.field],
+      error_message: error[form_fields.regenerate_email_templates.field] is defined ? error[form_fields.regenerate_email_templates.field] : null,
     } %}
 
     {% include "@ModuleAutoUpgrade/components/render-switch.html.twig" with {
@@ -42,7 +42,7 @@
         "one method or as many as you need. This option disables all classes & controllers overrides, allowing " ~
         "you to avoid conflicts during and after updates.",
       value: form_fields.disable_all_overrides.value,
-      error_message: error[form_fields.disable_all_overrides.field],
+      error_message: error[form_fields.disable_all_overrides.field] is defined ? error[form_fields.disable_all_overrides.field] : null,
     } %}
   </form>
 {% endblock %}

--- a/views/templates/steps/update-options.html.twig
+++ b/views/templates/steps/update-options.html.twig
@@ -22,7 +22,7 @@
       description: "All the modules installed after creating your store are considered non-native modules. They might be " ~
         "incompatible with the new version of PrestaShop. We recommend deactivating them during the update."|trans({}),
       value: form_fields.deactive_non_native_modules.value,
-      error_message: error[form_fields.deactive_non_native_modules.field] is defined ? error[form_fields.deactive_non_native_modules.field] : null,
+      error_message: errors[form_fields.deactive_non_native_modules.field] is defined ? errors[form_fields.deactive_non_native_modules.field] : null,
     } %}
 
     {% include "@ModuleAutoUpgrade/components/render-switch.html.twig" with {
@@ -31,7 +31,7 @@
       title: "Regenerate email templates"|trans({}),
       description: "If you've customized email templates, your changes will be lost if you activate this option."|trans({}),
       value: form_fields.regenerate_email_templates.value,
-      error_message: error[form_fields.regenerate_email_templates.field] is defined ? error[form_fields.regenerate_email_templates.field] : null,
+      error_message: errors[form_fields.regenerate_email_templates.field] is defined ? errors[form_fields.regenerate_email_templates.field] : null,
     } %}
 
     {% include "@ModuleAutoUpgrade/components/render-switch.html.twig" with {
@@ -42,7 +42,7 @@
         "one method or as many as you need. This option disables all classes & controllers overrides, allowing " ~
         "you to avoid conflicts during and after updates."|trans({}),
       value: form_fields.disable_all_overrides.value,
-      error_message: error[form_fields.disable_all_overrides.field] is defined ? error[form_fields.disable_all_overrides.field] : null,
+      error_message: errors[form_fields.disable_all_overrides.field] is defined ? errors[form_fields.disable_all_overrides.field] : null,
     } %}
   </form>
 {% endblock %}

--- a/views/templates/steps/update-options.html.twig
+++ b/views/templates/steps/update-options.html.twig
@@ -7,7 +7,14 @@
 {% endblock %}
 
 {% block content %}
-  <div class="update-options-page__field-list">
+  <form 
+    class="update-options-page__field-list"
+    action=""
+    data-route-to-save="{{ form_route_to_save }}"
+    data-route-to-submit="{{ form_route_to_submit }}"
+    id="update-options-page-form"
+    name="update-options-page-form"
+  >
     {% include "@ModuleAutoUpgrade/components/render-switch.html.twig" with {
       id: "PS_AUTOUP_CUSTOM_MOD_DESACT",
       name: "PS_AUTOUP_CUSTOM_MOD_DESACT",
@@ -34,11 +41,14 @@
         "you to avoid conflicts during and after updates.",
       value: disable_all_overrides
     } %}
-  </div>
+  </form>
 {% endblock %}
 
 {% block buttons_inner %}
-  <button class="btn btn-lg btn-primary" type="button">
+  <button
+    class="btn btn-lg btn-primary" type="submit"
+    form="update-options-page-form"
+  >
     {{ 'Next'|trans({}) }}
     <i class="material-icons">arrow_forward</i>
   </button>

--- a/views/templates/steps/update-options.html.twig
+++ b/views/templates/steps/update-options.html.twig
@@ -18,9 +18,9 @@
     {% include "@ModuleAutoUpgrade/components/render-switch.html.twig" with {
       id: form_fields.deactive_non_native_modules.field,
       name: form_fields.deactive_non_native_modules.field,
-      title: "Deactivate non-native modules",
+      title: "Deactivate non-native modules"|trans({}),
       description: "All the modules installed after creating your store are considered non-native modules. They might be " ~
-        "incompatible with the new version of PrestaShop. We recommend deactivating them during the update.",
+        "incompatible with the new version of PrestaShop. We recommend deactivating them during the update."|trans({}),
       value: form_fields.deactive_non_native_modules.value,
       error_message: error[form_fields.deactive_non_native_modules.field] is defined ? error[form_fields.deactive_non_native_modules.field] : null,
     } %}
@@ -28,8 +28,8 @@
     {% include "@ModuleAutoUpgrade/components/render-switch.html.twig" with {
       id: form_fields.regenerate_email_templates.field,
       name: form_fields.regenerate_email_templates.field,
-      title: "Regenerate email templates",
-      description: "If you've customized email templates, your changes will be lost if you activate this option.",
+      title: "Regenerate email templates"|trans({}),
+      description: "If you've customized email templates, your changes will be lost if you activate this option."|trans({}),
       value: form_fields.regenerate_email_templates.value,
       error_message: error[form_fields.regenerate_email_templates.field] is defined ? error[form_fields.regenerate_email_templates.field] : null,
     } %}
@@ -37,10 +37,10 @@
     {% include "@ModuleAutoUpgrade/components/render-switch.html.twig" with {
       id: form_fields.disable_all_overrides.field,
       name: form_fields.disable_all_overrides.field,
-      title: "Disable all overrides",
+      title: "Disable all overrides"|trans({}),
       description: "Overriding is a way to replace business behaviors (class files and controller files) to target only " ~
         "one method or as many as you need. This option disables all classes & controllers overrides, allowing " ~
-        "you to avoid conflicts during and after updates.",
+        "you to avoid conflicts during and after updates."|trans({}),
       value: form_fields.disable_all_overrides.value,
       error_message: error[form_fields.disable_all_overrides.field] is defined ? error[form_fields.disable_all_overrides.field] : null,
     } %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Handle update option with a brand new page
| Type?             | new feature
| BC breaks?        | Yes, the config var `PS_AUTOUP_KEEP_EMAIL` is now `PS_AUTOUP_REGEN_EMAIL`
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Update options can be updated via the new UI. Refreshing a page after an option is switched on or off must keep its value.

![image](https://github.com/user-attachments/assets/a609b600-f71c-4863-9b3c-076bf1ccf3e0)
