### PR TITLE
[FIX] Fixed unintentional language update

### DIFF
--- a/upgrade/php/install_ps_distributionapiclient.php
+++ b/upgrade/php/install_ps_distributionapiclient.php
@@ -27,6 +27,7 @@ function install_ps_distributionapiclient()
 {
     if (class_exists('Ps_Distributionapiclient')) {
         $module = new Ps_Distributionapiclient();
+        $module->updateTranslationsAfterInstall(false);
         $module->install();
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | See https://github.com/PrestaShop/PrestaShop/issues/33321 for context. After debugging, the problem comes from the installation of the Ps_distributionApiClient module. Each module installation updates the languages ​​and associated tables, which causes our problem. Furthermore in the context of the autoupgrade module, no need to upgrade the languages ​​because this is already done in another step
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     |no
| Fixed ticket?     | Fixes  https://github.com/PrestaShop/PrestaShop/issues/33321
| Sponsor company   | -
| How to test?      | See https://github.com/PrestaShop/PrestaShop/issues/33321
