### PR TITLE
[CLI] Add conditions for empty altered files in command

### DIFF
--- a/classes/Commands/CheckRequirementsCommand.php
+++ b/classes/Commands/CheckRequirementsCommand.php
@@ -162,31 +162,39 @@ class CheckRequirementsCommand extends AbstractCommand
                 case UpgradeSelfCheck::CORE_TEMPERED_FILES_LIST_NOT_EMPTY:
                     $missingFiles = $this->upgradeSelfCheck->getCoreMissingFiles();
 
-                    $this->output->writeln("\t" . count($missingFiles) . ' files are missing:');
-                    foreach ($missingFiles as $missingFile) {
-                        $this->output->writeln("\t\t" . $missingFile);
+                    if (!empty($missingFiles)) {
+                        $this->output->writeln("\t" . count($missingFiles) . ' files are missing:');
+                        foreach ($missingFiles as $missingFile) {
+                            $this->output->writeln("\t\t" . $missingFile);
+                        }
                     }
 
                     $alteredFiles = $this->upgradeSelfCheck->getCoreAlteredFiles();
 
-                    $this->output->writeln("\t" . count($alteredFiles) . ' files are altered:');
-                    foreach ($alteredFiles as $alteredFile) {
-                        $this->output->writeln("\t\t" . $alteredFile);
+                    if (!empty($alteredFiles)) {
+                        $this->output->writeln("\t" . count($alteredFiles) . ' files are altered:');
+                        foreach ($alteredFiles as $alteredFile) {
+                            $this->output->writeln("\t\t" . $alteredFile);
+                        }
                     }
                     break;
                 case UpgradeSelfCheck::THEME_TEMPERED_FILES_LIST_NOT_EMPTY:
                     $missingFiles = $this->upgradeSelfCheck->getThemeMissingFiles();
 
-                    $this->output->writeln("\t" . count($missingFiles) . ' files are missing:');
-                    foreach ($missingFiles as $missingFile) {
-                        $this->output->writeln("\t\t" . $missingFile);
+                    if (!empty($missingFiles)) {
+                        $this->output->writeln("\t" . count($missingFiles) . ' files are missing:');
+                        foreach ($missingFiles as $missingFile) {
+                            $this->output->writeln("\t\t" . $missingFile);
+                        }
                     }
 
                     $alteredFiles = $this->upgradeSelfCheck->getThemeAlteredFiles();
 
-                    $this->output->writeln("\t" . count($alteredFiles) . ' files are altered:');
-                    foreach ($alteredFiles as $alteredFile) {
-                        $this->output->writeln("\t\t" . $alteredFile);
+                    if (!empty($alteredFiles)) {
+                        $this->output->writeln("\t" . count($alteredFiles) . ' files are altered:');
+                        foreach ($alteredFiles as $alteredFile) {
+                            $this->output->writeln("\t\t" . $alteredFile);
+                        }
                     }
                     break;
                 default:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add conditions for empty altered files in command
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | -
| How to test?      | if a file is missing, the message "0 files are altered:" is not displayed, and vice versa
