### PR TITLE
Add test to show issues from a script unloaded too late

### DIFF
--- a/_dev/src/ts/routing/ScriptHandler.ts
+++ b/_dev/src/ts/routing/ScriptHandler.ts
@@ -68,4 +68,15 @@ export default class ScriptHandler {
     this.#currentScript?.beforeDestroy();
     this.#loadScript(newRoute);
   }
+
+  /**
+   * @public
+   * @returns void
+   * @description Unloads the currently loaded script.
+   *  Should be called before updating the DOM.
+   */
+  public unloadRouteScript(): void {
+    this.#currentScript?.beforeDestroy();
+    this.#currentScript = undefined;
+  }
 }

--- a/_dev/src/ts/utils/Hydration.ts
+++ b/_dev/src/ts/utils/Hydration.ts
@@ -27,6 +27,10 @@ export default class Hydration {
     const elementToUpdate = document.getElementById(data.parent_to_update);
 
     if (elementToUpdate && data.new_content) {
+      if (data.new_route) {
+        scriptHandler.unloadRouteScript();
+      }
+
       elementToUpdate.innerHTML = data.new_content;
 
       if (data.new_route) {

--- a/_dev/tests/utils/Hydration.test.ts
+++ b/_dev/tests/utils/Hydration.test.ts
@@ -5,6 +5,7 @@ import ScriptHandler from '../../src/ts/routing/ScriptHandler';
 
 const setNewRouteMock = jest.spyOn(RouteHandler.prototype, 'setNewRoute');
 const updateRouteScriptMock = jest.spyOn(ScriptHandler.prototype, 'updateRouteScript');
+const unloadRouteScriptMock = jest.spyOn(ScriptHandler.prototype, 'unloadRouteScript');
 
 jest.mock('../../src/ts/pages/HomePage', () => {
   return jest.fn().mockImplementation(() => {
@@ -159,6 +160,9 @@ describe('Hydration and scripts lifecycle', () => {
     };
     hydration.hydrate(initialResponse);
 
+    expect(setNewRouteMock).toHaveBeenCalledTimes(1);
+    expect(unloadRouteScriptMock).toHaveBeenCalledTimes(1);
+
     const nextResponse: ApiResponseHydration = {
       hydration: true,
       new_content: `<p>New Content</p>`,
@@ -166,5 +170,8 @@ describe('Hydration and scripts lifecycle', () => {
       new_route: 'home-page'
     };
     hydration.hydrate(nextResponse);
+
+    expect(setNewRouteMock).toHaveBeenCalledTimes(2);
+    expect(unloadRouteScriptMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/_dev/tests/utils/Hydration.test.ts
+++ b/_dev/tests/utils/Hydration.test.ts
@@ -1,15 +1,33 @@
 import Hydration from '../../src/ts/utils/Hydration';
 import { ApiResponseHydration } from '../../src/ts/types/apiTypes';
-import { routeHandler, scriptHandler } from '../../src/ts/autoUpgrade';
+import RouteHandler from '../../src/ts/routing/RouteHandler';
+import ScriptHandler from '../../src/ts/routing/ScriptHandler';
 
-jest.mock('../../src/ts/autoUpgrade', () => ({
-  routeHandler: {
-    setNewRoute: jest.fn()
-  },
-  scriptHandler: {
-    updateRouteScript: jest.fn()
-  }
-}));
+const setNewRouteMock = jest.spyOn(RouteHandler.prototype, 'setNewRoute');
+const updateRouteScriptMock = jest.spyOn(ScriptHandler.prototype, 'updateRouteScript');
+
+jest.mock('../../src/ts/pages/HomePage', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      mount: () => {},
+      beforeDestroy: () => {}
+    };
+  });
+});
+
+jest.mock('../../src/ts/pages/UpdatePageBackup', () => {
+  return jest.fn().mockImplementation(() => ({
+    mount: () => {},
+    beforeDestroy: () => {
+      const element = document.getElementById('my_paragraph');
+      if (!element) {
+        throw new Error(
+          'Script unloaded too late, the element has already been removed from the DOM'
+        );
+      }
+    }
+  }));
+});
 
 describe('Hydration', () => {
   let hydration: Hydration;
@@ -51,7 +69,7 @@ describe('Hydration', () => {
 
     hydration.hydrate(response);
 
-    expect(scriptHandler.updateRouteScript).toHaveBeenCalledWith('new_route_value');
+    expect(updateRouteScriptMock).toHaveBeenCalledWith('new_route_value');
   });
 
   it('should call routeHandler.setNewRoute when new_route is provided and fromPopState is false', () => {
@@ -64,7 +82,7 @@ describe('Hydration', () => {
 
     hydration.hydrate(response);
 
-    expect(routeHandler.setNewRoute).toHaveBeenCalledWith('new_route_value');
+    expect(setNewRouteMock).toHaveBeenCalledWith('new_route_value');
   });
 
   it('should not call routeHandler.setNewRoute when fromPopState is true', () => {
@@ -77,7 +95,7 @@ describe('Hydration', () => {
 
     hydration.hydrate(response, true);
 
-    expect(routeHandler.setNewRoute).not.toHaveBeenCalled();
+    expect(setNewRouteMock).not.toHaveBeenCalled();
   });
 
   it('should not update the content if the element does not exist', () => {
@@ -113,5 +131,40 @@ describe('Hydration', () => {
         type: Hydration.hydrationEventName
       })
     );
+  });
+});
+
+describe('Hydration and scripts lifecycle', () => {
+  let hydration: Hydration;
+
+  beforeEach(() => {
+    hydration = new Hydration();
+    document.body.innerHTML = `
+      <div id="parent">
+        <p>Old Content</p>
+      </div>
+    `;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should unload the current script safely before loading the next one', () => {
+    const initialResponse: ApiResponseHydration = {
+      hydration: true,
+      new_content: `<p id="my_paragraph">Old Content</p>`,
+      parent_to_update: 'parent',
+      new_route: 'update-page-backup'
+    };
+    hydration.hydrate(initialResponse);
+
+    const nextResponse: ApiResponseHydration = {
+      hydration: true,
+      new_content: `<p>New Content</p>`,
+      parent_to_update: 'parent',
+      new_route: 'home-page'
+    };
+    hydration.hydrate(nextResponse);
   });
 });


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Change the order we call the different method when loading a new page on the new UI. We expect to call the `beforeDestroy` before updating the DOM, so we can safely remove stuff such as the event listeners.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | There is no visible impact on the current state of the dev branch. But when implementing the next pages, we won't get unexpected exception for a missing element in the DOM while unloading a script.

**Note:** The first commit of this PR will fail. Only the test has been added to show how it will be fixed by the second commit.