### PR TITLE
Fix validator errors on UpdateConfig

### DIFF
--- a/classes/Task/Miscellaneous/UpdateConfig.php
+++ b/classes/Task/Miscellaneous/UpdateConfig.php
@@ -77,7 +77,7 @@ class UpdateConfig extends AbstractTask
         $error = $this->container->getConfigurationValidator()->validate($config);
 
         if ($isLocal && empty($error)) {
-            $this->container->getLocalChannelConfigurationValidator()->validate($config);
+            $error = $this->container->getLocalChannelConfigurationValidator()->validate($config);
         }
 
         if (!empty($error)) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix validator errors on UpdateConfig
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | -
| How to test?      | Try in CLI to get the error "The PrestaShop version in your archive doesn’t match the one in XML file. Please fix this issue and try again." using a ZIP and an XML with different versions
