### PR TITLE
Improve AssetsEvironment to handle several entrypoint locations

### DIFF
--- a/classes/Twig/AssetsEnvironment.php
+++ b/classes/Twig/AssetsEnvironment.php
@@ -31,7 +31,15 @@ use Symfony\Component\HttpFoundation\Request;
 
 class AssetsEnvironment
 {
-    const DEV_BASE_URL = 'http://localhost:5173/';
+    const DEV_BASE_URL = 'http://localhost:5173';
+
+    /** @var string */
+    private $shopBasePath;
+
+    public function __construct(string $shopBasePath)
+    {
+        $this->shopBasePath = $shopBasePath;
+    }
 
     public function isDevMode(): bool
     {
@@ -49,9 +57,21 @@ class AssetsEnvironment
 
     private function getShopUrlFromRequest(Request $request): string
     {
-        // The calls are made from the admin folder. We remove it from the caller URL to get the shop path.
+        $subDirs = explode(
+            DIRECTORY_SEPARATOR,
+            trim(
+                str_replace(
+                    $this->shopBasePath,
+                    '',
+                    dirname($request->server->get('SCRIPT_FILENAME', '')
+                )
+            ), DIRECTORY_SEPARATOR)
+        );
+        $numberOfSubDirs = count($subDirs);
+
         $path = explode('/', $request->getBasePath());
-        array_pop($path);
+
+        $path = array_splice($path, 0, -$numberOfSubDirs);
 
         return $request->getSchemeAndHttpHost() . implode('/', $path);
     }

--- a/classes/Twig/AssetsEnvironment.php
+++ b/classes/Twig/AssetsEnvironment.php
@@ -57,6 +57,10 @@ class AssetsEnvironment
 
     private function getShopUrlFromRequest(Request $request): string
     {
+        // Determine the subdirectories of the PHP entry point (the script being executed)
+        // relative to the shop root folder.
+        // This calculation helps generate a base path that correctly accounts for any subfolder in which
+        // the shop might be installed.
         $subDirs = explode(
             DIRECTORY_SEPARATOR,
             trim(

--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -753,7 +753,7 @@ class UpgradeContainer
             return $this->assetsEnvironment;
         }
 
-        return $this->assetsEnvironment = new AssetsEnvironment();
+        return $this->assetsEnvironment = new AssetsEnvironment($this->getProperty(self::PS_ROOT_PATH));
     }
 
     /**

--- a/controllers/admin/AdminSelfUpgradeController.php
+++ b/controllers/admin/AdminSelfUpgradeController.php
@@ -547,8 +547,8 @@ class AdminSelfUpgradeController extends ModuleAdminController
         $twig = $this->upgradeContainer->getTwig();
 
         if ($assetsEnvironment->isDevMode()) {
-            $this->context->controller->addCSS($assetsBaseUrl . 'src/scss/main.scss');
-            $this->content .= $twig->render('@ModuleAutoUpgrade/module-script-tag.html.twig', ['module_type' => true, 'src' => $assetsBaseUrl . 'src/ts/main.ts']);
+            $this->context->controller->addCSS($assetsBaseUrl . '/src/scss/main.scss');
+            $this->content .= $twig->render('@ModuleAutoUpgrade/module-script-tag.html.twig', ['module_type' => true, 'src' => $assetsBaseUrl . '/src/ts/main.ts']);
         } else {
             $this->context->controller->addCSS($assetsBaseUrl . '/css/autoupgrade.css');
             $this->content .= $twig->render('@ModuleAutoUpgrade/module-script-tag.html.twig', ['src' => $assetsBaseUrl . '/js/autoupgrade.js?version=' . $this->module->version]);

--- a/tests/unit/Twig/AssetsEnvironmentTest.php
+++ b/tests/unit/Twig/AssetsEnvironmentTest.php
@@ -33,7 +33,8 @@ class AssetsEnvironmentTest extends TestCase
 
     protected function setUp()
     {
-        $this->assetsEnvironment = new AssetsEnvironment();
+        $shopBasePath = '/yo/doge';
+        $this->assetsEnvironment = new AssetsEnvironment($shopBasePath);
     }
 
     protected function tearDown()
@@ -69,7 +70,7 @@ class AssetsEnvironmentTest extends TestCase
         $this->assertSame(AssetsEnvironment::DEV_BASE_URL, $this->assetsEnvironment->getAssetsBaseUrl($request));
     }
 
-    public function testGetAssetsBaseUrlReturnsProductionUrlWhenNotInDevMode()
+    public function testGetAssetsBaseUrlReturnsProductionUrl()
     {
         $expectedUrl = 'http://localhost/modules/autoupgrade/views';
         $server = [
@@ -77,7 +78,7 @@ class AssetsEnvironmentTest extends TestCase
             'SERVER_PORT' => '80',
             'QUERY_STRING' => '',
             'PHP_SELF' => '/admin-wololo/index.php',
-            'SCRIPT_FILENAME' => '/yo/doge/index.php',
+            'SCRIPT_FILENAME' => '/yo/doge/admin-wololo/index.php',
             'REQUEST_URI' => 'index.php',
         ];
 
@@ -86,14 +87,14 @@ class AssetsEnvironmentTest extends TestCase
         $this->assertSame($expectedUrl, $this->assetsEnvironment->getAssetsBaseUrl($request));
     }
 
-    public function testGetAssetsBaseUrlReturnsProductionUrlWhenNotInDevModeWithSubFolder()
+    public function testGetAssetsBaseUrlReturnsProductionUrlWithShopInSubFolder()
     {
         $server = [
             'HTTP_HOST' => 'localhost',
             'SERVER_PORT' => '80',
             'QUERY_STRING' => '',
             'PHP_SELF' => '/hello-world/admin-wololo/index.php',
-            'SCRIPT_FILENAME' => '/yo/doge/index.php',
+            'SCRIPT_FILENAME' => '/yo/doge/admin-wololo/index.php',
             'REQUEST_URI' => 'hello-world/index.php',
         ];
 
@@ -103,14 +104,31 @@ class AssetsEnvironmentTest extends TestCase
         $this->assertSame($expectedUrl, $this->assetsEnvironment->getAssetsBaseUrl($request));
     }
 
-    public function testGetAssetsBaseUrlReturnsProductionUrlWhenNotInDevModeWithSubFolderAndParams()
+    public function testGetAssetsBaseUrlReturnsProductionUrlWithCustomEntrypoint()
+    {
+        $server = [
+            'HTTP_HOST' => 'localhost',
+            'SERVER_PORT' => '80',
+            'QUERY_STRING' => '',
+            'PHP_SELF' => '/admin-wololo/autoupgrade/ajax-upgradetab.php',
+            'SCRIPT_FILENAME' => '/yo/doge/admin-wololo/autoupgrade/ajax-upgradetab.php',
+            'REQUEST_URI' => '/admin-wololo/autoupgrade/ajax-upgradetab.php?route=update-step-backup-submit',
+        ];
+
+        $request = new Request([], [], [], [], [], $server);
+
+        $expectedUrl = 'http://localhost/modules/autoupgrade/views';
+        $this->assertSame($expectedUrl, $this->assetsEnvironment->getAssetsBaseUrl($request));
+    }
+
+    public function testGetAssetsBaseUrlReturnsProductionUrlWithShopInSubFolderAndParams()
     {
         $server = [
             'HTTP_HOST' => 'localhost',
             'SERVER_PORT' => '80',
             'QUERY_STRING' => '',
             'PHP_SELF' => '/hello-world/admin-wololo/index.php',
-            'SCRIPT_FILENAME' => '/yo/doge/index.php',
+            'SCRIPT_FILENAME' => '/yo/doge/admin-wololo/index.php',
             'REQUEST_URI' => 'hello-world/admin-wololo/index.php?controller=AdminSelfUpgrade',
         ];
 

--- a/views/templates/modals/modal-update.html.twig
+++ b/views/templates/modals/modal-update.html.twig
@@ -31,7 +31,7 @@
       <button type="button" class="btn btn-primary">
         <img
           class="modal__rocket-icon rocket-icon"
-          src="{{ psBaseUri }}img/rocket_white.svg"
+          src="{{ assets_base_path }}/img/rocket_white.svg"
           width="20"
           height="20"
           alt=""


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR allows images to be found when refreshing templates from calls to `ajax-updatetab.php`
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | The images are displayed properly. For instance the rocket in the modal asking to confirm the update.
