### PR TITLE
Prevent leaving the page when the update is in progress

### DIFF
--- a/_dev/src/ts/pages/UpdatePageUpdate.ts
+++ b/_dev/src/ts/pages/UpdatePageUpdate.ts
@@ -21,6 +21,8 @@ export default class UpdatePageUpdate extends UpdatePage {
     const stepContent = document.getElementById('ua_step_content')!;
     const updateAction = stepContent.dataset.initialProcessAction!;
 
+    this.#enableExitConfirmation();
+
     const process = new Process({
       onProcessResponse: this.#onProcessResponse,
       onProcessEnd: this.#onProcessEnd,
@@ -36,6 +38,7 @@ export default class UpdatePageUpdate extends UpdatePage {
     this.#restoreAlertForm?.removeEventListener('submit', this.#handleSubmit);
     this.#restoreButtonForm?.removeEventListener('submit', this.#handleSubmit);
     this.#submitErrorReportForm?.removeEventListener('submit', this.#handleSubmit);
+    this.#disableExitConfirmation();
   };
 
   get #progressTrackerContainer(): HTMLDivElement {
@@ -55,6 +58,7 @@ export default class UpdatePageUpdate extends UpdatePage {
   };
 
   #onProcessEnd = async (response: ApiResponseAction): Promise<void> => {
+    this.#disableExitConfirmation();
     if (response.error) {
       this.#onError(response);
     } else {
@@ -63,6 +67,7 @@ export default class UpdatePageUpdate extends UpdatePage {
   };
 
   #onError = (response: ApiResponseAction): void => {
+    this.#disableExitConfirmation();
     this.#progressTracker.updateProgress(response);
     this.#progressTracker.endProgress();
     this.#displayErrorAlert();
@@ -104,5 +109,20 @@ export default class UpdatePageUpdate extends UpdatePage {
     const form = event.target as HTMLFormElement;
 
     await api.post(form.dataset.routeToSubmit!);
+  };
+
+  #enableExitConfirmation = () => {
+    window.addEventListener('beforeunload', this.#handleBeforeUnload);
+  };
+
+  #disableExitConfirmation = () => {
+    window.removeEventListener('beforeunload', this.#handleBeforeUnload);
+  };
+
+  #handleBeforeUnload = (event: Event) => {
+    event.preventDefault();
+
+    // Included for legacy support, e.g. Chrome/Edge < 119
+    event.returnValue = true;
   };
 }

--- a/_dev/src/ts/pages/UpdatePageUpdate.ts
+++ b/_dev/src/ts/pages/UpdatePageUpdate.ts
@@ -111,15 +111,15 @@ export default class UpdatePageUpdate extends UpdatePage {
     await api.post(form.dataset.routeToSubmit!);
   };
 
-  #enableExitConfirmation = () => {
+  #enableExitConfirmation = (): void => {
     window.addEventListener('beforeunload', this.#handleBeforeUnload);
   };
 
-  #disableExitConfirmation = () => {
+  #disableExitConfirmation = (): void => {
     window.removeEventListener('beforeunload', this.#handleBeforeUnload);
   };
 
-  #handleBeforeUnload = (event: Event) => {
+  #handleBeforeUnload = (event: Event): void => {
     event.preventDefault();
 
     // Included for legacy support, e.g. Chrome/Edge < 119


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | To avoid accidents while the update is in progress, we had the confirmation modal when the users attempts to leave the page.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | While the update is in progress, try refreshing or closing the page. You will be asked to confirm the action:

![Capture d’écran du 2024-12-12 14-59-21](https://github.com/user-attachments/assets/f27d6f79-2c5c-44e5-8741-8ce3dbfe0d44)
