### PR TITLE
Autoupgrade PR for 37261

### DIFF
--- a/upgrade/sql/9.0.0.sql
+++ b/upgrade/sql/9.0.0.sql
@@ -3,10 +3,12 @@ SET NAMES 'utf8mb4';
 
 /* Enable controlling of default language URL prefix - https://github.com/PrestaShop/PrestaShop/pull/37236 */
 /* Add a file separator input to the sql manager settings - https://github.com/PrestaShop/PrestaShop/pull/35843 */
+/* Allow configuring maximum word difference - https://github.com/PrestaShop/PrestaShop/pull/37261 */
 INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES
   ('PS_DEBUG_COOKIE_NAME', '', NOW(), NOW()),
   ('PS_DEBUG_COOKIE_VALUE', '', NOW(), NOW()),
   ('PS_PRODUCT_BREADCRUMB_CATEGORY', 'default', NOW(), NOW()),
+  ('PS_SEARCH_FUZZY_MAX_DIFFERENCE', 5, NOW(), NOW()),
   ('PS_DEFAULT_LANGUAGE_URL_PREFIX', 1, NOW(), NOW())
 ;
 


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Adds new configuration value for https://github.com/PrestaShop/PrestaShop/pull/37261
| Type?             | 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     |
| Sponsor company   | 
| How to test?      | Upgrade to 9.0.0, see that `PS_SEARCH_FUZZY_MAX_DIFFERENCE` is in `ps_configuration` table. But I honestly think that automatic tests are sufficient, it's just one of many simmilar lines there.
