### PR TITLE
Ensure logs use the correct timezone in CLI and Web contexts

### DIFF
--- a/ajax-upgradetabconfig.php
+++ b/ajax-upgradetabconfig.php
@@ -24,13 +24,8 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
-use PrestaShop\Module\AutoUpgrade\Tools14;
 
-if (function_exists('date_default_timezone_set')) {
-    // date_default_timezone_get calls date_default_timezone_set, which can provide warning
-    $timezone = @date_default_timezone_get();
-    date_default_timezone_set($timezone);
-}
+use PrestaShop\Module\AutoUpgrade\Tools14;
 
 /**
  * Set constants & general values used by the autoupgrade.
@@ -41,13 +36,6 @@ if (function_exists('date_default_timezone_set')) {
  */
 function autoupgrade_init_container($callerFilePath)
 {
-    if (PHP_SAPI === 'cli') {
-        $options = getopt('', ['dir:']);
-        if (isset($options['dir'])) {
-            $_POST['dir'] = $options['dir'];
-        }
-    }
-
     // the following test confirm the directory exists
     if (empty($_POST['dir'])) {
         echo 'No admin directory provided (dir). Update assistant cannot proceed.';

--- a/classes/Commands/AbstractCommand.php
+++ b/classes/Commands/AbstractCommand.php
@@ -81,6 +81,9 @@ abstract class AbstractCommand extends Command
         define('_PS_ADMIN_DIR_', $adminDir);
 
         $this->upgradeContainer = new UpgradeContainer($prodRootDir, $adminDir);
+        // We need to store the timezone this early because it can be altered by the core initialization later.
+        $this->upgradeContainer->getLogsState()->setTimeZone(date_default_timezone_get());
+
         $this->logger->debug('Update container initialized.');
 
         $this->logger->debug('Logger initialized: ' . get_class($this->logger));

--- a/classes/State/LogsState.php
+++ b/classes/State/LogsState.php
@@ -40,6 +40,9 @@ class LogsState extends AbstractState
     /** @var string|null */
     protected $activeUpdateLogFile;
 
+    /** @var string|null */
+    protected $timeZone;
+
     protected function getFileNameForPersistentStorage(): string
     {
         return UpgradeFileNames::STATE_LOGS_FILENAME;
@@ -79,6 +82,19 @@ class LogsState extends AbstractState
     public function setActiveUpdateLogFromDateTime(string $datetime): self
     {
         $this->activeUpdateLogFile = $datetime . '-update.txt';
+        $this->save();
+
+        return $this;
+    }
+
+    public function getTimeZone(): ?string
+    {
+        return $this->timeZone;
+    }
+
+    public function setTimeZone(string $timeZone): self
+    {
+        $this->timeZone = $timeZone;
         $this->save();
 
         return $this;

--- a/classes/Task/Runner/ChainedTasks.php
+++ b/classes/Task/Runner/ChainedTasks.php
@@ -29,6 +29,8 @@ namespace PrestaShop\Module\AutoUpgrade\Task\Runner;
 
 use Exception;
 use PrestaShop\Module\AutoUpgrade\AjaxResponse;
+use PrestaShop\Module\AutoUpgrade\DbWrapper;
+use PrestaShop\Module\AutoUpgrade\Exceptions\UpdateDatabaseException;
 use PrestaShop\Module\AutoUpgrade\Task\AbstractTask;
 use PrestaShop\Module\AutoUpgrade\Task\TaskName;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\TaskRepository;
@@ -112,22 +114,42 @@ abstract class ChainedTasks extends AbstractTask
         return false;
     }
 
+    /**
+     * @throws Exception
+     */
     private function setupLogging(): void
     {
+        $logsState = $this->container->getLogsState();
         $initializationSteps = [TaskName::TASK_BACKUP_INITIALIZATION, TaskName::TASK_UPDATE_INITIALIZATION, TaskName::TASK_RESTORE_INITIALIZATION];
 
         if (in_array($this->step, $initializationSteps)) {
+            if (php_sapi_name() !== 'cli') {
+                $this->container->initPrestaShopCore();
+                try {
+                    $timeZone = DbWrapper::getValue('SELECT `value` FROM `' . _DB_PREFIX_ . 'configuration` WHERE `name` = \'PS_TIMEZONE\'');
+                } catch (UpdateDatabaseException $e) {
+                    $timeZone = date_default_timezone_get();
+                }
+                $logsState->setTimeZone($timeZone);
+                date_default_timezone_set($timeZone);
+            }
+
             $timestamp = date('Y-m-d-His');
             switch ($this->step) {
                 case TaskName::TASK_BACKUP_INITIALIZATION:
-                    $this->container->getLogsState()->setActiveBackupLogFromDateTime($timestamp);
+                    $logsState->setActiveBackupLogFromDateTime($timestamp);
                     break;
                 case TaskName::TASK_RESTORE_INITIALIZATION:
-                    $this->container->getLogsState()->setActiveRestoreLogFromDateTime($timestamp);
+                    $logsState->setActiveRestoreLogFromDateTime($timestamp);
                     break;
                 case TaskName::TASK_UPDATE_INITIALIZATION:
-                    $this->container->getLogsState()->setActiveUpdateLogFromDateTime($timestamp);
+                    $logsState->setActiveUpdateLogFromDateTime($timestamp);
                     break;
+            }
+        } else {
+            $timeZone = $logsState->getTimeZone();
+            if ($timeZone) {
+                date_default_timezone_set($timeZone);
             }
         }
     }

--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -969,6 +969,11 @@ class UpgradeContainer
 
         $id_employee = !empty($_COOKIE['id_employee']) ? $_COOKIE['id_employee'] : 1;
         \Context::getContext()->employee = new \Employee((int) $id_employee);
+
+        // During a CLI process, we reset the original time zone, which was modified with the call to CORE
+        if (php_sapi_name() === 'cli') {
+            date_default_timezone_set($this->getLogsState()->getTimeZone());
+        }
     }
 
     /**

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -234,9 +234,6 @@ abstract class CoreUpgrader
         if (!defined('_PS_INSTALLER_PHP_UPGRADE_DIR_')) {
             define('_PS_INSTALLER_PHP_UPGRADE_DIR_', $this->pathToUpgradeScripts . 'php/');
         }
-        if (function_exists('date_default_timezone_set')) {
-            date_default_timezone_set('Europe/Paris');
-        }
 
         // if _PS_ROOT_DIR_ is defined, use it instead of "guessing" the module dir.
         if (defined('_PS_ROOT_DIR_') && !defined('_PS_MODULE_DIR_')) {

--- a/tests/unit/State/LogsStateTest.php
+++ b/tests/unit/State/LogsStateTest.php
@@ -22,11 +22,13 @@ class LogsStateTest extends TestCase
         $this->state->setActiveBackupLogFromDateTime('20121212121212');
         $this->state->setActiveRestoreLogFromDateTime('20251225133713');
         $this->state->setActiveUpdateLogFromDateTime('20250101213000');
+        $this->state->setTimeZone('Europe/Paris');
 
         $expected = [
             'activeBackupLogFile' => '20121212121212-backup.txt',
             'activeRestoreLogFile' => '20251225133713-restore.txt',
             'activeUpdateLogFile' => '20250101213000-update.txt',
+            'timeZone' => 'Europe/Paris',
         ];
 
         $this->assertEquals($expected, $this->state->export());
@@ -44,6 +46,7 @@ class LogsStateTest extends TestCase
                 'activeBackupLogFile' => $expectedFileName,
                 'activeRestoreLogFile' => null,
                 'activeUpdateLogFile' => null,
+                'timeZone' => null,
             ]);
 
         $this->state->setActiveBackupLogFromDateTime($timestamp);
@@ -62,6 +65,7 @@ class LogsStateTest extends TestCase
                 'activeBackupLogFile' => null,
                 'activeRestoreLogFile' => $expectedFileName,
                 'activeUpdateLogFile' => null,
+                'timeZone' => null,
             ]);
 
         $this->state->setActiveRestoreLogFromDateTime($timestamp);
@@ -80,10 +84,29 @@ class LogsStateTest extends TestCase
                 'activeBackupLogFile' => null,
                 'activeRestoreLogFile' => null,
                 'activeUpdateLogFile' => $expectedFileName,
+                'timeZone' => null,
             ]);
 
         $this->state->setActiveUpdateLogFromDateTime($timestamp);
         $this->assertEquals($expectedFileName, $this->state->getActiveUpdateLogFile());
+    }
+
+    public function testSetAndGetTimezone(): void
+    {
+        $timezone = 'Europe/Paris';
+
+        $this->fileConfigurationStorageMock
+            ->expects($this->once())
+            ->method('save')
+            ->with([
+                'activeBackupLogFile' => null,
+                'activeRestoreLogFile' => null,
+                'activeUpdateLogFile' => null,
+                'timeZone' => $timezone,
+            ]);
+
+        $this->state->setTimeZone($timezone);
+        $this->assertEquals($timezone, $this->state->getTimeZone());
     }
 
     public function testLoadState(): void
@@ -92,6 +115,7 @@ class LogsStateTest extends TestCase
             'activeBackupLogFile' => '20241218-backup.txt',
             'activeRestoreLogFile' => '20241218-restore.txt',
             'activeUpdateLogFile' => '20241218-update.txt',
+            'timeZone' => 'Europe/Paris',
         ];
 
         $this->fileConfigurationStorageMock
@@ -105,6 +129,7 @@ class LogsStateTest extends TestCase
         $this->assertEquals('20241218-backup.txt', $this->state->getActiveBackupLogFile());
         $this->assertEquals('20241218-restore.txt', $this->state->getActiveRestoreLogFile());
         $this->assertEquals('20241218-update.txt', $this->state->getActiveUpdateLogFile());
+        $this->assertEquals('Europe/Paris', $this->state->getTimeZone());
     }
 
     public function testSaveState(): void
@@ -113,6 +138,7 @@ class LogsStateTest extends TestCase
             'activeBackupLogFile' => '20241218210000-backup.txt',
             'activeRestoreLogFile' => '20241218210000-restore.txt',
             'activeUpdateLogFile' => '20241218210000-update.txt',
+            'timeZone' => 'Europe/Paris',
         ];
 
         $this->fileConfigurationStorageMock
@@ -127,12 +153,14 @@ class LogsStateTest extends TestCase
             'activeBackupLogFile' => '20241218210000-backup.txt',
             'activeRestoreLogFile' => '20241218210000-restore.txt',
             'activeUpdateLogFile' => '20241218210000-update.txt',
+            'timeZone' => 'Europe/Paris',
         ];
 
         $expectedState1 = [
             'activeBackupLogFile' => '20241218210000-backup.txt',
             'activeRestoreLogFile' => '20250101122600-restore.txt',
             'activeUpdateLogFile' => '20241218210000-update.txt',
+            'timeZone' => 'Europe/Paris',
         ];
 
         $this->fileConfigurationStorageMock


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | see below
| Type?             | feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | -
| How to test?      | See below

This PR updates the logging behavior to ensure timestamps are correctly aligned with the execution context:

- CLI Context: Logs will use the system's timezone.
- Web Context: Logs will use the timezone configured in the PrestaShop settings.
