### PR TITLE
Update AdminSelfUpgradeController.php

### DIFF
--- a/controllers/admin/AdminSelfUpgradeController.php
+++ b/controllers/admin/AdminSelfUpgradeController.php
@@ -150,16 +150,17 @@ class AdminSelfUpgradeController extends ModuleAdminController
 
                 return;
             }
-
-            // If a previous version of ajax-upgradetab.php exists, delete it
-            if (file_exists($this->autoupgradePath . DIRECTORY_SEPARATOR . 'ajax-upgradetab.php')) {
-                @unlink($this->autoupgradePath . DIRECTORY_SEPARATOR . 'ajax-upgradetab.php');
-            }
-
+            
+            clearstatcache();
             $file_tab = @filemtime($this->autoupgradePath . DIRECTORY_SEPARATOR . 'ajax-upgradetab.php');
             $file = @filemtime(_PS_ROOT_DIR_ . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR . $this->autoupgradeDir . DIRECTORY_SEPARATOR . 'ajax-upgradetab.php');
 
             if ($file_tab < $file) {
+                // If a previous version of ajax-upgradetab.php exists, delete it
+                if (file_exists($this->autoupgradePath . DIRECTORY_SEPARATOR . 'ajax-upgradetab.php')) {
+                    @unlink($this->autoupgradePath . DIRECTORY_SEPARATOR . 'ajax-upgradetab.php');
+                }
+                // copy new file
                 @copy(_PS_ROOT_DIR_ . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR . $this->autoupgradeDir . DIRECTORY_SEPARATOR . 'ajax-upgradetab.php',
                     $this->autoupgradePath . DIRECTORY_SEPARATOR . 'ajax-upgradetab.php');
             }

--- a/controllers/admin/AdminSelfUpgradeController.php
+++ b/controllers/admin/AdminSelfUpgradeController.php
@@ -163,6 +163,8 @@ class AdminSelfUpgradeController extends ModuleAdminController
                 // copy new file
                 @copy(_PS_ROOT_DIR_ . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR . $this->autoupgradeDir . DIRECTORY_SEPARATOR . 'ajax-upgradetab.php',
                     $this->autoupgradePath . DIRECTORY_SEPARATOR . 'ajax-upgradetab.php');
+                // adjust file modification time
+                @touch($this->autoupgradePath . DIRECTORY_SEPARATOR . 'ajax-upgradetab.php', $file);
             }
 
             // Make sure that the XML config directory exists


### PR DESCRIPTION
Delete 'ajax-upgradetab.php' only when it needs to be deleted, that is befory copying a new file.

Adding clearstatcache() makes sure filemtime() gives right value in file changes.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Change in logic when to delete 'ajax-upgradetab.php'. I had quite often problems with '[TECHNICAL ERROR] ajax-upgradetab.php is missing. Please reinstall or reset the module.'
| Type?             | improvement
| BC breaks?        | yno
| Deprecations?     | no
| Fixed ticket?     | none
| Sponsor company   | none
| How to test?      | Use 1-Click Upgrade
