### PR TITLE
[CLI] Improve 'backup:create' command

### DIFF
--- a/classes/Commands/CheckRequirementsCommand.php
+++ b/classes/Commands/CheckRequirementsCommand.php
@@ -71,7 +71,7 @@ class CheckRequirementsCommand extends AbstractCommand
             $this->output = $output;
 
             $configPath = $input->getOption('config-file-path');
-            $exitCode = $this->loadConfiguration($configPath, $this->upgradeContainer);
+            $exitCode = $this->loadConfiguration($configPath);
             if ($exitCode !== ExitCode::SUCCESS) {
                 return $exitCode;
             }

--- a/classes/Commands/CreateBackupCommand.php
+++ b/classes/Commands/CreateBackupCommand.php
@@ -28,6 +28,7 @@
 namespace PrestaShop\Module\AutoUpgrade\Commands;
 
 use Exception;
+use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\Task\Runner\AllBackupTasks;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -45,6 +46,7 @@ class CreateBackupCommand extends AbstractCommand
             ->setDescription('Create backup.')
             ->setHelp('This command triggers the creation of the files and database backup.')
             ->addOption('config-file-path', null, InputOption::VALUE_REQUIRED, 'Configuration file location.')
+            ->addOption('include-images', null, InputOption::VALUE_REQUIRED, 'Include, or not, images in the store backup.')
             ->addArgument('admin-dir', InputArgument::REQUIRED, 'The admin directory name.');
     }
 
@@ -55,6 +57,14 @@ class CreateBackupCommand extends AbstractCommand
     {
         try {
             $this->setupEnvironment($input, $output);
+            $configPath = $input->getOption('config-file-path');
+            $includeImage = $input->getOption('include-images');
+
+            if ($includeImage !== null) {
+                $this->consoleInputConfiguration[UpgradeConfiguration::PS_AUTOUP_KEEP_IMAGES] = $includeImage;
+            }
+
+            $this->loadConfiguration($configPath);
 
             $controller = new AllBackupTasks($this->upgradeContainer);
             $controller->init();

--- a/classes/Commands/UpdateCommand.php
+++ b/classes/Commands/UpdateCommand.php
@@ -81,7 +81,7 @@ class UpdateCommand extends AbstractCommand
             // also we do not want to repeat the update of the config in the recursive commands
             if ($input->getOption('data') === null) {
                 $configPath = $input->getOption('config-file-path');
-                $exitCode = $this->loadConfiguration($configPath, $this->upgradeContainer);
+                $exitCode = $this->loadConfiguration($configPath);
                 if ($exitCode !== ExitCode::SUCCESS) {
                     return $exitCode;
                 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | add `include-images` option for 'backup:create' command
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | -
| How to test?      | Use 'backup:create' command with new `include-images` option
