### PR TITLE
[NEW UI] Optimise version choice loading

### DIFF
--- a/_dev/src/ts/pages/UpdatePageVersionChoice.ts
+++ b/_dev/src/ts/pages/UpdatePageVersionChoice.ts
@@ -17,6 +17,8 @@ export default class UpdatePageVersionChoice extends UpdatePage {
     this.form.addEventListener('change', this.saveForm.bind(this));
     this.form.addEventListener('submit', this.handleSubmit);
 
+    this.form.dispatchEvent(new Event('change'));
+
     this.onlineCardParent?.addEventListener(Hydration.hydrationEventName, this.handleHydrate);
     this.localCardParent?.addEventListener(Hydration.hydrationEventName, this.handleHydrate);
 

--- a/classes/Parameters/UpgradeFileNames.php
+++ b/classes/Parameters/UpgradeFileNames.php
@@ -33,6 +33,13 @@ namespace PrestaShop\Module\AutoUpgrade\Parameters;
 class UpgradeFileNames
 {
     /**
+     * stateFilename contains all state specific to the autoupgrade module.
+     *
+     * @var string
+     */
+    const STATE_FILENAME = 'state.var';
+
+    /**
      * configFilename contains all configuration specific to the autoupgrade module.
      *
      * @var string

--- a/classes/Parameters/UpgradeFileNames.php
+++ b/classes/Parameters/UpgradeFileNames.php
@@ -162,6 +162,7 @@ class UpgradeFileNames
      * @var array<string, string>
      */
     public static $update_tmp_files = [
+        'STATE_FILENAME' => self::STATE_FILENAME,
         'QUERIES_TO_UPGRADE_LIST' => self::QUERIES_TO_UPGRADE_LIST, // used ?
         'FILES_TO_UPGRADE_LIST' => self::FILES_TO_UPGRADE_LIST,
         'DB_TABLES_TO_CLEAN_LIST' => self::DB_TABLES_TO_CLEAN_LIST,
@@ -180,6 +181,7 @@ class UpgradeFileNames
      * @var array<string, string>
      */
     public static $backup_tmp_files = [
+        'STATE_FILENAME' => self::STATE_FILENAME,
         'FILES_TO_BACKUP_LIST' => self::FILES_TO_BACKUP_LIST,
         'DB_TABLES_TO_BACKUP_LIST' => self::DB_TABLES_TO_BACKUP_LIST,
     ];
@@ -188,6 +190,7 @@ class UpgradeFileNames
      * @var array<string, string>
      */
     public static $restore_tmp_files = [
+        'STATE_FILENAME' => self::STATE_FILENAME,
         'QUERIES_TO_RESTORE_LIST' => self::QUERIES_TO_RESTORE_LIST,
         'FILES_FROM_ARCHIVE_LIST' => self::FILES_FROM_ARCHIVE_LIST,
     ];

--- a/classes/State.php
+++ b/classes/State.php
@@ -302,7 +302,7 @@ class State
         return $this;
     }
 
-    public function setDestinationVersion(string $destinationVersion): State
+    public function setDestinationVersion(?string $destinationVersion): State
     {
         $this->destinationVersion = $destinationVersion;
 

--- a/classes/State.php
+++ b/classes/State.php
@@ -167,6 +167,7 @@ class State
     {
         $state = get_object_vars($this);
         unset($state['fileConfigurationStorage']);
+
         return $state;
     }
 

--- a/classes/State.php
+++ b/classes/State.php
@@ -29,6 +29,8 @@ namespace PrestaShop\Module\AutoUpgrade;
 
 use InvalidArgumentException;
 use PrestaShop\Module\AutoUpgrade\Backup\BackupFinder;
+use PrestaShop\Module\AutoUpgrade\Parameters\FileConfigurationStorage;
+use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeFileNames;
 
 /**
  * Class storing the temporary data to keep between 2 ajax requests.
@@ -108,8 +110,23 @@ class State
     /** @var ?string */
     private $processTimestamp;
 
-    /** @var bool Allows you to know if the state has been initialized using the initDefault method */
-    private $initialized = false;
+    /** @var FileConfigurationStorage */
+    private $fileConfigurationStorage;
+
+    public function __construct(FileConfigurationStorage $fileConfigurationStorage)
+    {
+        $this->fileConfigurationStorage = $fileConfigurationStorage;
+    }
+
+    /**
+     * @return void
+     */
+    public function load()
+    {
+        $state = $this->fileConfigurationStorage->load(UpgradeFileNames::STATE_FILENAME);
+
+        $this->importFromArray($state);
+    }
 
     /**
      * @param array<string, mixed> $savedState from another request
@@ -136,11 +153,21 @@ class State
     }
 
     /**
+     * @return bool
+     */
+    public function save(): bool
+    {
+        return $this->fileConfigurationStorage->save($this->export(), UpgradeFileNames::STATE_FILENAME);
+    }
+
+    /**
      * @return array<string, mixed> of class properties for export
      */
     public function export(): array
     {
-        return get_object_vars($this);
+        $state = get_object_vars($this);
+        unset($state['fileConfigurationStorage']);
+        return $state;
     }
 
     public function initDefault(string $currentVersion, ?string $destinationVersion): void
@@ -160,7 +187,7 @@ class State
         $this->setBackupName($backupName);
         $this->setCurrentVersion($currentVersion);
         $this->setDestinationVersion($destinationVersion);
-        $this->initialized = true;
+        $this->save();
     }
 
     // GETTERS
@@ -251,6 +278,21 @@ class State
         return $this->processTimestamp;
     }
 
+    /**
+     * Pick version from restoration file name in the format v[version]_[date]-[time]-[random]
+     */
+    public function getRestoreVersion(): ?string
+    {
+        $matches = [];
+        preg_match(
+            '/^V(?<version>[1-9\.]+)_/',
+            $this->getRestoreName(),
+            $matches
+        );
+
+        return $matches[1] ?? null;
+    }
+
     // SETTERS
     public function setCurrentVersion(string $currentVersion): State
     {
@@ -259,7 +301,7 @@ class State
         return $this;
     }
 
-    public function setDestinationVersion(?string $destinationVersion): State
+    public function setDestinationVersion(string $destinationVersion): State
     {
         $this->destinationVersion = $destinationVersion;
 
@@ -345,21 +387,6 @@ class State
     }
 
     /**
-     * Pick version from restoration file name in the format v[version]_[date]-[time]-[random]
-     */
-    public function getRestoreVersion(): ?string
-    {
-        $matches = [];
-        preg_match(
-            '/^V(?<version>[1-9\.]+)_/',
-            $this->getRestoreName(),
-            $matches
-        );
-
-        return $matches[1] ?? null;
-    }
-
-    /**
      * @param string[] $installedLanguagesIso
      */
     public function setInstalledLanguagesIso(array $installedLanguagesIso): State
@@ -394,6 +421,6 @@ class State
 
     public function isInitialized(): bool
     {
-        return $this->initialized;
+        return $this->fileConfigurationStorage->exists(UpgradeFileNames::STATE_FILENAME);
     }
 }

--- a/classes/Task/Update/UpdateComplete.php
+++ b/classes/Task/Update/UpdateComplete.php
@@ -29,6 +29,7 @@ namespace PrestaShop\Module\AutoUpgrade\Task\Update;
 
 use Exception;
 use PrestaShop\Module\AutoUpgrade\Analytics;
+use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeFileNames;
 use PrestaShop\Module\AutoUpgrade\Task\AbstractTask;
 use PrestaShop\Module\AutoUpgrade\Task\ExitCode;
 use PrestaShop\Module\AutoUpgrade\Task\TaskName;
@@ -75,6 +76,7 @@ class UpdateComplete extends AbstractTask
 
         // removing temporary files
         $this->container->getFileConfigurationStorage()->cleanAllUpdateFiles();
+        $this->container->getFileConfigurationStorage()->clean(UpgradeFileNames::STATE_FILENAME);
         $this->container->getAnalytics()->track('Upgrade Succeeded', Analytics::WITH_UPDATE_PROPERTIES);
 
         return ExitCode::SUCCESS;

--- a/classes/Task/Update/UpdateComplete.php
+++ b/classes/Task/Update/UpdateComplete.php
@@ -29,7 +29,6 @@ namespace PrestaShop\Module\AutoUpgrade\Task\Update;
 
 use Exception;
 use PrestaShop\Module\AutoUpgrade\Analytics;
-use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeFileNames;
 use PrestaShop\Module\AutoUpgrade\Task\AbstractTask;
 use PrestaShop\Module\AutoUpgrade\Task\ExitCode;
 use PrestaShop\Module\AutoUpgrade\Task\TaskName;

--- a/classes/Task/Update/UpdateComplete.php
+++ b/classes/Task/Update/UpdateComplete.php
@@ -76,7 +76,6 @@ class UpdateComplete extends AbstractTask
 
         // removing temporary files
         $this->container->getFileConfigurationStorage()->cleanAllUpdateFiles();
-        $this->container->getFileConfigurationStorage()->clean(UpgradeFileNames::STATE_FILENAME);
         $this->container->getAnalytics()->track('Upgrade Succeeded', Analytics::WITH_UPDATE_PROPERTIES);
 
         return ExitCode::SUCCESS;

--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -574,7 +574,8 @@ class UpgradeContainer
             return $this->state;
         }
 
-        $this->state = new State();
+        $this->state = new State($this->getFileConfigurationStorage());
+        $this->state->load();
 
         return $this->state;
     }

--- a/controllers/admin/AdminSelfUpgradeController.php
+++ b/controllers/admin/AdminSelfUpgradeController.php
@@ -297,10 +297,13 @@ class AdminSelfUpgradeController extends ModuleAdminController
             $this->upgradeContainer->getFileConfigurationStorage()->cleanAllUpdateFiles();
         }
 
-        $this->upgradeContainer->getState()->initDefault(
-            $this->upgradeContainer->getProperty(UpgradeContainer::PS_VERSION),
-            $this->upgradeContainer->getUpgrader()->getDestinationVersion()
-        );
+        if (!$this->upgradeContainer->getState()->isInitialized()) {
+            $this->upgradeContainer->getState()->initDefault(
+                $this->upgradeContainer->getProperty(UpgradeContainer::PS_VERSION),
+                $this->upgradeContainer->getUpgrader()->getDestinationVersion()
+            );
+        }
+
 
         // If you have defined this somewhere, you know what you do
         // load options from configuration if we're not in ajax mode

--- a/controllers/admin/AdminSelfUpgradeController.php
+++ b/controllers/admin/AdminSelfUpgradeController.php
@@ -304,7 +304,6 @@ class AdminSelfUpgradeController extends ModuleAdminController
             );
         }
 
-
         // If you have defined this somewhere, you know what you do
         // load options from configuration if we're not in ajax mode
         if (!$this->ajax) {

--- a/controllers/admin/AdminSelfUpgradeController.php
+++ b/controllers/admin/AdminSelfUpgradeController.php
@@ -292,12 +292,15 @@ class AdminSelfUpgradeController extends ModuleAdminController
             empty($_REQUEST['params']) ? [] : $_REQUEST['params']
         );
 
-        if (!$this->upgradeContainer->getState()->isInitialized()) {
-            $this->upgradeContainer->getState()->initDefault(
-                $this->upgradeContainer->getProperty(UpgradeContainer::PS_VERSION),
-                $this->upgradeContainer->getUpgrader()->getDestinationVersion()
-            );
+        if (!$this->ajax) {
+            // removing temporary files before init state to make sure state is already available
+            $this->upgradeContainer->getFileConfigurationStorage()->cleanAllUpdateFiles();
         }
+
+        $this->upgradeContainer->getState()->initDefault(
+            $this->upgradeContainer->getProperty(UpgradeContainer::PS_VERSION),
+            $this->upgradeContainer->getUpgrader()->getDestinationVersion()
+        );
 
         // If you have defined this somewhere, you know what you do
         // load options from configuration if we're not in ajax mode
@@ -315,8 +318,6 @@ class AdminSelfUpgradeController extends ModuleAdminController
                 $upgrader->clearXmlMd5File($upgrader->getDestinationVersion());
                 Tools14::redirectAdmin(self::$currentIndex . '&conf=5&token=' . Tools14::getValue('token'));
             }
-            // removing temporary files
-            $this->upgradeContainer->getFileConfigurationStorage()->cleanAllUpdateFiles();
         }
     }
 

--- a/controllers/admin/self-managed/AbstractGlobalController.php
+++ b/controllers/admin/self-managed/AbstractGlobalController.php
@@ -45,25 +45,6 @@ abstract class AbstractGlobalController
     {
         $this->upgradeContainer = $upgradeContainer;
         $this->request = $request;
-
-        $state = $this->upgradeContainer->getState();
-
-        if (!$this->upgradeContainer->getFileConfigurationStorage()->exists(UpgradeFileNames::STATE_FILENAME)) {
-            try {
-                $currentVersion = $this->upgradeContainer->getProperty(UpgradeContainer::PS_VERSION);
-                $destinationVersion = $this->upgradeContainer->getUpgrader()->getDestinationVersion();
-                $state->initDefault(
-                    $currentVersion,
-                    $destinationVersion
-                );
-                $this->upgradeContainer->getFileConfigurationStorage()->save($state->export(), UpgradeFileNames::STATE_FILENAME);
-            } catch (\Exception $e) {
-                return AjaxResponseBuilder::errorResponse($e, 500);
-            }
-        } else {
-            $importedState = $this->upgradeContainer->getFileConfigurationStorage()->load(UpgradeFileNames::STATE_FILENAME);
-            $state->importFromArray($importedState);
-        }
     }
 
     protected function getTwig()

--- a/controllers/admin/self-managed/AbstractGlobalController.php
+++ b/controllers/admin/self-managed/AbstractGlobalController.php
@@ -27,8 +27,6 @@
 
 namespace PrestaShop\Module\AutoUpgrade\Controller;
 
-use PrestaShop\Module\AutoUpgrade\AjaxResponseBuilder;
-use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeFileNames;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;

--- a/controllers/admin/self-managed/UpdatePageVersionChoiceController.php
+++ b/controllers/admin/self-managed/UpdatePageVersionChoiceController.php
@@ -52,8 +52,8 @@ class UpdatePageVersionChoiceController extends AbstractPageController
         UpgradeConfiguration::ARCHIVE_XML => UpgradeConfiguration::ARCHIVE_XML,
     ];
     const FORM_OPTIONS = [
-        'online_value' => Upgrader::CHANNEL_ONLINE,
-        'local_value' => Upgrader::CHANNEL_LOCAL,
+        'online_value' => UpgradeConfiguration::CHANNEL_ONLINE,
+        'local_value' => UpgradeConfiguration::CHANNEL_LOCAL,
     ];
 
     protected function getPageTemplate(): string

--- a/controllers/admin/self-managed/UpdatePageVersionChoiceController.php
+++ b/controllers/admin/self-managed/UpdatePageVersionChoiceController.php
@@ -37,7 +37,6 @@ use PrestaShop\Module\AutoUpgrade\Services\PhpVersionResolverService;
 use PrestaShop\Module\AutoUpgrade\Twig\PageSelectors;
 use PrestaShop\Module\AutoUpgrade\Twig\UpdateSteps;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
-use PrestaShop\Module\AutoUpgrade\Upgrader;
 use PrestaShop\Module\AutoUpgrade\UpgradeSelfCheck;
 use PrestaShop\Module\AutoUpgrade\VersionUtils;
 use Symfony\Component\HttpFoundation\JsonResponse;

--- a/controllers/admin/self-managed/UpdatePageVersionChoiceController.php
+++ b/controllers/admin/self-managed/UpdatePageVersionChoiceController.php
@@ -217,6 +217,8 @@ class UpdatePageVersionChoiceController extends AbstractPageController
             $config->merge($requestConfig);
 
             $this->upgradeContainer->getUpgradeConfigurationStorage()->save($config, UpgradeFileNames::CONFIG_FILENAME);
+            $state = $this->upgradeContainer->getState()->setDestinationVersion($this->upgradeContainer->getUpgrader()->getDestinationVersion());
+            $state->save();
 
             if ($channel !== null) {
                 $params[$channel . '_requirements'] = $this->getRequirements();

--- a/tests/unit/AnalyticsTest.php
+++ b/tests/unit/AnalyticsTest.php
@@ -25,6 +25,7 @@
  */
 use PHPUnit\Framework\TestCase;
 use PrestaShop\Module\AutoUpgrade\Analytics;
+use PrestaShop\Module\AutoUpgrade\Parameters\FileConfigurationStorage;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\State;
 
@@ -32,7 +33,10 @@ class AnalyticsTest extends TestCase
 {
     public function testProperties()
     {
-        $state = (new State())
+        $fixturesDir = __DIR__ . '/../../fixtures/config/';
+        $fileStorage = new FileConfigurationStorage($fixturesDir);
+
+        $state = (new State($fileStorage))
             ->setCurrentVersion('8.8.8')
             ->setDestinationVersion('8.8.808')
             ->setRestoreName('V1.2.3_blablabla-🐶');

--- a/tests/unit/StateTest.php
+++ b/tests/unit/StateTest.php
@@ -24,8 +24,8 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
 use PHPUnit\Framework\TestCase;
+use PrestaShop\Module\AutoUpgrade\Parameters\FileConfigurationStorage;
 use PrestaShop\Module\AutoUpgrade\State;
-use PrestaShop\Module\AutoUpgrade\FileConfigurationStorage;
 
 class StateTest extends TestCase
 {
@@ -52,9 +52,9 @@ class StateTest extends TestCase
     public function testClassReceivesProperty()
     {
         $this->state->importFromArray(['backupName' => 'doge']);
-        $exported =  $this->state->export();
+        $exported = $this->state->export();
 
-        $this->assertSame('doge',  $this->state->getBackupName());
+        $this->assertSame('doge', $this->state->getBackupName());
         $this->assertSame('doge', $exported['backupName']);
     }
 
@@ -64,7 +64,7 @@ class StateTest extends TestCase
             'wow' => 'epic',
             'backupName' => 'doge',
         ]);
-        $exported =  $this->state->export();
+        $exported = $this->state->export();
 
         $this->assertArrayNotHasKey('wow', $exported);
         $this->assertSame('doge', $exported['backupName']);
@@ -88,7 +88,7 @@ class StateTest extends TestCase
         $this->state->importFromEncodedData($encodedData);
         $exported = $this->state->export();
 
-        $this->assertSame('doge',  $this->state->getBackupName());
+        $this->assertSame('doge', $this->state->getBackupName());
         $this->assertSame('doge', $exported['backupName']);
     }
 
@@ -109,13 +109,13 @@ class StateTest extends TestCase
 
     public function testProgressionValue()
     {
-        $this->assertSame(null,  $this->state->getProgressPercentage());
+        $this->assertSame(null, $this->state->getProgressPercentage());
 
         $this->state->setProgressPercentage(0);
-        $this->assertSame(0,  $this->state->getProgressPercentage());
+        $this->assertSame(0, $this->state->getProgressPercentage());
 
         $this->state->setProgressPercentage(55);
-        $this->assertSame(55,  $this->state->getProgressPercentage());
+        $this->assertSame(55, $this->state->getProgressPercentage());
 
         // Percentage cannot go down, an exception will be thrown
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | the version choice page should load very quickly and the requirements check only runs once on the page. Requirements should only be displayed if there are no errors in our form. This also allows errors to be displayed if present when loading the page (at the end of the API call), which was not the case before.
| Type?             | improvement / refactor
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | @PrestaShopCorp
| How to test?      | Multiple thing to test see bellow.

## Test Cases

### Fast Loading of the Version Choice Page:
**Objective:** Ensure the page loads quickly and that the requirements checks do not slow down the initial load.

**Steps:**
- Access the version choice page.
- Measure the loading time until the page is fully displayed.  

**Expected Result:** The page should load without excessive latency, and the requirements checks should not affect loading speed.

### Single Execution of Requirements Check:

**Objective:** Verify that the requirements checks run only once per page load session.

**Steps:**
- Reload the version choice page.
- Confirm that the requirements check only runs once during the initial page load.  

**Expected Result:** The requirements check should execute only once, without repetition.

### Conditional Display of Requirements:

**Objective:** Confirm that requirements are displayed only if there are no errors in the form.

**Steps:**
- Load the version choice page with a form containing no errors.
- Load the version choice page with a form containing errors.

**Expected Result:**
- If the form is valid (no errors): Requirements should be displayed.
- If errors are present in the form: Requirements should not be displayed.

### Error Display After Page Load:

**Objective:** Ensure that errors are displayed if detected at the end of the API call, even after the page has already loaded.

**Steps:**
- Load the page with a form that contains errors detected after the API call completes.

**Expected Result:** Errors should be visible to the user after the page fully loads, following the completion of the API call.
