### PR TITLE
[FIX] Fix "getTamperedFilesOnShop" cache

### DIFF
--- a/tests/unit/Xml/ChecksumCompareTest.php
+++ b/tests/unit/Xml/ChecksumCompareTest.php
@@ -100,10 +100,10 @@ class ChecksumCompareTest extends TestCase
         $tamperedFiles = $checksumCompare->getTamperedFilesOnShop('8.1.0');
 
         $expected = [
-            'mail' => ['missing' => [], 'altered' => []],
-            'translation' => ['missing' => [], 'altered' => ['translations/default/AdminActions.xlf']],
-            'core' => ['missing' => ['admin/init.php'], 'altered' => ['admin/.htaccess']],
-            'themes' => ['missing' => [], 'altered' => ['themes/classic/config/theme.yml']],
+            ChecksumCompare::CATEGORY_MAIL => [ChecksumCompare::FILE_MISSING => [], ChecksumCompare::FILE_ALTERED => []],
+            ChecksumCompare::CATEGORY_TRANSLATION => [ChecksumCompare::FILE_MISSING => [], ChecksumCompare::FILE_ALTERED => ['translations/default/AdminActions.xlf']],
+            ChecksumCompare::CATEGORY_CORE => [ChecksumCompare::FILE_MISSING => ['admin/init.php'], ChecksumCompare::FILE_ALTERED => ['admin/.htaccess']],
+            ChecksumCompare::CATEGORY_THEME => [ChecksumCompare::FILE_MISSING => [], ChecksumCompare::FILE_ALTERED => ['themes/classic/config/theme.yml']],
         ];
 
         $this->assertEquals($expected, $tamperedFiles);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix "getTamperedFilesOnShop" cache, before the condition was not good, duplications could be present
| Type?             | bug fix
| BC breaks?         no
| Deprecations?     |no
| Fixed ticket?     | -
| Sponsor company   | -
| How to test?      | -