### PR TITLE
Adapt to recent PRs

### DIFF
--- a/upgrade/sql/9.0.0.sql
+++ b/upgrade/sql/9.0.0.sql
@@ -1,11 +1,23 @@
 SET SESSION sql_mode='';
 SET NAMES 'utf8mb4';
 
+/* Enable controlling of default language URL prefix - https://github.com/PrestaShop/PrestaShop/pull/37236 */
+/* Add a file separator input to the sql manager settings - https://github.com/PrestaShop/PrestaShop/pull/35843 */
 INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES
   ('PS_DEBUG_COOKIE_NAME', '', NOW(), NOW()),
   ('PS_DEBUG_COOKIE_VALUE', '', NOW(), NOW()),
-  ('PS_PRODUCT_BREADCRUMB_CATEGORY', 'default', NOW(), NOW())
+  ('PS_PRODUCT_BREADCRUMB_CATEGORY', 'default', NOW(), NOW()),
+  ('PS_DEFAULT_LANGUAGE_URL_PREFIX', 1, NOW(), NOW())
 ;
+
+/* Remove meta keywords - https://github.com/PrestaShop/PrestaShop/pull/36873 */
+/* PHP:drop_column_if_exists('category_lang', 'meta_keywords'); */;
+/* PHP:drop_column_if_exists('cms_lang', 'meta_keywords'); */;
+/* PHP:drop_column_if_exists('cms_category_lang', 'meta_keywords'); */;
+/* PHP:drop_column_if_exists('manufacturer_lang', 'meta_keywords'); */;
+/* PHP:drop_column_if_exists('meta_lang', 'keywords'); */;
+/* PHP:drop_column_if_exists('product_lang', 'meta_keywords'); */;
+/* PHP:drop_column_if_exists('supplier_lang', 'meta_keywords'); */;
 
 INSERT INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES
   (NULL, 'actionUpdateCartAddress', 'Triggers after changing address on the cart', 'This hook is called after address is changed on the cart', '1'),


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Autoupgrade PR for recent PRs - https://github.com/PrestaShop/PrestaShop/pull/37236/ and https://github.com/PrestaShop/PrestaShop/pull/36873/ and added a comment about https://github.com/PrestaShop/PrestaShop/pull/35843/ (in dev branch)
| Type?             | 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | 
| How to test?      | 

### How to test
- Upgrade from 8.1 to 9.0
- Open phpmyadmin
- See that: 
  - A) `meta_keywords` columns is removed from all tables.
  - B) There is `PS_DEFAULT_LANGUAGE_URL_PREFIX` record in `ps_configuration`.
  - C) There is `PS_SEPARATOR_FILE_MANAGER_SQL` record in `ps_configuration`.
- No need to test anything else, not in the scope of this PR