### PR TITLE
Update wording when checking a module for updates

### DIFF
--- a/classes/Task/Update/UpdateModules.php
+++ b/classes/Task/Update/UpdateModules.php
@@ -126,7 +126,7 @@ class UpdateModules extends AbstractTask
         if ($modules_left) {
             $this->stepDone = false;
             $this->next = TaskName::TASK_UPDATE_MODULES;
-            $this->logger->info($this->translator->trans('%s modules left to update.', [$modules_left]));
+            $this->logger->info($this->translator->trans('%s modules left to check.', [$modules_left]));
         } else {
             $this->stepDone = true;
             $this->status = 'ok';


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When updating modules, we check all installed modules. Not all of them will have an update to display, but we could understand from the logs that we always have a new available version.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Logs explain we "check" modules instead of "update"


```
[2024-10-30 12:08:29] INFO - 11 modules left to check.
[2024-10-30 12:08:29] NOTICE - Module ps_categorytree update files (2.0.3 => 3.0.0) have been fetched from https://api.addons.prestashop.com/?id_module=22314&method=module&version=9.0.0.
[2024-10-30 12:08:29] INFO - Module ps_categorytree does not need to be migrated. Module is up to date.
[2024-10-30 12:08:33] INFO - 10 modules left to check.
[2024-10-30 12:08:33] INFO - 9 modules left to check.
[2024-10-30 12:08:34] INFO - 8 modules left to check.
[2024-10-30 12:08:34] INFO - 7 modules left to check.
[2024-10-30 12:08:34] INFO - 6 modules left to check.
[2024-10-30 12:08:34] INFO - 5 modules left to check.
[2024-10-30 12:08:34] INFO - 4 modules left to check.
[2024-10-30 12:08:34] INFO - 3 modules left to check.
[2024-10-30 12:08:34] INFO - 2 modules left to check.
[2024-10-30 12:08:35] INFO - 1 modules left to check.
[2024-10-30 12:08:35] INFO - All modules have been updated.
```