### PR TITLE
[CLI] Add new options for update command

### DIFF
--- a/classes/Task/Runner/AllUpdateTasks.php
+++ b/classes/Task/Runner/AllUpdateTasks.php
@@ -29,9 +29,7 @@ namespace PrestaShop\Module\AutoUpgrade\Task\Runner;
 
 use Exception;
 use PrestaShop\Module\AutoUpgrade\AjaxResponse;
-use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\Task\TaskName;
-use UnexpectedValueException;
 
 /**
  * Execute the whole upgrade process in a single request.
@@ -60,19 +58,6 @@ class AllUpdateTasks extends ChainedTasks
     {
         if (!empty($options['action'])) {
             $this->step = $options['action'];
-        }
-
-        if (!empty($options[UpgradeConfiguration::CHANNEL])) {
-            $config = [
-                UpgradeConfiguration::CHANNEL => $options[UpgradeConfiguration::CHANNEL],
-            ];
-            $error = $this->container->getConfigurationValidator()->validate($config);
-
-            if (!empty($error)) {
-                throw new UnexpectedValueException(reset($error)['message']);
-            }
-
-            $this->container->getUpgradeConfiguration()->merge($config);
         }
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add new options for update command. `zip` / `xml` / `disable-non-native-modules` / `regenerate-email-templates` / `disable-all-overrides`
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     |no
| Fixed ticket?     | -
| Sponsor company   | -
| How to test?      | use new options for update command
