### PR TITLE
[NEW UI] Added configuration key constants

### DIFF
--- a/classes/Commands/UpdateCommand.php
+++ b/classes/Commands/UpdateCommand.php
@@ -29,6 +29,7 @@ namespace PrestaShop\Module\AutoUpgrade\Commands;
 
 use Exception;
 use PrestaShop\Module\AutoUpgrade\DeveloperDocumentation;
+use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\Task\ExitCode;
 use PrestaShop\Module\AutoUpgrade\Task\Runner\AllUpdateTasks;
 use Symfony\Component\Console\Input\InputArgument;
@@ -54,7 +55,7 @@ class UpdateCommand extends AbstractCommand
             ->addArgument('admin-dir', InputArgument::REQUIRED, 'The admin directory name.')
             ->addOption('chain', null, InputOption::VALUE_NONE, 'True by default. Allows you to chain update commands automatically. The command will continue executing subsequent tasks without requiring manual intervention to restart the process.')
             ->addOption('no-chain', null, InputOption::VALUE_NONE, 'Prevents chaining of update commands. The command will execute a task and then stop, logging the next command that needs to be run. You will need to manually restart the process to continue with the next step.')
-            ->addOption('channel', null, InputOption::VALUE_REQUIRED, "Selects what update to run ('local' / 'online')")
+            ->addOption(UpgradeConfiguration::CHANNEL, null, InputOption::VALUE_REQUIRED, "Selects what update to run ('local' / 'online')")
             ->addOption('config-file-path', null, InputOption::VALUE_REQUIRED, 'Configuration file location for update.')
             ->addOption('action', null, InputOption::VALUE_REQUIRED, 'Advanced users only. Sets the step you want to start from (Default: UpgradeNow, see ' . DeveloperDocumentation::DEV_DOC_UPGRADE_CLI_URL . ' for other values available)')
             ->addOption('data', null, InputOption::VALUE_REQUIRED, 'Advanced users only. Contains the state of the update process encoded in base64');
@@ -93,7 +94,7 @@ class UpdateCommand extends AbstractCommand
             $controller->setOptions([
                 'data' => $input->getOption('data'),
                 'action' => $input->getOption('action'),
-                'channel' => $input->getOption('channel'),
+                UpgradeConfiguration::CHANNEL => $input->getOption(UpgradeConfiguration::CHANNEL),
             ]);
             $controller->init();
             $exitCode = $controller->run();

--- a/classes/Commands/UpdateCommand.php
+++ b/classes/Commands/UpdateCommand.php
@@ -55,7 +55,7 @@ class UpdateCommand extends AbstractCommand
             ->addArgument('admin-dir', InputArgument::REQUIRED, 'The admin directory name.')
             ->addOption('chain', null, InputOption::VALUE_NONE, 'True by default. Allows you to chain update commands automatically. The command will continue executing subsequent tasks without requiring manual intervention to restart the process.')
             ->addOption('no-chain', null, InputOption::VALUE_NONE, 'Prevents chaining of update commands. The command will execute a task and then stop, logging the next command that needs to be run. You will need to manually restart the process to continue with the next step.')
-            ->addOption(UpgradeConfiguration::CHANNEL, null, InputOption::VALUE_REQUIRED, "Selects what update to run ('local' / 'online')")
+            ->addOption('channel', null, InputOption::VALUE_REQUIRED, "Selects what update to run ('local' / 'online')")
             ->addOption('config-file-path', null, InputOption::VALUE_REQUIRED, 'Configuration file location for update.')
             ->addOption('action', null, InputOption::VALUE_REQUIRED, 'Advanced users only. Sets the step you want to start from (Default: UpgradeNow, see ' . DeveloperDocumentation::DEV_DOC_UPGRADE_CLI_URL . ' for other values available)')
             ->addOption('data', null, InputOption::VALUE_REQUIRED, 'Advanced users only. Contains the state of the update process encoded in base64');

--- a/classes/Commands/UpdateCommand.php
+++ b/classes/Commands/UpdateCommand.php
@@ -94,7 +94,7 @@ class UpdateCommand extends AbstractCommand
             $controller->setOptions([
                 'data' => $input->getOption('data'),
                 'action' => $input->getOption('action'),
-                UpgradeConfiguration::CHANNEL => $input->getOption(UpgradeConfiguration::CHANNEL),
+                UpgradeConfiguration::CHANNEL => $input->getOption('channel'),
             ]);
             $controller->init();
             $exitCode = $controller->run();

--- a/classes/Parameters/ConfigurationValidator.php
+++ b/classes/Parameters/ConfigurationValidator.php
@@ -51,23 +51,23 @@ class ConfigurationValidator
     {
         $errors = [];
 
-        $isLocal = isset($array['channel']) && $array['channel'] === Upgrader::CHANNEL_LOCAL;
+        $isLocal = isset($array[UpgradeConfiguration::CHANNEL]) && $array[UpgradeConfiguration::CHANNEL] === Upgrader::CHANNEL_LOCAL;
 
         foreach ($array as $key => $value) {
             switch ($key) {
-                case 'channel':
+                case UpgradeConfiguration::CHANNEL:
                     $error = $this->validateChannel($value);
                     break;
-                case 'archive_zip':
+                case UpgradeConfiguration::ARCHIVE_ZIP:
                     $error = $this->validateArchiveZip($value, $isLocal);
                     break;
-                case 'archive_xml':
+                case UpgradeConfiguration::ARCHIVE_XML:
                     $error = $this->validateArchiveXml($value, $isLocal);
                     break;
-                case 'PS_AUTOUP_CUSTOM_MOD_DESACT':
-                case 'PS_AUTOUP_KEEP_MAILS':
-                case 'PS_AUTOUP_KEEP_IMAGES':
-                case 'PS_DISABLE_OVERRIDES':
+                case UpgradeConfiguration::PS_AUTOUP_CUSTOM_MOD_DESACT :
+                case UpgradeConfiguration::PS_AUTOUP_KEEP_MAILS:
+                case UpgradeConfiguration::PS_AUTOUP_KEEP_IMAGES:
+                case UpgradeConfiguration::PS_DISABLE_OVERRIDES:
                     $error = $this->validateBool($value, $key);
                     break;
             }

--- a/classes/Parameters/ConfigurationValidator.php
+++ b/classes/Parameters/ConfigurationValidator.php
@@ -64,7 +64,7 @@ class ConfigurationValidator
                 case UpgradeConfiguration::ARCHIVE_XML:
                     $error = $this->validateArchiveXml($value, $isLocal);
                     break;
-                case UpgradeConfiguration::PS_AUTOUP_CUSTOM_MOD_DESACT :
+                case UpgradeConfiguration::PS_AUTOUP_CUSTOM_MOD_DESACT:
                 case UpgradeConfiguration::PS_AUTOUP_KEEP_MAILS:
                 case UpgradeConfiguration::PS_AUTOUP_KEEP_IMAGES:
                 case UpgradeConfiguration::PS_DISABLE_OVERRIDES:

--- a/classes/Parameters/LocalChannelConfigurationValidator.php
+++ b/classes/Parameters/LocalChannelConfigurationValidator.php
@@ -77,12 +77,12 @@ class LocalChannelConfigurationValidator
 
         $errors = [];
 
-        $zipErrors = $this->validateZipFile($array['archive_zip']);
+        $zipErrors = $this->validateZipFile($array[UpgradeConfiguration::ARCHIVE_ZIP]);
         if ($zipErrors) {
             $errors[] = $zipErrors;
         }
 
-        $xmlErrors = $this->validateXmlFile($array['archive_xml']);
+        $xmlErrors = $this->validateXmlFile($array[UpgradeConfiguration::ARCHIVE_XML]);
         if ($xmlErrors) {
             $errors[] = $xmlErrors;
         }
@@ -107,7 +107,7 @@ class LocalChannelConfigurationValidator
         if (!file_exists($fullFilePath)) {
             return [
                 'message' => $this->translator->trans('File %s does not exist. Unable to select that channel.', [$file]),
-                'target' => 'archive_zip',
+                'target' => UpgradeConfiguration::ARCHIVE_ZIP,
             ];
         }
 
@@ -116,7 +116,7 @@ class LocalChannelConfigurationValidator
         } catch (Exception $exception) {
             return [
                 'message' => $this->translator->trans('We couldn\'t find a PrestaShop version in the .zip file that was uploaded in your local archive. Please try again.'),
-                'target' => 'archive_zip',
+                'target' => UpgradeConfiguration::ARCHIVE_ZIP,
             ];
         }
 
@@ -133,7 +133,7 @@ class LocalChannelConfigurationValidator
         if (!file_exists($fullXmlPath)) {
             return [
                 'message' => $this->translator->trans('File %s does not exist. Unable to select that channel.', [$file]),
-                'target' => 'archive_xml',
+                'target' => UpgradeConfiguration::ARCHIVE_XML,
             ];
         }
 
@@ -142,7 +142,7 @@ class LocalChannelConfigurationValidator
         } catch (Exception $exception) {
             return [
                 'message' => $this->translator->trans('We couldn\'t find a PrestaShop version in the XML file that was uploaded in your local archive. Please try again.'),
-                'target' => 'archive_xml',
+                'target' => UpgradeConfiguration::ARCHIVE_XML,
             ];
         }
 

--- a/classes/Parameters/UpgradeConfiguration.php
+++ b/classes/Parameters/UpgradeConfiguration.php
@@ -119,6 +119,7 @@ class UpgradeConfiguration extends ArrayCollection
 
     /**
      * Get channel selected on config panel (Minor, major ...).
+     * @return Upgrader::CHANNEL_*|null
      */
     public function getChannel(): ?string
     {

--- a/classes/Parameters/UpgradeConfiguration.php
+++ b/classes/Parameters/UpgradeConfiguration.php
@@ -119,6 +119,7 @@ class UpgradeConfiguration extends ArrayCollection
 
     /**
      * Get channel selected on config panel (Minor, major ...).
+     *
      * @return Upgrader::CHANNEL_*|null
      */
     public function getChannel(): ?string

--- a/classes/Parameters/UpgradeConfiguration.php
+++ b/classes/Parameters/UpgradeConfiguration.php
@@ -40,25 +40,36 @@ use UnexpectedValueException;
  */
 class UpgradeConfiguration extends ArrayCollection
 {
+    const PS_AUTOUP_CUSTOM_MOD_DESACT = 'PS_AUTOUP_CUSTOM_MOD_DESACT';
+    const PS_AUTOUP_CHANGE_DEFAULT_THEME = 'PS_AUTOUP_CHANGE_DEFAULT_THEME';
+    const PS_AUTOUP_KEEP_MAILS = 'PS_AUTOUP_KEEP_MAILS';
+    const PS_AUTOUP_BACKUP = 'PS_AUTOUP_BACKUP';
+    const PS_AUTOUP_KEEP_IMAGES = 'PS_AUTOUP_KEEP_IMAGES';
+    const PS_DISABLE_OVERRIDES = 'PS_DISABLE_OVERRIDES';
+    const CHANNEL = 'channel';
+    const ARCHIVE_ZIP = 'archive_zip';
+    const ARCHIVE_XML = 'archive_xml';
+    const ARCHIVE_VERSION_NUM = 'archive_version_num';
+
     const UPGRADE_CONST_KEYS = [
-        'PS_AUTOUP_CUSTOM_MOD_DESACT',
-        'PS_AUTOUP_CHANGE_DEFAULT_THEME',
-        'PS_AUTOUP_KEEP_MAILS',
-        'PS_AUTOUP_BACKUP',
-        'PS_AUTOUP_KEEP_IMAGES',
-        'PS_DISABLE_OVERRIDES',
-        'channel',
-        'archive_zip',
-        'archive_xml',
-        'archive_version_num',
+        self::PS_AUTOUP_CUSTOM_MOD_DESACT,
+        self::PS_AUTOUP_CHANGE_DEFAULT_THEME,
+        self::PS_AUTOUP_KEEP_MAILS,
+        self::PS_AUTOUP_BACKUP,
+        self::PS_AUTOUP_KEEP_IMAGES,
+        self::PS_DISABLE_OVERRIDES,
+        self::CHANNEL,
+        self::ARCHIVE_ZIP,
+        self::ARCHIVE_XML,
+        self::ARCHIVE_VERSION_NUM,
     ];
 
     const PS_CONST_DEFAULT_VALUE = [
-        'PS_AUTOUP_CUSTOM_MOD_DESACT' => true,
-        'PS_AUTOUP_CHANGE_DEFAULT_THEME' => false,
-        'PS_AUTOUP_KEEP_MAILS' => false,
-        'PS_AUTOUP_BACKUP' => true,
-        'PS_AUTOUP_KEEP_IMAGES' => true,
+        self::PS_AUTOUP_CUSTOM_MOD_DESACT => true,
+        self::PS_AUTOUP_CHANGE_DEFAULT_THEME => false,
+        self::PS_AUTOUP_KEEP_MAILS => false,
+        self::PS_AUTOUP_BACKUP => true,
+        self::PS_AUTOUP_KEEP_IMAGES => true,
     ];
 
     const DEFAULT_CHANNEL = Upgrader::CHANNEL_ONLINE;
@@ -81,7 +92,7 @@ class UpgradeConfiguration extends ArrayCollection
      */
     public function getLocalChannelZip(): ?string
     {
-        return $this->get('archive_zip');
+        return $this->get(self::ARCHIVE_ZIP);
     }
 
     public function getChannelZip(): ?string
@@ -95,7 +106,7 @@ class UpgradeConfiguration extends ArrayCollection
 
     public function getLocalChannelXml(): ?string
     {
-        return $this->get('archive_xml');
+        return $this->get(self::ARCHIVE_XML);
     }
 
     /**
@@ -103,7 +114,7 @@ class UpgradeConfiguration extends ArrayCollection
      */
     public function getLocalChannelVersion(): ?string
     {
-        return $this->get('archive_version_num');
+        return $this->get(self::ARCHIVE_VERSION_NUM);
     }
 
     /**
@@ -111,7 +122,7 @@ class UpgradeConfiguration extends ArrayCollection
      */
     public function getChannel(): ?string
     {
-        return $this->get('channel');
+        return $this->get(self::CHANNEL);
     }
 
     /**
@@ -148,7 +159,7 @@ class UpgradeConfiguration extends ArrayCollection
 
     public function shouldBackupFilesAndDatabase(): bool
     {
-        return $this->computeBooleanConfiguration('PS_AUTOUP_BACKUP');
+        return $this->computeBooleanConfiguration(self::PS_AUTOUP_BACKUP);
     }
 
     /**
@@ -156,7 +167,7 @@ class UpgradeConfiguration extends ArrayCollection
      */
     public function shouldBackupImages(): bool
     {
-        return $this->computeBooleanConfiguration('PS_AUTOUP_KEEP_IMAGES');
+        return $this->computeBooleanConfiguration(self::PS_AUTOUP_KEEP_IMAGES);
     }
 
     /**
@@ -164,7 +175,7 @@ class UpgradeConfiguration extends ArrayCollection
      */
     public function shouldDeactivateCustomModules(): bool
     {
-        return $this->computeBooleanConfiguration('PS_AUTOUP_CUSTOM_MOD_DESACT');
+        return $this->computeBooleanConfiguration(self::PS_AUTOUP_CUSTOM_MOD_DESACT);
     }
 
     /**
@@ -172,7 +183,7 @@ class UpgradeConfiguration extends ArrayCollection
      */
     public function shouldKeepMails(): bool
     {
-        return $this->computeBooleanConfiguration('PS_AUTOUP_KEEP_MAILS');
+        return $this->computeBooleanConfiguration(self::PS_AUTOUP_KEEP_MAILS);
     }
 
     /**
@@ -180,7 +191,7 @@ class UpgradeConfiguration extends ArrayCollection
      */
     public function shouldSwitchToDefaultTheme(): bool
     {
-        return $this->computeBooleanConfiguration('PS_AUTOUP_CHANGE_DEFAULT_THEME');
+        return $this->computeBooleanConfiguration(self::PS_AUTOUP_CHANGE_DEFAULT_THEME);
     }
 
     private function computeBooleanConfiguration(string $const): bool
@@ -199,15 +210,15 @@ class UpgradeConfiguration extends ArrayCollection
 
     public static function isOverrideAllowed(): bool
     {
-        return (bool) Configuration::get('PS_DISABLE_OVERRIDES');
+        return (bool) Configuration::get(self::PS_DISABLE_OVERRIDES);
     }
 
     public static function updateDisabledOverride(bool $value, ?int $shopId = null): void
     {
         if ($shopId) {
-            Configuration::updateValue('PS_DISABLE_OVERRIDES', $value, false, null, (int) $shopId);
+            Configuration::updateValue(self::PS_DISABLE_OVERRIDES, $value, false, null, (int) $shopId);
         } else {
-            Configuration::updateGlobalValue('PS_DISABLE_OVERRIDES', $value);
+            Configuration::updateGlobalValue(self::PS_DISABLE_OVERRIDES, $value);
         }
     }
 

--- a/classes/Task/Miscellaneous/UpdateConfig.php
+++ b/classes/Task/Miscellaneous/UpdateConfig.php
@@ -66,14 +66,14 @@ class UpdateConfig extends AbstractTask
                 continue;
             }
             // The PS_DISABLE_OVERRIDES variable must only be updated on the database side
-            if ($key === 'PS_DISABLE_OVERRIDES') {
+            if ($key === UpgradeConfiguration::PS_DISABLE_OVERRIDES) {
                 UpgradeConfiguration::updatePSDisableOverrides((bool) $configurationData[$key]);
             } else {
                 $config[$key] = $configurationData[$key];
             }
         }
 
-        $isLocal = $config['channel'] === Upgrader::CHANNEL_LOCAL;
+        $isLocal = $config[UpgradeConfiguration::CHANNEL] === Upgrader::CHANNEL_LOCAL;
 
         $error = $this->container->getConfigurationValidator()->validate($config);
 
@@ -89,7 +89,7 @@ class UpdateConfig extends AbstractTask
         }
 
         if ($isLocal) {
-            $file = $config['archive_zip'];
+            $file = $config[UpgradeConfiguration::ARCHIVE_ZIP];
             $fullFilePath = $this->container->getProperty(UpgradeContainer::DOWNLOAD_PATH) . DIRECTORY_SEPARATOR . $file;
             try {
                 $config['archive_version_num'] = $this->container->getPrestashopVersionService()->extractPrestashopVersionFromZip($fullFilePath);

--- a/classes/Task/Runner/AllUpdateTasks.php
+++ b/classes/Task/Runner/AllUpdateTasks.php
@@ -29,6 +29,7 @@ namespace PrestaShop\Module\AutoUpgrade\Task\Runner;
 
 use Exception;
 use PrestaShop\Module\AutoUpgrade\AjaxResponse;
+use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\Task\TaskName;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 use UnexpectedValueException;
@@ -62,9 +63,9 @@ class AllUpdateTasks extends ChainedTasks
             $this->step = $options['action'];
         }
 
-        if (!empty($options['channel'])) {
+        if (!empty($options[UpgradeConfiguration::CHANNEL])) {
             $config = [
-                'channel' => $options['channel'],
+                UpgradeConfiguration::CHANNEL => $options[UpgradeConfiguration::CHANNEL],
             ];
             $error = $this->container->getConfigurationValidator()->validate($config);
 

--- a/classes/Task/Update/UpdateComplete.php
+++ b/classes/Task/Update/UpdateComplete.php
@@ -29,7 +29,6 @@ namespace PrestaShop\Module\AutoUpgrade\Task\Update;
 
 use Exception;
 use PrestaShop\Module\AutoUpgrade\Analytics;
-use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\Task\AbstractTask;
 use PrestaShop\Module\AutoUpgrade\Task\ExitCode;
 use PrestaShop\Module\AutoUpgrade\Task\TaskName;

--- a/classes/Task/Update/UpdateComplete.php
+++ b/classes/Task/Update/UpdateComplete.php
@@ -68,7 +68,7 @@ class UpdateComplete extends AbstractTask
             $this->logger->debug('<strong>' . $this->translator->trans('Please remove %s by FTP', [$this->container->getFilePath()]) . '</strong>');
         }
 
-        if ($this->container->getUpgradeConfiguration()->getChannel() != 'directory' && file_exists($this->container->getProperty(UpgradeContainer::LATEST_PATH)) && FilesystemAdapter::deleteDirectory($this->container->getProperty(UpgradeContainer::LATEST_PATH))) {
+        if (file_exists($this->container->getProperty(UpgradeContainer::LATEST_PATH)) && FilesystemAdapter::deleteDirectory($this->container->getProperty(UpgradeContainer::LATEST_PATH))) {
             $this->logger->debug($this->translator->trans('%s removed', [$this->container->getProperty(UpgradeContainer::LATEST_PATH)]));
         } elseif (is_dir($this->container->getProperty(UpgradeContainer::LATEST_PATH))) {
             $this->logger->debug('<strong>' . $this->translator->trans('Please remove %s by FTP', [$this->container->getProperty(UpgradeContainer::LATEST_PATH)]) . '</strong>');

--- a/classes/Task/Update/UpdateComplete.php
+++ b/classes/Task/Update/UpdateComplete.php
@@ -29,6 +29,7 @@ namespace PrestaShop\Module\AutoUpgrade\Task\Update;
 
 use Exception;
 use PrestaShop\Module\AutoUpgrade\Analytics;
+use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\Task\AbstractTask;
 use PrestaShop\Module\AutoUpgrade\Task\ExitCode;
 use PrestaShop\Module\AutoUpgrade\Task\TaskName;
@@ -62,13 +63,13 @@ class UpdateComplete extends AbstractTask
 
         $this->next = TaskName::TASK_COMPLETE;
 
-        if ($this->container->getUpgradeConfiguration()->get('channel') != Upgrader::CHANNEL_LOCAL && file_exists($this->container->getFilePath()) && unlink($this->container->getFilePath())) {
+        if ($this->container->getUpgradeConfiguration()->get(UpgradeConfiguration::CHANNEL) != Upgrader::CHANNEL_LOCAL && file_exists($this->container->getFilePath()) && unlink($this->container->getFilePath())) {
             $this->logger->debug($this->translator->trans('%s removed', [$this->container->getFilePath()]));
         } elseif (is_file($this->container->getFilePath())) {
             $this->logger->debug('<strong>' . $this->translator->trans('Please remove %s by FTP', [$this->container->getFilePath()]) . '</strong>');
         }
 
-        if ($this->container->getUpgradeConfiguration()->get('channel') != 'directory' && file_exists($this->container->getProperty(UpgradeContainer::LATEST_PATH)) && FilesystemAdapter::deleteDirectory($this->container->getProperty(UpgradeContainer::LATEST_PATH))) {
+        if ($this->container->getUpgradeConfiguration()->get(UpgradeConfiguration::CHANNEL) != 'directory' && file_exists($this->container->getProperty(UpgradeContainer::LATEST_PATH)) && FilesystemAdapter::deleteDirectory($this->container->getProperty(UpgradeContainer::LATEST_PATH))) {
             $this->logger->debug($this->translator->trans('%s removed', [$this->container->getProperty(UpgradeContainer::LATEST_PATH)]));
         } elseif (is_dir($this->container->getProperty(UpgradeContainer::LATEST_PATH))) {
             $this->logger->debug('<strong>' . $this->translator->trans('Please remove %s by FTP', [$this->container->getProperty(UpgradeContainer::LATEST_PATH)]) . '</strong>');

--- a/classes/Task/Update/UpdateComplete.php
+++ b/classes/Task/Update/UpdateComplete.php
@@ -63,13 +63,13 @@ class UpdateComplete extends AbstractTask
 
         $this->next = TaskName::TASK_COMPLETE;
 
-        if ($this->container->getUpgradeConfiguration()->get(UpgradeConfiguration::CHANNEL) != Upgrader::CHANNEL_LOCAL && file_exists($this->container->getFilePath()) && unlink($this->container->getFilePath())) {
+        if ($this->container->getUpgradeConfiguration()->getChannel() != Upgrader::CHANNEL_LOCAL && file_exists($this->container->getFilePath()) && unlink($this->container->getFilePath())) {
             $this->logger->debug($this->translator->trans('%s removed', [$this->container->getFilePath()]));
         } elseif (is_file($this->container->getFilePath())) {
             $this->logger->debug('<strong>' . $this->translator->trans('Please remove %s by FTP', [$this->container->getFilePath()]) . '</strong>');
         }
 
-        if ($this->container->getUpgradeConfiguration()->get(UpgradeConfiguration::CHANNEL) != 'directory' && file_exists($this->container->getProperty(UpgradeContainer::LATEST_PATH)) && FilesystemAdapter::deleteDirectory($this->container->getProperty(UpgradeContainer::LATEST_PATH))) {
+        if ($this->container->getUpgradeConfiguration()->getChannel() != 'directory' && file_exists($this->container->getProperty(UpgradeContainer::LATEST_PATH)) && FilesystemAdapter::deleteDirectory($this->container->getProperty(UpgradeContainer::LATEST_PATH))) {
             $this->logger->debug($this->translator->trans('%s removed', [$this->container->getProperty(UpgradeContainer::LATEST_PATH)]));
         } elseif (is_dir($this->container->getProperty(UpgradeContainer::LATEST_PATH))) {
             $this->logger->debug('<strong>' . $this->translator->trans('Please remove %s by FTP', [$this->container->getProperty(UpgradeContainer::LATEST_PATH)]) . '</strong>');

--- a/classes/Twig/Form/BackupOptionsForm.php
+++ b/classes/Twig/Form/BackupOptionsForm.php
@@ -27,6 +27,7 @@
 
 namespace PrestaShop\Module\AutoUpgrade\Twig\Form;
 
+use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator;
 
 class BackupOptionsForm
@@ -52,7 +53,7 @@ class BackupOptionsForm
         $this->formRenderer = $formRenderer;
 
         $this->fields = [
-            'PS_AUTOUP_BACKUP' => [
+            UpgradeConfiguration::PS_AUTOUP_BACKUP => [
                 'title' => $this->translator->trans('Back up my files and database'),
                 'cast' => 'intval',
                 'validation' => 'isBool',
@@ -62,7 +63,7 @@ class BackupOptionsForm
                     'Automatically back up your database and files in order to restore your shop if needed. This is experimental: you should still perform your own manual backup for safety.'
                 ),
             ],
-            'PS_AUTOUP_KEEP_IMAGES' => [
+            UpgradeConfiguration::PS_AUTOUP_KEEP_IMAGES => [
                 'title' => $this->translator->trans(
                     'Back up my images'
                 ),

--- a/classes/Twig/Form/FormRenderer.php
+++ b/classes/Twig/Form/FormRenderer.php
@@ -73,7 +73,7 @@ class FormRenderer
             $required = !empty($field['required']);
             $disabled = !empty($field['disabled']);
 
-            if ($key === 'PS_DISABLE_OVERRIDES') {
+            if ($key === UpgradeConfiguration::PS_DISABLE_OVERRIDES) {
                 // values fetched from configuration in database
                 $val = UpgradeConfiguration::isOverrideAllowed();
             } else {

--- a/classes/Twig/Form/UpgradeOptionsForm.php
+++ b/classes/Twig/Form/UpgradeOptionsForm.php
@@ -27,6 +27,7 @@
 
 namespace PrestaShop\Module\AutoUpgrade\Twig\Form;
 
+use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator;
 
 class UpgradeOptionsForm
@@ -52,7 +53,7 @@ class UpgradeOptionsForm
         $this->formRenderer = $formRenderer;
 
         $this->fields = [
-            'PS_AUTOUP_CUSTOM_MOD_DESACT' => [
+            UpgradeConfiguration::PS_AUTOUP_CUSTOM_MOD_DESACT => [
                 'title' => $translator->trans('Disable non-native modules'),
                 'cast' => 'intval',
                 'validation' => 'isBool',
@@ -61,7 +62,7 @@ class UpgradeOptionsForm
                         'As non-native modules can experience some compatibility issues, we recommend to disable them by default.') . '<br />' .
                     $translator->trans('Keeping them enabled might prevent you from loading the "Modules" page properly after the upgrade.'),
             ],
-            'PS_DISABLE_OVERRIDES' => [
+            UpgradeConfiguration::PS_DISABLE_OVERRIDES => [
                 'title' => $translator->trans('Disable all overrides'),
                 'cast' => 'intval',
                 'validation' => 'isBool',
@@ -69,7 +70,7 @@ class UpgradeOptionsForm
                 'desc' => $translator->trans('Enable or disable all classes and controllers overrides.'),
             ],
 
-            'PS_AUTOUP_CHANGE_DEFAULT_THEME' => [
+            UpgradeConfiguration::PS_AUTOUP_CHANGE_DEFAULT_THEME => [
                 'title' => $translator->trans('Switch to the default theme'),
                 'cast' => 'intval',
                 'validation' => 'isBool',
@@ -78,7 +79,7 @@ class UpgradeOptionsForm
                 'desc' => $translator->trans('This will change your theme: your shop will then use the default theme of the version of PrestaShop you are upgrading to.'),
             ],
 
-            'PS_AUTOUP_KEEP_MAILS' => [
+            UpgradeConfiguration::PS_AUTOUP_KEEP_MAILS => [
                 'title' => $translator->trans('Keep the customized email templates'),
                 'cast' => 'intval',
                 'validation' => 'isBool',

--- a/classes/UpgradePage.php
+++ b/classes/UpgradePage.php
@@ -277,7 +277,7 @@ class UpgradePage
             'ajaxUpgradeTabExists' => file_exists($this->autoupgradePath . DIRECTORY_SEPARATOR . 'ajax-upgradetab.php'),
             'currentIndex' => $this->currentIndex,
             'tab' => 'AdminSelfUpgrade',
-            UpgradeConfiguration::CHANNEL => $this->config->get(UpgradeConfiguration::CHANNEL),
+            UpgradeConfiguration::CHANNEL => $this->config->getChannel(),
             'autoupgrade' => [
                 'version' => $this->upgradeSelfCheck->getModuleVersion(),
             ],

--- a/classes/UpgradePage.php
+++ b/classes/UpgradePage.php
@@ -269,7 +269,7 @@ class UpgradePage
         return [
             'psBaseUri' => __PS_BASE_URI__,
             '_PS_MODE_DEV_' => (defined('_PS_MODE_DEV_') && true == _PS_MODE_DEV_),
-            'PS_AUTOUP_BACKUP' => $this->config->shouldBackupFilesAndDatabase(),
+            UpgradeConfiguration::PS_AUTOUP_BACKUP => $this->config->shouldBackupFilesAndDatabase(),
             'adminDir' => $adminDir,
             'adminUrl' => __PS_BASE_URI__ . $adminDir,
             'token' => $this->token,
@@ -277,7 +277,7 @@ class UpgradePage
             'ajaxUpgradeTabExists' => file_exists($this->autoupgradePath . DIRECTORY_SEPARATOR . 'ajax-upgradetab.php'),
             'currentIndex' => $this->currentIndex,
             'tab' => 'AdminSelfUpgrade',
-            'channel' => $this->config->get('channel'),
+            UpgradeConfiguration::CHANNEL => $this->config->get(UpgradeConfiguration::CHANNEL),
             'autoupgrade' => [
                 'version' => $this->upgradeSelfCheck->getModuleVersion(),
             ],

--- a/controllers/admin/AdminSelfUpgradeController.php
+++ b/controllers/admin/AdminSelfUpgradeController.php
@@ -197,7 +197,7 @@ class AdminSelfUpgradeController extends ModuleAdminController
     private function _setFields()
     {
         $this->_fieldsBackupOptions = [
-            'PS_AUTOUP_BACKUP' => [
+            UpgradeConfiguration::PS_AUTOUP_BACKUP => [
                 'title' => $this->trans('Back up my files and database'),
                 'cast' => 'intval',
                 'validation' => 'isBool',
@@ -205,7 +205,7 @@ class AdminSelfUpgradeController extends ModuleAdminController
                 'type' => 'bool',
                 'desc' => $this->trans('Automatically back up your database and files in order to restore your shop if needed. This is experimental: you should still perform your own manual backup for safety.'),
             ],
-            'PS_AUTOUP_KEEP_IMAGES' => [
+            UpgradeConfiguration::PS_AUTOUP_KEEP_IMAGES => [
                 'title' => $this->trans('Back up my images'),
                 'cast' => 'intval',
                 'validation' => 'isBool',
@@ -215,7 +215,7 @@ class AdminSelfUpgradeController extends ModuleAdminController
             ],
         ];
         $this->_fieldsUpgradeOptions = [
-            'PS_AUTOUP_CUSTOM_MOD_DESACT' => [
+            UpgradeConfiguration::PS_AUTOUP_CUSTOM_MOD_DESACT => [
                 'title' => $this->trans('Disable non-native modules'),
                 'cast' => 'intval',
                 'validation' => 'isBool',
@@ -223,14 +223,14 @@ class AdminSelfUpgradeController extends ModuleAdminController
                 'desc' => $this->trans('As non-native modules can experience some compatibility issues, we recommend to disable them by default.') . '<br />' .
                     $this->trans('Keeping them enabled might prevent you from loading the "Modules" page properly after the upgrade.'),
             ],
-            'PS_DISABLE_OVERRIDES' => [
+            UpgradeConfiguration::PS_DISABLE_OVERRIDES => [
                 'title' => $this->trans('Disable all overrides'),
                 'cast' => 'intval',
                 'validation' => 'isBool',
                 'type' => 'bool',
                 'desc' => $this->trans('Enable or disable all classes and controllers overrides.'),
             ],
-            'PS_AUTOUP_CHANGE_DEFAULT_THEME' => [
+            UpgradeConfiguration::PS_AUTOUP_CHANGE_DEFAULT_THEME => [
                 'title' => $this->trans('Switch to the default theme'),
                 'cast' => 'intval',
                 'validation' => 'isBool',
@@ -238,7 +238,7 @@ class AdminSelfUpgradeController extends ModuleAdminController
                 'type' => 'bool',
                 'desc' => $this->trans('This will change your theme: your shop will then use the default theme of the version of PrestaShop you are upgrading to.'),
             ],
-            'PS_AUTOUP_KEEP_MAILS' => [
+            UpgradeConfiguration::PS_AUTOUP_KEEP_MAILS => [
                 'title' => $this->trans('Keep the customized email templates'),
                 'cast' => 'intval',
                 'validation' => 'isBool',
@@ -394,7 +394,7 @@ class AdminSelfUpgradeController extends ModuleAdminController
                 continue;
             }
             // The PS_DISABLE_OVERRIDES variable must only be updated on the database side
-            if ($key === 'PS_DISABLE_OVERRIDES') {
+            if ($key === UpgradeConfiguration::PS_DISABLE_OVERRIDES) {
                 UpgradeConfiguration::updatePSDisableOverrides((bool) $_POST[$key]);
             } else {
                 $config[$key] = $_POST[$key];

--- a/controllers/admin/self-managed/UpdatePageVersionChoiceController.php
+++ b/controllers/admin/self-managed/UpdatePageVersionChoiceController.php
@@ -29,6 +29,7 @@ namespace PrestaShop\Module\AutoUpgrade\Controller;
 
 use Exception;
 use PrestaShop\Module\AutoUpgrade\AjaxResponseBuilder;
+use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeFileNames;
 use PrestaShop\Module\AutoUpgrade\Router\Routes;
 use PrestaShop\Module\AutoUpgrade\Services\DistributionApiService;
@@ -46,9 +47,9 @@ class UpdatePageVersionChoiceController extends AbstractPageController
     const CURRENT_STEP = UpdateSteps::STEP_VERSION_CHOICE;
     const FORM_NAME = 'version_choice';
     const FORM_FIELDS = [
-        'channel' => 'channel',
-        'archive_zip' => 'archive_zip',
-        'archive_xml' => 'archive_xml',
+        'channel' => UpgradeConfiguration::CHANNEL,
+        'archive_zip' => UpgradeConfiguration::ARCHIVE_ZIP,
+        'archive_xml' => UpgradeConfiguration::ARCHIVE_XML,
     ];
     const FORM_OPTIONS = [
         'online_value' => Upgrader::CHANNEL_ONLINE,
@@ -214,7 +215,7 @@ class UpdatePageVersionChoiceController extends AbstractPageController
 
         if (empty($errors)) {
             if ($isLocal) {
-                $file = $requestConfig['archive_zip'];
+                $file = $requestConfig[UpgradeConfiguration::ARCHIVE_ZIP];
                 $fullFilePath = $this->upgradeContainer->getProperty(UpgradeContainer::DOWNLOAD_PATH) . DIRECTORY_SEPARATOR . $file;
                 $requestConfig['archive_version_num'] = $this->upgradeContainer->getPrestashopVersionService()->extractPrestashopVersionFromZip($fullFilePath);
             }

--- a/controllers/admin/self-managed/UpdatePageVersionChoiceController.php
+++ b/controllers/admin/self-managed/UpdatePageVersionChoiceController.php
@@ -47,9 +47,9 @@ class UpdatePageVersionChoiceController extends AbstractPageController
     const CURRENT_STEP = UpdateSteps::STEP_VERSION_CHOICE;
     const FORM_NAME = 'version_choice';
     const FORM_FIELDS = [
-        'channel' => UpgradeConfiguration::CHANNEL,
-        'archive_zip' => UpgradeConfiguration::ARCHIVE_ZIP,
-        'archive_xml' => UpgradeConfiguration::ARCHIVE_XML,
+        UpgradeConfiguration::CHANNEL => UpgradeConfiguration::CHANNEL,
+        UpgradeConfiguration::ARCHIVE_ZIP => UpgradeConfiguration::ARCHIVE_ZIP,
+        UpgradeConfiguration::ARCHIVE_XML => UpgradeConfiguration::ARCHIVE_XML,
     ];
     const FORM_OPTIONS = [
         'online_value' => Upgrader::CHANNEL_ONLINE,

--- a/tests/unit/AnalyticsTest.php
+++ b/tests/unit/AnalyticsTest.php
@@ -37,13 +37,13 @@ class AnalyticsTest extends TestCase
             ->setInstallVersion('8.8.808')
             ->setRestoreName('V1.2.3_blablabla-🐶');
         $upgradeConfiguration = (new UpgradeConfiguration([
-            'PS_AUTOUP_CUSTOM_MOD_DESACT' => 0,
-            'PS_AUTOUP_CHANGE_DEFAULT_THEME' => 1,
-            'PS_AUTOUP_KEEP_MAILS' => 0,
-            'PS_AUTOUP_BACKUP' => 1,
-            'PS_AUTOUP_KEEP_IMAGES' => 0,
-            'channel' => 'major',
-            'archive_zip' => 'zip.zip',
+            UpgradeConfiguration::PS_AUTOUP_CUSTOM_MOD_DESACT => 0,
+            UpgradeConfiguration::PS_AUTOUP_CHANGE_DEFAULT_THEME => 1,
+            UpgradeConfiguration::PS_AUTOUP_KEEP_MAILS => 0,
+            UpgradeConfiguration::PS_AUTOUP_BACKUP => 1,
+            UpgradeConfiguration::PS_AUTOUP_KEEP_IMAGES => 0,
+            UpgradeConfiguration::CHANNEL => 'major',
+            UpgradeConfiguration::ARCHIVE_ZIP => 'zip.zip',
         ]));
 
         $analytics = new Analytics(

--- a/tests/unit/Parameters/ConfigurationValidatorTest.php
+++ b/tests/unit/Parameters/ConfigurationValidatorTest.php
@@ -83,7 +83,7 @@ class ConfigurationValidatorTest extends TestCase
 
     public function testValidateZipFail()
     {
-        $result = $this->validator->validate(['channel' => 'local', UpgradeConfiguration::ARCHIVE_ZIP => '']);
+        $result = $this->validator->validate([UpgradeConfiguration::CHANNEL => 'local', UpgradeConfiguration::ARCHIVE_ZIP => '']);
         $this->assertEquals([
             [
                 'message' => 'No zip archive provided',

--- a/tests/unit/Parameters/ConfigurationValidatorTest.php
+++ b/tests/unit/Parameters/ConfigurationValidatorTest.php
@@ -28,6 +28,7 @@ namespace Parameters;
 
 use PHPUnit\Framework\TestCase;
 use PrestaShop\Module\AutoUpgrade\Parameters\ConfigurationValidator;
+use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator;
 
 class ConfigurationValidatorTest extends TestCase
@@ -48,10 +49,10 @@ class ConfigurationValidatorTest extends TestCase
 
     public function testValidateChannelSuccess()
     {
-        $result = $this->validator->validate(['channel' => 'online']);
+        $result = $this->validator->validate([UpgradeConfiguration::CHANNEL => 'online']);
         $this->assertEmpty($result);
 
-        $result = $this->validator->validate(['channel' => 'local']);
+        $result = $this->validator->validate([UpgradeConfiguration::CHANNEL => 'local']);
         $this->assertEmpty($result);
     }
 
@@ -59,57 +60,57 @@ class ConfigurationValidatorTest extends TestCase
     {
         $channel = 'toto';
 
-        $result = $this->validator->validate(['channel' => $channel]);
+        $result = $this->validator->validate([UpgradeConfiguration::CHANNEL => $channel]);
         $this->assertEquals([
             [
                 'message' => 'Unknown channel ' . $channel,
-                'target' => 'channel',
+                'target' => UpgradeConfiguration::CHANNEL,
             ],
         ], $result);
     }
 
     public function testValidateZipSuccess()
     {
-        $result = $this->validator->validate(['archive_zip' => 'prestashop.zip']);
+        $result = $this->validator->validate([UpgradeConfiguration::ARCHIVE_ZIP => 'prestashop.zip']);
         $this->assertEmpty($result);
 
-        $result = $this->validator->validate(['channel' => 'local', 'archive_zip' => 'prestashop.zip']);
+        $result = $this->validator->validate([UpgradeConfiguration::CHANNEL => 'local', UpgradeConfiguration::ARCHIVE_ZIP => 'prestashop.zip']);
         $this->assertEmpty($result);
 
-        $result = $this->validator->validate(['channel' => 'online', 'archive_zip' => '']);
+        $result = $this->validator->validate([UpgradeConfiguration::CHANNEL => 'online', UpgradeConfiguration::ARCHIVE_ZIP => '']);
         $this->assertEmpty($result);
     }
 
     public function testValidateZipFail()
     {
-        $result = $this->validator->validate(['channel' => 'local', 'archive_zip' => '']);
+        $result = $this->validator->validate(['channel' => 'local', UpgradeConfiguration::ARCHIVE_ZIP => '']);
         $this->assertEquals([
             [
                 'message' => 'No zip archive provided',
-                'target' => 'archive_zip',
+                'target' => UpgradeConfiguration::ARCHIVE_ZIP,
             ],
         ], $result);
     }
 
     public function testValidateXmlSuccess()
     {
-        $result = $this->validator->validate(['archive_xml' => 'prestashop.xml']);
+        $result = $this->validator->validate([UpgradeConfiguration::ARCHIVE_XML => 'prestashop.xml']);
         $this->assertEmpty($result);
 
-        $result = $this->validator->validate(['channel' => 'local', 'archive_xml' => 'prestashop.xml']);
+        $result = $this->validator->validate([UpgradeConfiguration::CHANNEL => 'local', UpgradeConfiguration::ARCHIVE_XML => 'prestashop.xml']);
         $this->assertEmpty($result);
 
-        $result = $this->validator->validate(['channel' => 'online', 'archive_xml' => '']);
+        $result = $this->validator->validate([UpgradeConfiguration::CHANNEL => 'online', UpgradeConfiguration::ARCHIVE_XML => '']);
         $this->assertEmpty($result);
     }
 
     public function testValidateXmlFail()
     {
-        $result = $this->validator->validate(['channel' => 'local', 'archive_xml' => '']);
+        $result = $this->validator->validate([UpgradeConfiguration::CHANNEL => 'local', UpgradeConfiguration::ARCHIVE_XML => '']);
         $this->assertEquals([
             [
                 'message' => 'No xml archive provided',
-                'target' => 'archive_xml',
+                'target' => UpgradeConfiguration::ARCHIVE_XML,
             ],
         ], $result);
     }
@@ -119,26 +120,26 @@ class ConfigurationValidatorTest extends TestCase
         $validValues = ['1', '0', 'true', 'false', 'on', 'off'];
 
         foreach ($validValues as $value) {
-            $result = $this->validator->validate(['PS_AUTOUP_CUSTOM_MOD_DESACT' => $value]);
+            $result = $this->validator->validate([UpgradeConfiguration::PS_AUTOUP_CUSTOM_MOD_DESACT => $value]);
             $this->assertEmpty($result);
         }
     }
 
     public function testValidateBoolFail()
     {
-        $result = $this->validator->validate(['PS_AUTOUP_CUSTOM_MOD_DESACT' => 'toto']);
+        $result = $this->validator->validate([UpgradeConfiguration::PS_AUTOUP_CUSTOM_MOD_DESACT => 'toto']);
         $this->assertEquals([
             [
-                'message' => 'Value must be a boolean for PS_AUTOUP_CUSTOM_MOD_DESACT',
-                'target' => 'PS_AUTOUP_CUSTOM_MOD_DESACT',
+                'message' => 'Value must be a boolean for ' . UpgradeConfiguration::PS_AUTOUP_CUSTOM_MOD_DESACT,
+                'target' => UpgradeConfiguration::PS_AUTOUP_CUSTOM_MOD_DESACT,
             ],
         ], $result);
 
-        $result = $this->validator->validate(['PS_AUTOUP_CUSTOM_MOD_DESACT' => '']);
+        $result = $this->validator->validate([UpgradeConfiguration::PS_AUTOUP_CUSTOM_MOD_DESACT => '']);
         $this->assertEquals([
             [
-                'message' => 'Value must be a boolean for PS_AUTOUP_CUSTOM_MOD_DESACT',
-                'target' => 'PS_AUTOUP_CUSTOM_MOD_DESACT',
+                'message' => 'Value must be a boolean for ' . UpgradeConfiguration::PS_AUTOUP_CUSTOM_MOD_DESACT,
+                'target' => UpgradeConfiguration::PS_AUTOUP_CUSTOM_MOD_DESACT,
             ],
         ], $result);
     }
@@ -146,19 +147,19 @@ class ConfigurationValidatorTest extends TestCase
     public function testValidateMultipleInputFail()
     {
         $result = $this->validator->validate([
-            'channel' => 'local',
-            'archive_zip' => '',
-            'archive_xml' => '',
+            UpgradeConfiguration::CHANNEL => 'local',
+            UpgradeConfiguration::ARCHIVE_ZIP => '',
+            UpgradeConfiguration::ARCHIVE_XML => '',
         ]);
 
         $this->assertEquals([
             [
                 'message' => 'No zip archive provided',
-                'target' => 'archive_zip',
+                'target' => UpgradeConfiguration::ARCHIVE_ZIP,
             ],
             [
                 'message' => 'No xml archive provided',
-                'target' => 'archive_xml',
+                'target' => UpgradeConfiguration::ARCHIVE_XML,
             ],
         ], $result);
     }

--- a/tests/unit/Parameters/LocalChannelConfigurationValidatorTest.php
+++ b/tests/unit/Parameters/LocalChannelConfigurationValidatorTest.php
@@ -2,6 +2,7 @@
 
 use PHPUnit\Framework\TestCase;
 use PrestaShop\Module\AutoUpgrade\Parameters\LocalChannelConfigurationValidator;
+use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 
 class LocalChannelConfigurationValidatorTest extends TestCase

--- a/tests/unit/Parameters/LocalChannelConfigurationValidatorTest.php
+++ b/tests/unit/Parameters/LocalChannelConfigurationValidatorTest.php
@@ -26,51 +26,51 @@ class LocalChannelConfigurationValidatorTest extends TestCase
 
     public function testValidateReturnsErrorIfZipFileDoesNotExist()
     {
-        $data = ['archive_zip' => 'non_existent.zip', 'archive_xml' => 'versioned_8.1.0.xml'];
+        $data = [UpgradeConfiguration::ARCHIVE_ZIP => 'non_existent.zip', UpgradeConfiguration::ARCHIVE_XML => 'versioned_8.1.0.xml'];
         $result = $this->validator->validate($data);
 
         $this->assertSame([
-            'message' => 'File ' . $data['archive_zip'] . ' does not exist. Unable to select that channel.',
-            'target' => 'archive_zip',
+            'message' => 'File ' . $data[UpgradeConfiguration::ARCHIVE_ZIP] . ' does not exist. Unable to select that channel.',
+            'target' => UpgradeConfiguration::ARCHIVE_ZIP,
         ], $result[0]);
     }
 
     public function testValidateReturnsErrorIfNotVersionedZipFile()
     {
-        $data = ['archive_zip' => 'not_versioned_8.2.0.zip', 'archive_xml' => 'versioned_8.1.0.xml'];
+        $data = [UpgradeConfiguration::ARCHIVE_ZIP => 'not_versioned_8.2.0.zip', UpgradeConfiguration::ARCHIVE_XML => 'versioned_8.1.0.xml'];
         $result = $this->validator->validate($data);
 
         $this->assertSame([
             'message' => 'We couldn\'t find a PrestaShop version in the .zip file that was uploaded in your local archive. Please try again.',
-            'target' => 'archive_zip',
+            'target' => UpgradeConfiguration::ARCHIVE_ZIP,
         ], $result[0]);
     }
 
     public function testValidateReturnsErrorIfXmlFileDoesNotExist()
     {
-        $data = ['archive_zip' => 'versioned_8.2.0.zip', 'archive_xml' => 'non_existent.xml'];
+        $data = [UpgradeConfiguration::ARCHIVE_ZIP => 'versioned_8.2.0.zip', UpgradeConfiguration::ARCHIVE_XML => 'non_existent.xml'];
         $result = $this->validator->validate($data);
 
         $this->assertSame([
-            'message' => 'File ' . $data['archive_xml'] . ' does not exist. Unable to select that channel.',
-            'target' => 'archive_xml',
+            'message' => 'File ' . $data[UpgradeConfiguration::ARCHIVE_XML] . ' does not exist. Unable to select that channel.',
+            'target' => UpgradeConfiguration::ARCHIVE_XML,
         ], $result[0]);
     }
 
     public function testValidateReturnsErrorIfNotVersionedXmlFile()
     {
-        $data = ['archive_zip' => 'versioned_8.2.0.zip', 'archive_xml' => 'not_versioned_8.2.0.xml'];
+        $data = [UpgradeConfiguration::ARCHIVE_ZIP => 'versioned_8.2.0.zip', UpgradeConfiguration::ARCHIVE_XML => 'not_versioned_8.2.0.xml'];
         $result = $this->validator->validate($data);
 
         $this->assertSame([
             'message' => 'We couldn\'t find a PrestaShop version in the XML file that was uploaded in your local archive. Please try again.',
-            'target' => 'archive_xml',
+            'target' => UpgradeConfiguration::ARCHIVE_XML,
         ], $result[0]);
     }
 
     public function testValidateReturnsErrorIfVersionsDoNotMatch()
     {
-        $data = ['archive_zip' => 'versioned_8.2.0.zip', 'archive_xml' => 'versioned_8.1.0.xml'];
+        $data = [UpgradeConfiguration::ARCHIVE_ZIP => 'versioned_8.2.0.zip', UpgradeConfiguration::ARCHIVE_XML => 'versioned_8.1.0.xml'];
         $result = $this->validator->validate($data);
 
         $this->assertSame([
@@ -80,7 +80,7 @@ class LocalChannelConfigurationValidatorTest extends TestCase
 
     public function testValidatePassesWithValidFiles()
     {
-        $data = ['archive_zip' => 'versioned_8.2.0.zip', 'archive_xml' => 'versioned_8.2.0.xml'];
+        $data = [UpgradeConfiguration::ARCHIVE_ZIP => 'versioned_8.2.0.zip', UpgradeConfiguration::ARCHIVE_XML => 'versioned_8.2.0.xml'];
         $result = $this->validator->validate($data);
 
         $this->assertEmpty($result);

--- a/tests/unit/UpgradeContainer/FilesystemAdapterTest.php
+++ b/tests/unit/UpgradeContainer/FilesystemAdapterTest.php
@@ -76,7 +76,7 @@ class FilesystemAdapterTest extends TestCase
 
     public function testListFilesInDirForBackupWithImages()
     {
-        $this->container->getUpgradeConfiguration()->set('PS_AUTOUP_KEEP_IMAGES', true);
+        $this->container->getUpgradeConfiguration()->set(UpgradeConfiguration::PS_AUTOUP_KEEP_IMAGES, true);
         $expected = $this->loadFixtureAndAddPrefixToFilePaths(
             __DIR__ . '/../../fixtures/listOfFiles-backup-with-images.json',
             self::$pathToFakeShop
@@ -93,7 +93,7 @@ class FilesystemAdapterTest extends TestCase
 
     public function testListFilesInDirForBackupWithoutImages()
     {
-        $this->container->getUpgradeConfiguration()->set('PS_AUTOUP_KEEP_IMAGES', false);
+        $this->container->getUpgradeConfiguration()->set(UpgradeConfiguration::PS_AUTOUP_KEEP_IMAGES, false);
         $expected = $this->loadFixtureAndAddPrefixToFilePaths(
             __DIR__ . '/../../fixtures/listOfFiles-backup-without-images.json',
             self::$pathToFakeShop
@@ -110,7 +110,7 @@ class FilesystemAdapterTest extends TestCase
 
     public function testListFilesInDirForRestoreWithImages()
     {
-        $this->container->getUpgradeConfiguration()->set('PS_AUTOUP_KEEP_IMAGES', true);
+        $this->container->getUpgradeConfiguration()->set(UpgradeConfiguration::PS_AUTOUP_KEEP_IMAGES, true);
         $expected = $this->loadFixtureAndAddPrefixToFilePaths(
             __DIR__ . '/../../fixtures/listOfFiles-restore-with-images.json',
             self::$pathToFakeShop
@@ -127,7 +127,7 @@ class FilesystemAdapterTest extends TestCase
 
     public function testListFilesInDirForRestoreWithoutImages()
     {
-        $this->container->getUpgradeConfiguration()->set('PS_AUTOUP_KEEP_IMAGES', false);
+        $this->container->getUpgradeConfiguration()->set(UpgradeConfiguration::PS_AUTOUP_KEEP_IMAGES, false);
         $expected = $this->loadFixtureAndAddPrefixToFilePaths(
             __DIR__ . '/../../fixtures/listOfFiles-restore-without-images.json',
             self::$pathToFakeShop

--- a/tests/unit/UpgradeContainer/FilesystemAdapterTest.php
+++ b/tests/unit/UpgradeContainer/FilesystemAdapterTest.php
@@ -26,6 +26,7 @@
  */
 
 use PHPUnit\Framework\TestCase;
+use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 
 class FilesystemAdapterTest extends TestCase


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | We were just using strings to define the keys of the configuration fields, which can lead to a typo problem and maintainability problem. This PR aims to fix this problem by adding constants that replaced our old strings.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | @PrestaShopCorp
| How to test?      | You have to test everything to see if all work fine (CLI / old UI / new UI)
