### PR TITLE
Update icon

### DIFF
--- a/autoupgrade.php
+++ b/autoupgrade.php
@@ -89,7 +89,7 @@ class Autoupgrade extends Module
         if (!Tab::getIdFromClassName('AdminSelfUpgrade')) {
             $tab = new Tab();
             $tab->class_name = 'AdminSelfUpgrade';
-            $tab->icon = 'upgrade';
+            $tab->icon = 'arrow_upward';
             $tab->module = 'autoupgrade';
 
             // We use DEFAULT to add Upgrade tab as a standalone tab in the back office menu

--- a/upgrade/upgrade-7.0.0.php
+++ b/upgrade/upgrade-7.0.0.php
@@ -38,13 +38,14 @@ function upgrade_module_7_0_0($module)
     $id_tab = \Tab::getIdFromClassName('AdminSelfUpgrade');
     if ($id_tab) {
         $tab = new \Tab($id_tab);
+        $tab->icon = 'arrow_upward';
     } else {
         // If the tab doesn't exist, create it
         $tab = new \Tab();
         $tab->class_name = 'AdminSelfUpgrade';
         $tab->module = 'autoupgrade';
         $tab->id_parent = (int) \Tab::getIdFromClassName('CONFIGURE');
-        $tab->icon = 'upgrade';
+        $tab->icon = 'arrow_upward';
     }
 
     foreach (\Language::getLanguages(false) as $lang) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | the current icon causes a problem on versions 1.7, the current behavior makes the icon "grade" which is a star, and adds empty content before the icon, which corresponds to the "up" content. See https://mui.com/material-ui/material-icons/?query=grade+
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #https://github.com/PrestaShop/PrestaShop/issues/36803
| Sponsor company   | -
| How to test?      | -
