### PR TITLE
[NEW UI] Feat : add connection to page post update

### DIFF
--- a/controllers/admin/self-managed/UpdatePagePostUpdateController.php
+++ b/controllers/admin/self-managed/UpdatePagePostUpdateController.php
@@ -27,12 +27,12 @@
 
 namespace PrestaShop\Module\AutoUpgrade\Controller;
 
+use PrestaShop\Module\AutoUpgrade\Router\Routes;
 use PrestaShop\Module\AutoUpgrade\Twig\UpdateSteps;
 
 class UpdatePagePostUpdateController extends AbstractPageWithStepController
 {
     const CURRENT_STEP = UpdateSteps::STEP_POST_UPDATE;
-    const CURRENT_PAGE = 'update';
 
     protected function getPageTemplate(): string
     {
@@ -42,6 +42,11 @@ class UpdatePagePostUpdateController extends AbstractPageWithStepController
     protected function getStepTemplate(): string
     {
         return self::CURRENT_STEP;
+    }
+
+    protected function displayRouteInUrl(): ?string
+    {
+        return Routes::UPDATE_PAGE_POST_UPDATE;
     }
 
     /**

--- a/views/templates/components/progress-tracker.html.twig
+++ b/views/templates/components/progress-tracker.html.twig
@@ -2,7 +2,7 @@
     class="progress-tracker"
     data-component="progress-tracker"
     {% if successRoute is defined %}
-        data-sucess-route="{{ successRoute }}"
+        data-success-route="{{ successRoute }}"
     {% endif %}
 >
     <div class="log-progress">


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Then update is ended with success we loading the post update page.
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | @PrestaShopCorp
| How to test?      | Try and update, if the update finish without blocking error you need to be redirected to the post update page.
