### PR TITLE
[NEW UI] Update page - download logs

### DIFF
--- a/_dev/src/ts/components/LogsViewer.ts
+++ b/_dev/src/ts/components/LogsViewer.ts
@@ -103,7 +103,7 @@ export default class LogsViewer extends ComponentAbstract implements Destroyable
       this.#logsSummary.addEventListener('click', this.#handleLinkEvent);
     }
 
-    await api.post('update-step-update-download-logs');
+    await api.post(this.element.dataset.downloadLogsRoute!);
 
     this.#appendFragmentElement(fragment, this.#logsSummary);
     this.#isSummaryDisplayed = true;

--- a/_dev/src/ts/components/ProgressTracker.ts
+++ b/_dev/src/ts/components/ProgressTracker.ts
@@ -46,7 +46,7 @@ export default class ProgressTracker extends ComponentAbstract implements Destro
    * - Adds new logs to the logs viewer.
    * - Adds errors if present to logs viewer.
    */
-  public updateProgress(data: ApiResponseAction): void {
+  public updateProgress = (data: ApiResponseAction): void => {
     this.#logsSummary?.setLogsSummaryText(data.next_desc ?? '');
     this.#progressBar?.setProgressPercentage(data.nextParams?.progressPercentage || 0);
     this.#logsViewer.addLogs(data.nextQuickInfo);
@@ -54,7 +54,7 @@ export default class ProgressTracker extends ComponentAbstract implements Destro
     if (data.nextErrors) {
       this.#logsViewer.addLogs(data.nextErrors);
     }
-  }
+  };
 
   /**
    * @public
@@ -62,7 +62,7 @@ export default class ProgressTracker extends ComponentAbstract implements Destro
    * @description Displays a summary of error logs in the logs viewer.
    *              Destroy and null logsSummary and ProgressBar.
    */
-  public endProgress(): void {
+  public endProgress = (): void => {
     this.#logsSummary?.beforeDestroy();
     this.#logsSummary = null;
 
@@ -70,6 +70,6 @@ export default class ProgressTracker extends ComponentAbstract implements Destro
     this.#progressBar = null;
 
     // Todo: we need to retrieve the download link
-    this.#logsViewer.displaySummary('download/logs/link.txt');
-  }
+    this.#logsViewer.displaySummary();
+  };
 }

--- a/_dev/tests/components/LogsViewer.test.ts
+++ b/_dev/tests/components/LogsViewer.test.ts
@@ -38,15 +38,6 @@ describe('LogsViewer', () => {
       <template id="summary-error-link">
         <a class="logs__summary-anchor link">See error</a>
       </template>
-      
-      <template id="summary-buttons">
-        <div data-slot-template="summary-buttons" class="logs__buttons">
-          <a data-slot-template="download-button" class="btn btn-primary" href="#" download="#">
-            <i class="material-icons">file_upload</i>
-            Download update logs
-          </a>
-        </div>
-      </template>
     `;
     document.body.appendChild(container);
     logsViewer = new LogsViewer(container);
@@ -87,7 +78,7 @@ describe('LogsViewer', () => {
 
       expect(logLines.length).toBe(0);
 
-      logsViewer.displaySummary('test');
+      logsViewer.displaySummary();
       logsViewer.addLogs(['INFO - Log message']);
 
       expect(consoleSpy).toHaveBeenCalledWith('Cannot display summary because logs are empty');
@@ -98,13 +89,13 @@ describe('LogsViewer', () => {
   });
 
   describe('displaySummary', () => {
-    it('should create a summary with grouped logs by severity', () => {
+    it('should create a summary with grouped logs by severity', async () => {
       logsViewer.addLogs([
         'WARNING - First warning',
         'ERROR - First error',
         'WARNING - Second warning'
       ]);
-      logsViewer.displaySummary('test');
+      await logsViewer.displaySummary();
 
       const summaryContainer = container.querySelector('[data-slot-component="summary"]');
       expect(summaryContainer).not.toBeNull();
@@ -136,35 +127,13 @@ describe('LogsViewer', () => {
 
     it('should not display summary if no logs are present', () => {
       const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
-      logsViewer.displaySummary('test');
+      logsViewer.displaySummary();
 
       const summary = container.querySelector('[data-slot-component="summary"]');
       expect(summary!.children.length).toBe(0);
       expect(consoleSpy).toHaveBeenCalledWith('Cannot display summary because logs are empty');
 
       consoleSpy.mockRestore();
-    });
-
-    it('should display the button if logs link is provided', () => {
-      const logFile = 'logs.txt';
-      const logPath = `http://localhost/path/to/${logFile}`;
-
-      logsViewer.addLogs([
-        'WARNING - First warning',
-        'ERROR - First error',
-        'WARNING - Second warning'
-      ]);
-      logsViewer.displaySummary(logPath);
-
-      const summaryButtons = container.querySelector('[data-slot-template="summary-buttons"]');
-      expect(summaryButtons).not.toBeNull();
-
-      const downloadButton = summaryButtons?.querySelector(
-        '[data-slot-template="download-button"]'
-      ) as HTMLAnchorElement;
-      expect(downloadButton).not.toBeNull();
-      expect(downloadButton.href).toBe(logPath);
-      expect(downloadButton.download).toBe(logFile);
     });
   });
 });

--- a/classes/Router/Router.php
+++ b/classes/Router/Router.php
@@ -126,6 +126,10 @@ class Router
             'controller' => UpdatePageUpdateController::class,
             'method' => 'step',
         ],
+        Routes::UPDATE_STEP_UPDATE_DOWNLOAD_LOGS => [
+            'controller' => UpdatePageUpdateController::class,
+            'method' => 'getDownloadLogsButton',
+        ],
         Routes::UPDATE_PAGE_POST_UPDATE => [
             'controller' => UpdatePagePostUpdateController::class,
             'method' => 'index',

--- a/classes/Router/Routes.php
+++ b/classes/Router/Routes.php
@@ -33,6 +33,7 @@ class Routes
     /* step: update */
     const UPDATE_PAGE_UPDATE = 'update-page-update';
     const UPDATE_STEP_UPDATE = 'update-step-update';
+    const UPDATE_STEP_UPDATE_DOWNLOAD_LOGS = 'update-step-update-download-logs';
 
     /* step: post update */
     const UPDATE_PAGE_POST_UPDATE = 'update-page-post-update';

--- a/classes/Twig/PageSelectors.php
+++ b/classes/Twig/PageSelectors.php
@@ -10,6 +10,7 @@ class PageSelectors
     public const DIALOG_PARENT_ID = 'ua_dialog';
     public const RADIO_CARD_ONLINE_PARENT_ID = 'radio_card_online';
     public const RADIO_CARD_ARCHIVE_PARENT_ID = 'radio_card_archive';
+    public const DOWNLOAD_LOGS_PARENT_ID = 'download_logs';
 
     /**
      * @return array<string, string>
@@ -23,6 +24,7 @@ class PageSelectors
             'dialog_parent_id' => self::DIALOG_PARENT_ID,
             'radio_card_online_parent_id' => self::RADIO_CARD_ONLINE_PARENT_ID,
             'radio_card_archive_parent_id' => self::RADIO_CARD_ARCHIVE_PARENT_ID,
+            'download_logs_parent_id' => self::DOWNLOAD_LOGS_PARENT_ID,
         ];
     }
 }

--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -872,4 +872,17 @@ class UpgradeContainer
 
         return $logPath;
     }
+
+    /**
+     * @throws Exception
+     *
+     * @param TaskType::TASK_TYPE_* $task
+     */
+    public function getDownloadLogsPath(string $task): ?string
+    {
+        $logPath = $this->getLogsPath($task);
+        $documentRoot = rtrim($_SERVER['DOCUMENT_ROOT'], '/');
+
+        return str_replace($documentRoot, '', $logPath);
+    }
 }

--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -44,6 +44,7 @@ use PrestaShop\Module\AutoUpgrade\Services\ComposerService;
 use PrestaShop\Module\AutoUpgrade\Services\DistributionApiService;
 use PrestaShop\Module\AutoUpgrade\Services\PhpVersionResolverService;
 use PrestaShop\Module\AutoUpgrade\Services\PrestashopVersionService;
+use PrestaShop\Module\AutoUpgrade\Task\TaskType;
 use PrestaShop\Module\AutoUpgrade\Twig\AssetsEnvironment;
 use PrestaShop\Module\AutoUpgrade\Twig\TransFilterExtension;
 use PrestaShop\Module\AutoUpgrade\Twig\TransFilterExtension3;
@@ -66,7 +67,6 @@ use Twig\Error\LoaderError;
 use Twig\Loader\FilesystemLoader;
 use Twig_Environment;
 use Twig_Loader_Filesystem;
-use PrestaShop\Module\AutoUpgrade\Task\TaskType;
 
 /**
  * Class responsible of the easy (& Lazy) loading of the different services
@@ -859,6 +859,7 @@ class UpgradeContainer
 
     /**
      * @throws Exception
+     *
      * @param TaskType::TASK_TYPE_* $task
      */
     public function getLogsPath(string $task): ?string

--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -66,6 +66,7 @@ use Twig\Error\LoaderError;
 use Twig\Loader\FilesystemLoader;
 use Twig_Environment;
 use Twig_Loader_Filesystem;
+use PrestaShop\Module\AutoUpgrade\Task\TaskType;
 
 /**
  * Class responsible of the easy (& Lazy) loading of the different services
@@ -858,6 +859,7 @@ class UpgradeContainer
 
     /**
      * @throws Exception
+     * @param TaskType::TASK_TYPE_* $task
      */
     public function getLogsPath(string $task): ?string
     {

--- a/controllers/admin/self-managed/UpdatePageUpdateController.php
+++ b/controllers/admin/self-managed/UpdatePageUpdateController.php
@@ -64,7 +64,7 @@ class UpdatePageUpdateController extends AbstractPageWithStepController
     public function getDownloadLogsButton(): JsonResponse
     {
         try {
-            $logsPath = $this->upgradeContainer->getLogsPath(TaskType::TASK_TYPE_UPDATE);
+            $logsPath = $this->upgradeContainer->getDownloadLogsPath(TaskType::TASK_TYPE_UPDATE);
         } catch (\Exception $e) {
             return AjaxResponseBuilder::errorResponse('Impossible to retrieve logs path');
         }

--- a/controllers/admin/self-managed/UpdatePageUpdateController.php
+++ b/controllers/admin/self-managed/UpdatePageUpdateController.php
@@ -96,6 +96,7 @@ class UpdatePageUpdateController extends AbstractPageWithStepController
             $updateSteps->getStepParams($this::CURRENT_STEP),
             [
                 'success_route' => Routes::UPDATE_STEP_POST_UPDATE,
+                'download_logs_route' => Routes::UPDATE_STEP_UPDATE_DOWNLOAD_LOGS,
                 'restore_route' => Routes::RESTORE_PAGE_BACKUP_SELECTION,
                 'initial_process_action' => TaskName::TASK_UPDATE_INITIALIZATION,
                 'backup_available' => !empty($backupFinder->getAvailableBackups()),

--- a/controllers/admin/self-managed/UpdatePageUpdateController.php
+++ b/controllers/admin/self-managed/UpdatePageUpdateController.php
@@ -27,9 +27,13 @@
 
 namespace PrestaShop\Module\AutoUpgrade\Controller;
 
+use PrestaShop\Module\AutoUpgrade\AjaxResponseBuilder;
 use PrestaShop\Module\AutoUpgrade\Router\Routes;
 use PrestaShop\Module\AutoUpgrade\Task\TaskName;
+use PrestaShop\Module\AutoUpgrade\Task\TaskType;
+use PrestaShop\Module\AutoUpgrade\Twig\PageSelectors;
 use PrestaShop\Module\AutoUpgrade\Twig\UpdateSteps;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class UpdatePageUpdateController extends AbstractPageWithStepController
@@ -55,6 +59,27 @@ class UpdatePageUpdateController extends AbstractPageWithStepController
     protected function displayRouteInUrl(): ?string
     {
         return Routes::UPDATE_PAGE_UPDATE;
+    }
+
+    public function getDownloadLogsButton(): JsonResponse
+    {
+        try {
+            $logsPath = $this->upgradeContainer->getLogsPath(TaskType::TASK_TYPE_UPDATE);
+        } catch (\Exception $e) {
+            return AjaxResponseBuilder::errorResponse('Impossible to retrieve logs path');
+        }
+
+        return AjaxResponseBuilder::hydrationResponse(
+            PageSelectors::DOWNLOAD_LOGS_PARENT_ID,
+            $this->getTwig()->render(
+                '@ModuleAutoUpgrade/components/download_logs.html.twig',
+                [
+                    'button_label' => $this->upgradeContainer->getTranslator()->trans('Download update logs'),
+                    'download_path' => $logsPath,
+                    'filename' => basename($logsPath),
+                ]
+            )
+        );
     }
 
     /**

--- a/controllers/admin/self-managed/UpdatePageUpdateController.php
+++ b/controllers/admin/self-managed/UpdatePageUpdateController.php
@@ -100,6 +100,7 @@ class UpdatePageUpdateController extends AbstractPageWithStepController
                 'restore_route' => Routes::RESTORE_PAGE_BACKUP_SELECTION,
                 'initial_process_action' => TaskName::TASK_UPDATE_INITIALIZATION,
                 'backup_available' => !empty($backupFinder->getAvailableBackups()),
+                'download_logs_parent_id' => PageSelectors::DOWNLOAD_LOGS_PARENT_ID,
             ]
         );
     }

--- a/views/templates/components/download_logs.html.twig
+++ b/views/templates/components/download_logs.html.twig
@@ -1,0 +1,4 @@
+<a data-slot-template="download-button" class="btn btn-primary" href="{{ download_path }}" download="{{ filename }}">
+    <i class="material-icons">file_upload</i>
+    {{ button_label }}
+</a>

--- a/views/templates/components/logs-templates.html.twig
+++ b/views/templates/components/logs-templates.html.twig
@@ -23,12 +23,3 @@
 <template id="summary-error-link">
   <a class="logs__summary-anchor link">{{ "See error"|trans({}) }}</a>
 </template>
-
-<template id="summary-buttons">
-  <div data-slot-template="summary-buttons" class="logs__buttons">
-    <a data-slot-template="download-button" class="btn btn-primary" href="#" download="#">
-      <i class="material-icons">file_upload</i>
-      {{ 'Download update logs'|trans({}) }}
-    </a>
-  </div>
-</template>

--- a/views/templates/components/logs-viewer.html.twig
+++ b/views/templates/components/logs-viewer.html.twig
@@ -1,4 +1,4 @@
-<div data-component="logs-viewer" class="logs__inner">
+<div data-component="logs-viewer" data-download-logs-route="{{ downloadLogsRoute }}" class="logs__inner">
   <div class="logs__scroll">
     <div data-slot-component="scroll" tabindex="0" class="logs__scroll-inner">
       <div data-slot-component="list" class="logs__list"></div>

--- a/views/templates/components/logs-viewer.html.twig
+++ b/views/templates/components/logs-viewer.html.twig
@@ -5,4 +5,5 @@
     </div>
   </div>
   <div data-slot-component="summary" class="logs__summaries"></div>
+  <div id="{{ download_logs_parent_id }}"></div>
 </div>

--- a/views/templates/steps/update.html.twig
+++ b/views/templates/steps/update.html.twig
@@ -20,7 +20,8 @@
     formName: 'restore-alert',
   } %}
   {% include "@ModuleAutoUpgrade/components/progress-tracker.html.twig" with {
-    successRoute: success_route
+    successRoute: success_route,
+    downloadLogsRoute: download_logs_route,
   } %}
 {% endblock %}
 


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Connect the button download update logs to download the logs saved.
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | @PrestaShopCorp
| How to test?      | You need to launch an update with the new UI and display summary, you can now see the download logs button, if you click on it you can download the logs. To have the display summary displayed you can throw and exception on task (backend side) or just make it visible on frontend side (manipulate the JS). If you have any question feel free to ask.

