### PR TITLE
[POC] Defer scroll to the bottom if previous one happened recently

### DIFF
--- a/_dev/src/ts/components/LogsViewer.ts
+++ b/_dev/src/ts/components/LogsViewer.ts
@@ -8,6 +8,8 @@ export default class LogsViewer extends ComponentAbstract implements Destroyable
   #errors: string[] = [];
   #isSummaryDisplayed: boolean = false;
 
+  #timeLastReflow: number = 0;
+
   #logsList = this.queryElement<HTMLDivElement>(
     '[data-slot-component="list"]',
     'Logs list not found'
@@ -169,7 +171,13 @@ export default class LogsViewer extends ComponentAbstract implements Destroyable
    * @description Automatically scrolls the logs container to the bottom of the list.
    */
   #scrollToBottom = () => {
-    this.#logsScroll.scrollTop = this.#logsScroll.scrollHeight;
+    const currentTime = Date.now();
+
+    // We defer scrolls to the bottom if they are happening too frequently
+    if (currentTime - this.#timeLastReflow > 500) {
+      this.#timeLastReflow = currentTime;
+      this.#logsScroll.scrollTop = this.#logsScroll.scrollHeight;
+    }
   };
 
   /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | At the end of each ajax request, we add the logs then scroll to the bottom. Unfortunately, this triggers a refresh of the whole page, requiring a lot of CPU time.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | /
| How to test?      | The summary is blazing fast and the logs are scrolled to the bottom less frequently.

Tests of updates from 1.7.5.1 -> 8.2.0:

On this scenario, the updates were running with another tab opened on Google Meet.
### With the PR:

```
Start date of the process: 2024-11-29 16:05:14
End date of the process: 2024-11-29 16:07:24
Diff time: 2 min 10 seconds
```

### On the `dev` branch:

```
Start date of the process: 2024-11-29 16:26:33
End date of the process: 2024-11-29 16:30:08
Diff time: 3 min 35 seconds
```

:arrow_right: **Improvement of 1 min 25**