### PR TITLE
[FIX] error then trying to load twig on low version of PrestaShop

### DIFF
--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -726,7 +726,7 @@ class UpgradeContainer
             return $this->twig;
         }
 
-        if (class_exists(Environment::class)) {
+        if (version_compare($this->getProperty(self::PS_VERSION), '1.7.8.0', '>')) {
             // We use Twig 3
             $loader = new FilesystemLoader();
             $loader->addPath(realpath(__DIR__ . '/..') . '/views/templates', 'ModuleAutoUpgrade');


### PR DESCRIPTION

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Allows to no longer rely on the class to determine the twig version to use. This allows to no longer have twig loading errors in the lowest versions (1.7.0.6/1.7.1.0 for example)
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     |  no
| Fixed ticket?     | N/A
| Sponsor company   | @PrestaShopCorp
| How to test?      | Try to acces update page (old and new UI) on version 1.7.0.6/1.7.1.0/8.0.0 and more if you want. 
