### PR TITLE
[NEW UI] Use background for icons on requirements

### DIFF
--- a/_dev/src/scss/components/_check-requirements.scss
+++ b/_dev/src/scss/components/_check-requirements.scss
@@ -27,44 +27,23 @@ $e: ".check-requirements";
     }
 
     &__requirement {
-      position: relative;
       padding-inline-start: 1.75rem;
+      background-repeat: no-repeat;
+      background-position: left center;
+      background-size: 1.5rem 1.5rem;
       font-size: 0.875rem;
       line-height: 1.4;
 
-      &::before {
-        content: "";
-        position: absolute;
-        top: 50%;
-        left: 0;
-        display: block;
-        width: 1.375rem;
-        height: 1.25rem;
-        font-family: var(--#{$ua-prefix}font-family-material-icons);
-        font-size: 1.25rem;
-        line-height: 1;
-        transform: translateY(-50%);
-      }
-
       &--success {
-        &::before {
-          content: "check";
-          color: var(--#{$ua-prefix}green-500);
-        }
+        background-image: url("../../img/check.svg");
       }
 
       &--warning {
-        &::before {
-          content: "warning";
-          color: var(--#{$ua-prefix}yellow-500);
-        }
+        background-image: url("../../img/warning.svg");
       }
 
       &--error {
-        &::before {
-          content: "close";
-          color: var(--#{$ua-prefix}red-500);
-        }
+        background-image: url("../../img/close.svg");
       }
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Use a background for the icons in the requirements section to align them with the icons used in the logs.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | @PrestaShopCorp
| How to test?      | In the new UI on the version choice step, select a version to perform the requirements check. Then, review the "Update Requirements" line, where the icons should now use background images instead of font icons.
