### PR TITLE
Enable PHPStan on all controllers

### DIFF
--- a/classes/AjaxResponseBuilder.php
+++ b/classes/AjaxResponseBuilder.php
@@ -35,7 +35,7 @@ class AjaxResponseBuilder
         ]);
     }
 
-    public static function errorResponse(string $error, ?int $errorNumber): JsonResponse
+    public static function errorResponse(string $error, ?int $errorNumber = null): JsonResponse
     {
         return new JsonResponse([
             'error' => $error,

--- a/controllers/admin/self-managed/AbstractGlobalController.php
+++ b/controllers/admin/self-managed/AbstractGlobalController.php
@@ -30,6 +30,8 @@ namespace PrestaShop\Module\AutoUpgrade\Controller;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Twig\Environment;
+use Twig_Environment;
 
 abstract class AbstractGlobalController
 {
@@ -45,6 +47,9 @@ abstract class AbstractGlobalController
         $this->request = $request;
     }
 
+    /**
+     * @return Twig_Environment|Environment
+     */
     protected function getTwig()
     {
         return $this->upgradeContainer->getTwig();

--- a/controllers/admin/self-managed/AbstractPageController.php
+++ b/controllers/admin/self-managed/AbstractPageController.php
@@ -29,6 +29,7 @@ namespace PrestaShop\Module\AutoUpgrade\Controller;
 
 use PrestaShop\Module\AutoUpgrade\AjaxResponseBuilder;
 use PrestaShop\Module\AutoUpgrade\DocumentationLinks;
+use PrestaShop\Module\AutoUpgrade\Router\Routes;
 use PrestaShop\Module\AutoUpgrade\Twig\PageSelectors;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
@@ -53,6 +54,9 @@ abstract class AbstractPageController extends AbstractGlobalController
         return $psClass;
     }
 
+    /**
+     * @param array<string, mixed> $params
+     */
     public function renderPage(string $page, array $params): string
     {
         $pageSelectors = new PageSelectors();
@@ -71,6 +75,9 @@ abstract class AbstractPageController extends AbstractGlobalController
         );
     }
 
+    /**
+     * @param array<string, mixed> $params
+     */
     public function renderPageContent(string $page, array $params): string
     {
         $pageSelectors = new PageSelectors();
@@ -121,7 +128,7 @@ abstract class AbstractPageController extends AbstractGlobalController
      * Provide another route to display in the address bar when this controller
      * is called from an ajax request.
      *
-     * @return Routes::*|void
+     * @return Routes::*|null
      */
     protected function displayRouteInUrl(): ?string
     {
@@ -129,7 +136,7 @@ abstract class AbstractPageController extends AbstractGlobalController
     }
 
     /**
-     * @return array
+     * @return array<string, mixed>
      */
     abstract protected function getParams(): array;
 }

--- a/controllers/admin/self-managed/AbstractPageWithStepController.php
+++ b/controllers/admin/self-managed/AbstractPageWithStepController.php
@@ -34,7 +34,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 abstract class AbstractPageWithStepController extends AbstractPageController
 {
-    public function step()
+    public function step(): Response
     {
         if (!$this->request->isXmlHttpRequest()) {
             return new Response('Unexpected call to a step route outside an ajax call.', 404);

--- a/controllers/admin/self-managed/HomePageController.php
+++ b/controllers/admin/self-managed/HomePageController.php
@@ -68,7 +68,7 @@ class HomePageController extends AbstractPageController
     }
 
     /**
-     * @return array
+     * @return array<string, mixed>
      *
      * @throws \Exception
      */

--- a/controllers/admin/self-managed/UpdatePageBackupController.php
+++ b/controllers/admin/self-managed/UpdatePageBackupController.php
@@ -109,7 +109,7 @@ class UpdatePageBackupController extends AbstractPageWithStepController
     }
 
     /**
-     * @return array
+     * @return array<string, mixed>
      *
      * @throws \Exception
      */
@@ -136,6 +136,9 @@ class UpdatePageBackupController extends AbstractPageWithStepController
         );
     }
 
+    /**
+     * @param array<string, mixed> $params
+     */
     private function getRefreshOfForm(array $params): JsonResponse
     {
         return AjaxResponseBuilder::hydrationResponse(
@@ -148,6 +151,9 @@ class UpdatePageBackupController extends AbstractPageWithStepController
         );
     }
 
+    /**
+     * @param array<string, mixed> $params
+     */
     private function displayDialog(string $dialogName, array $params): JsonResponse
     {
         $options = $dialogName === 'dialog-update' ? ['addScript' => 'start-update-dialog'] : null;

--- a/controllers/admin/self-managed/UpdatePagePostUpdateController.php
+++ b/controllers/admin/self-managed/UpdatePagePostUpdateController.php
@@ -50,7 +50,7 @@ class UpdatePagePostUpdateController extends AbstractPageWithStepController
     }
 
     /**
-     * @return array
+     * @return array<string, mixed>
      *
      * @throws \Exception
      */

--- a/controllers/admin/self-managed/UpdatePageUpdateController.php
+++ b/controllers/admin/self-managed/UpdatePageUpdateController.php
@@ -79,7 +79,7 @@ class UpdatePageUpdateController extends AbstractPageWithStepController
     }
 
     /**
-     * @return array
+     * @return array<string, mixed>
      *
      * @throws \Exception
      */

--- a/controllers/admin/self-managed/UpdatePageUpdateOptionsController.php
+++ b/controllers/admin/self-managed/UpdatePageUpdateOptionsController.php
@@ -69,10 +69,10 @@ class UpdatePageUpdateOptionsController extends AbstractPageWithStepController
         $errors = $this->upgradeContainer->getConfigurationValidator()->validate($config);
 
         if (empty($errors)) {
-            if (isset($config[UpgradeConfiguration::PS_DISABLE_OVERRIDES])) {
-                $this->upgradeContainer->initPrestaShopCore();
-                UpgradeConfiguration::updatePSDisableOverrides($config[UpgradeConfiguration::PS_DISABLE_OVERRIDES]);
-            }
+            // One specific option requires the Core to store the value in database.
+            $this->upgradeContainer->initPrestaShopCore();
+            UpgradeConfiguration::updatePSDisableOverrides($config[UpgradeConfiguration::PS_DISABLE_OVERRIDES]);
+
             $upgradeConfiguration->merge($config);
             $upgradeConfigurationStorage->save($upgradeConfiguration, UpgradeFileNames::CONFIG_FILENAME);
         }
@@ -89,7 +89,7 @@ class UpdatePageUpdateOptionsController extends AbstractPageWithStepController
     }
 
     /**
-     * @return array
+     * @return array<string, mixed>
      *
      * @throws \Exception
      */
@@ -123,6 +123,9 @@ class UpdatePageUpdateOptionsController extends AbstractPageWithStepController
         );
     }
 
+    /**
+     * @param array<string, mixed> $params
+     */
     private function getRefreshOfForm(array $params): JsonResponse
     {
         return AjaxResponseBuilder::hydrationResponse(

--- a/controllers/admin/self-managed/UpdatePageVersionChoiceController.php
+++ b/controllers/admin/self-managed/UpdatePageVersionChoiceController.php
@@ -72,7 +72,7 @@ class UpdatePageVersionChoiceController extends AbstractPageWithStepController
     }
 
     /**
-     * @return array
+     * @return array<string, mixed>
      *
      * @throws \Exception
      */
@@ -141,6 +141,11 @@ class UpdatePageVersionChoiceController extends AbstractPageWithStepController
     }
 
     /**
+     * @return array{
+     *                'requirements_ok': bool,
+     *                'warnings':array<int, array{'message': string, 'list'?: array<string>}>,
+     *                'errors':array<int, array{'message': string, 'list'?: array<string>}>}}
+     *
      * @throws Exception
      */
     private function getRequirements(): array

--- a/tests/phpstan/phpstan.neon
+++ b/tests/phpstan/phpstan.neon
@@ -8,7 +8,7 @@ parameters:
 		# From PHPStan 0.12, paths to check are relative to the neon file
 		- ./../../classes
 		- ./../../upgrade/php/deactivate_custom_modules.php
-		- ./../../controllers/admin/AdminSelfUpgradeController.php
+		- ./../../controllers
 		- ./../../ajax-upgradetab.php
 		- ./../../ajax-upgradetabconfig.php
 		- ./../../autoupgrade.php


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | PHPStan was configured to run only on the legacy controller. This PR changes the configuration 
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | CI must be green once the errors from PHPStan are fixed.