### PR TITLE
Fix: Autoupgrade attempts to update non-installed modules, causing the upgrade process to fail

### DIFF
--- a/classes/Task/Update/UpdateModules.php
+++ b/classes/Task/Update/UpdateModules.php
@@ -92,11 +92,11 @@ class UpdateModules extends AbstractTask
 
                     if ($dbVersion !== '') {
                         $module = \Module::getInstanceByName($moduleInfos['name']);
-    
+
                         if (!($module instanceof \Module)) {
                             throw (new UpgradeException($this->translator->trans('[WARNING] Error when trying to retrieve module %s instance.', [$moduleInfos['name']])))->setSeverity(UpgradeException::SEVERITY_WARNING);
                         }
-    
+
                         $moduleMigrationContext = new ModuleMigrationContext($module, $dbVersion);
     
                         if (!$moduleMigration->needMigration($moduleMigrationContext)) {


### PR DESCRIPTION
Added a check for the module version, ensuring that only the modules actually installed are updated.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When updating Prestashop using the "autoupgrade" module, the system attempts to update modules located in the "modules" folder even if they are not actually installed.
| Type?             | bug fix 
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | Fixes [#37445](https://github.com/PrestaShop/PrestaShop/issues/37445)
| Sponsor company   | @Codencode
| How to test?      | 1. Install autoupgrade module - 2. Copy the ps_mbo module into the modules folder without installing it. - 3. Perform the upgrade to the latest version of Prestashop.
