### PR TITLE
Set new option of lang prefix dynamically

### DIFF
--- a/upgrade/php/ps_900_set_url_lang_prefix.php
+++ b/upgrade/php/ps_900_set_url_lang_prefix.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ */
+
+use PrestaShop\Module\AutoUpgrade\DbWrapper;
+
+/**
+ * @return void
+ *
+ * @throws \PrestaShop\Module\AutoUpgrade\Exceptions\UpdateDatabaseException
+ */
+function ps_900_set_url_lang_prefix()
+{
+    $numberOfActiveLanguages = (int) DbWrapper::getValue(
+        'SELECT COUNT(*) AS lang_count FROM `' . _DB_PREFIX_ . 'lang` WHERE `active` = 1'
+    );
+
+    if ($numberOfActiveLanguages > 1) {
+        Configuration::updateValue('PS_DEFAULT_LANGUAGE_URL_PREFIX', 1);
+    } else {
+        Configuration::updateValue('PS_DEFAULT_LANGUAGE_URL_PREFIX', 0);
+    }
+}

--- a/upgrade/sql/9.0.0.sql
+++ b/upgrade/sql/9.0.0.sql
@@ -1,7 +1,6 @@
 SET SESSION sql_mode='';
 SET NAMES 'utf8mb4';
 
-/* Enable controlling of default language URL prefix - https://github.com/PrestaShop/PrestaShop/pull/37236 */
 /* Add a file separator input to the sql manager settings - https://github.com/PrestaShop/PrestaShop/pull/35843 */
 /* Allow configuring maximum word difference - https://github.com/PrestaShop/PrestaShop/pull/37261 */
 INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES
@@ -9,9 +8,11 @@ INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VAL
   ('PS_DEBUG_COOKIE_VALUE', '', NOW(), NOW()),
   ('PS_SEPARATOR_FILE_MANAGER_SQL', ';', NOW(), NOW()),
   ('PS_PRODUCT_BREADCRUMB_CATEGORY', 'default', NOW(), NOW()),
-  ('PS_SEARCH_FUZZY_MAX_DIFFERENCE', 5, NOW(), NOW()),
-  ('PS_DEFAULT_LANGUAGE_URL_PREFIX', 1, NOW(), NOW())
+  ('PS_SEARCH_FUZZY_MAX_DIFFERENCE', 5, NOW(), NOW())
 ;
+
+/* Enable controlling of default language URL prefix - https://github.com/PrestaShop/PrestaShop/pull/37236 */
+/* PHP:ps_900_set_url_lang_prefix(); */;
 
 /* Remove meta keywords - https://github.com/PrestaShop/PrestaShop/pull/36873 */
 /* PHP:drop_column_if_exists('category_lang', 'meta_keywords'); */;


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Sets the new option of default language URL prefixes dynamically. More info below. Related PR - https://github.com/PrestaShop/PrestaShop/pull/37592.
| Type?             | refactor
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | 
| How to test?      | 

### Description
- If someone will be running a shop for a while and he adds another language, if this option is ON (or previous behavior), it will highly damage his SEO, because all URLs will permanently change.
- So, if there are multiple active langs on the shop (prefixes for all langs) > upgrade to YES. No URL changes.
- If there is only single language on the shop (nonprefixed URLs) > upgrade to NO. So when he adds a language, his URLs will remain the same. Unless he decides otherwise.
