### PR TITLE
Update 'ajax-upgradetab.php' deleting in AdminSelfUpgradeController.php

### DIFF
--- a/controllers/admin/AdminSelfUpgradeController.php
+++ b/controllers/admin/AdminSelfUpgradeController.php
@@ -151,7 +151,6 @@ class AdminSelfUpgradeController extends ModuleAdminController
                 return;
             }
 
-            clearstatcache();
             $file_tab = @filemtime($this->autoupgradePath . DIRECTORY_SEPARATOR . 'ajax-upgradetab.php');
             $file = @filemtime(_PS_ROOT_DIR_ . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR . $this->autoupgradeDir . DIRECTORY_SEPARATOR . 'ajax-upgradetab.php');
 

--- a/controllers/admin/AdminSelfUpgradeController.php
+++ b/controllers/admin/AdminSelfUpgradeController.php
@@ -151,17 +151,20 @@ class AdminSelfUpgradeController extends ModuleAdminController
                 return;
             }
 
-            // If a previous version of ajax-upgradetab.php exists, delete it
-            if (file_exists($this->autoupgradePath . DIRECTORY_SEPARATOR . 'ajax-upgradetab.php')) {
-                @unlink($this->autoupgradePath . DIRECTORY_SEPARATOR . 'ajax-upgradetab.php');
-            }
-
+            clearstatcache();
             $file_tab = @filemtime($this->autoupgradePath . DIRECTORY_SEPARATOR . 'ajax-upgradetab.php');
             $file = @filemtime(_PS_ROOT_DIR_ . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR . $this->autoupgradeDir . DIRECTORY_SEPARATOR . 'ajax-upgradetab.php');
 
             if ($file_tab < $file) {
+                // If a previous version of ajax-upgradetab.php exists, delete it
+                if (file_exists($this->autoupgradePath . DIRECTORY_SEPARATOR . 'ajax-upgradetab.php')) {
+                    @unlink($this->autoupgradePath . DIRECTORY_SEPARATOR . 'ajax-upgradetab.php');
+                }
+                // copy new version
                 @copy(_PS_ROOT_DIR_ . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR . $this->autoupgradeDir . DIRECTORY_SEPARATOR . 'ajax-upgradetab.php',
                     $this->autoupgradePath . DIRECTORY_SEPARATOR . 'ajax-upgradetab.php');
+                // adjust file modification time
+                @touch($this->autoupgradePath . DIRECTORY_SEPARATOR . 'ajax-upgradetab.php', $file);
             }
 
             // Make sure that the XML config directory exists


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Change the logic how 'ajax-upgradetab.php' is deleted only when necessary. I had intermittend problems getting error '[TECHNICAL ERROR] ajax-upgradetab.php is missing. Please reinstall the module.'. This seems to solve that.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | none
| Sponsor company   | none
| How to test?      | Play with 1-Click Upgrade
