### PR TITLE
[NEW UI] Post restore page

### DIFF
--- a/_dev/src/ts/pages/RestorePagePostRestore.ts
+++ b/_dev/src/ts/pages/RestorePagePostRestore.ts
@@ -1,0 +1,13 @@
+import StepPage from './StepPage';
+
+export default class RestorePagePostRestore extends StepPage {
+  protected stepCode = 'post-restore';
+
+  constructor() {
+    super();
+  }
+
+  public mount() {
+    this.initStepper();
+  }
+}

--- a/_dev/src/ts/routing/ScriptHandler.ts
+++ b/_dev/src/ts/routing/ScriptHandler.ts
@@ -8,6 +8,7 @@ import UpdatePagePostUpdate from '../pages/UpdatePagePostUpdate';
 
 import RestorePageBackupSelection from '../pages/RestorePageBackupSelection';
 import RestorePageRestore from '../pages/RestorePageRestore';
+import RestorePagePostRestore from '../pages/RestorePagePostRestore';
 
 import StartUpdateDialog from '../dialogs/StartUpdateDialog';
 import SendErrorReportDialog from '../dialogs/SendErrorReportDialog';
@@ -35,6 +36,7 @@ export default class ScriptHandler {
 
     'restore-page-backup-selection': RestorePageBackupSelection,
     'restore-page-restore': RestorePageRestore,
+    'restore-page-post-restore': RestorePagePostRestore,
 
     'start-update-dialog': StartUpdateDialog,
     'send-error-report-dialog': SendErrorReportDialog

--- a/classes/DocumentationLinks.php
+++ b/classes/DocumentationLinks.php
@@ -10,6 +10,7 @@ class DocumentationLinks
     public const DEV_DOC_UPGRADE_CLI_URL = self::DEV_DOC_UPGRADE_URL . '/upgrade-cli';
     public const DEV_DOC_UPGRADE_WEB_URL = self::DEV_DOC_UP_TO_DATE_URL . '/use-autoupgrade-module';
     public const DEV_DOC_UPGRADE_POST_UPGRADE_URL = self:: DEV_DOC_UPGRADE_URL . '/post-update-checklist';
+    public const DEV_DOC_UPGRADE_POST_RESTORE_URL = self:: DEV_DOC_UPGRADE_URL . '/post-restore-checklist';
     public const PRESTASHOP_PROJECT_URL = 'https://www.prestashop-project.org';
     public const PRESTASHOP_PROJECT_DATA_TRANSPARENCY_URL = self::PRESTASHOP_PROJECT_URL . '/data-transparency';
 }

--- a/classes/Router/Router.php
+++ b/classes/Router/Router.php
@@ -31,6 +31,7 @@ use PrestaShop\Module\AutoUpgrade\Controller\ErrorReportController;
 use PrestaShop\Module\AutoUpgrade\Controller\HomePageController;
 use PrestaShop\Module\AutoUpgrade\Controller\LogsController;
 use PrestaShop\Module\AutoUpgrade\Controller\RestorePageBackupSelectionController;
+use PrestaShop\Module\AutoUpgrade\Controller\RestorePagePostRestoreController;
 use PrestaShop\Module\AutoUpgrade\Controller\RestorePageRestoreController;
 use PrestaShop\Module\AutoUpgrade\Controller\UpdatePageBackupController;
 use PrestaShop\Module\AutoUpgrade\Controller\UpdatePageBackupOptionsController;
@@ -195,14 +196,14 @@ class Router
             'method' => 'step',
         ],
         /* step: post restore */
-//        Routes::RESTORE_PAGE_POST_RESTORE => [
-//            'controller' => 'todo',
-//            'method' => 'index',
-//        ],
-//        Routes::RESTORE_STEP_POST_RESTORE => [
-//            'controller' => 'todo',
-//            'method' => 'step',
-//        ],
+        Routes::RESTORE_PAGE_POST_RESTORE => [
+            'controller' => RestorePagePostRestoreController::class,
+            'method' => 'index',
+        ],
+        Routes::RESTORE_STEP_POST_RESTORE => [
+            'controller' => RestorePagePostRestoreController::class,
+            'method' => 'step',
+        ],
         /* COMMON */
         /* error reporting */
         Routes::DISPLAY_ERROR_REPORT_MODAL => [

--- a/controllers/admin/self-managed/RestorePagePostRestoreController.php
+++ b/controllers/admin/self-managed/RestorePagePostRestoreController.php
@@ -32,7 +32,6 @@ use PrestaShop\Module\AutoUpgrade\Router\Routes;
 use PrestaShop\Module\AutoUpgrade\Task\TaskType;
 use PrestaShop\Module\AutoUpgrade\Twig\RestoreSteps;
 use PrestaShop\Module\AutoUpgrade\Twig\Steps;
-use PrestaShop\Module\AutoUpgrade\Twig\UpdateSteps;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 
 class RestorePagePostRestoreController extends AbstractPageWithStepController

--- a/controllers/admin/self-managed/RestorePagePostRestoreController.php
+++ b/controllers/admin/self-managed/RestorePagePostRestoreController.php
@@ -30,8 +30,8 @@ namespace PrestaShop\Module\AutoUpgrade\Controller;
 use PrestaShop\Module\AutoUpgrade\DocumentationLinks;
 use PrestaShop\Module\AutoUpgrade\Router\Routes;
 use PrestaShop\Module\AutoUpgrade\Task\TaskType;
-use PrestaShop\Module\AutoUpgrade\Twig\RestoreSteps;
-use PrestaShop\Module\AutoUpgrade\Twig\Steps;
+use PrestaShop\Module\AutoUpgrade\Twig\Steps\RestoreSteps;
+use PrestaShop\Module\AutoUpgrade\Twig\Steps\Stepper;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 
 class RestorePagePostRestoreController extends AbstractPageWithStepController
@@ -60,7 +60,7 @@ class RestorePagePostRestoreController extends AbstractPageWithStepController
      */
     protected function getParams(): array
     {
-        $updateSteps = new Steps($this->upgradeContainer->getTranslator(), TaskType::TASK_TYPE_RESTORE);
+        $updateSteps = new Stepper($this->upgradeContainer->getTranslator(), TaskType::TASK_TYPE_RESTORE);
 
         return array_merge(
             $updateSteps->getStepParams($this::CURRENT_STEP),

--- a/controllers/admin/self-managed/RestorePagePostRestoreController.php
+++ b/controllers/admin/self-managed/RestorePagePostRestoreController.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+namespace PrestaShop\Module\AutoUpgrade\Controller;
+
+use PrestaShop\Module\AutoUpgrade\DocumentationLinks;
+use PrestaShop\Module\AutoUpgrade\Router\Routes;
+use PrestaShop\Module\AutoUpgrade\Task\TaskType;
+use PrestaShop\Module\AutoUpgrade\Twig\RestoreSteps;
+use PrestaShop\Module\AutoUpgrade\Twig\Steps;
+use PrestaShop\Module\AutoUpgrade\Twig\UpdateSteps;
+use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
+
+class RestorePagePostRestoreController extends AbstractPageWithStepController
+{
+    const CURRENT_STEP = RestoreSteps::STEP_POST_RESTORE;
+
+    protected function getPageTemplate(): string
+    {
+        return 'restore';
+    }
+
+    protected function getStepTemplate(): string
+    {
+        return self::CURRENT_STEP;
+    }
+
+    protected function displayRouteInUrl(): ?string
+    {
+        return Routes::RESTORE_PAGE_POST_RESTORE;
+    }
+
+    /**
+     * @return array<string, mixed>
+     *
+     * @throws \Exception
+     */
+    protected function getParams(): array
+    {
+        $updateSteps = new Steps($this->upgradeContainer->getTranslator(), TaskType::TASK_TYPE_RESTORE);
+
+        return array_merge(
+            $updateSteps->getStepParams($this::CURRENT_STEP),
+            [
+                'exit_link' => DIRECTORY_SEPARATOR . $this->upgradeContainer->getProperty(UpgradeContainer::PS_ADMIN_SUBDIR) . DIRECTORY_SEPARATOR . 'index.php',
+                'dev_doc_link' => DocumentationLinks::DEV_DOC_UPGRADE_POST_RESTORE_URL,
+                'download_logs' => $this->upgradeContainer->getLogsService()->getDownloadLogsData(TaskType::TASK_TYPE_RESTORE),
+            ]
+        );
+    }
+}

--- a/views/templates/steps/post-restore.html.twig
+++ b/views/templates/steps/post-restore.html.twig
@@ -47,23 +47,25 @@
       </ul>
     </div>
 
-    <div class="content__section">
-      <a class="link" href="{{ backlog_link }}" download>
-        {{ 'Download restore logs'|trans({}) }}
-        <i class="material-icons">file_upload</i>
-      </a>
-    </div>
+    {% if download_logs is defined %}
+      <div class="content__section">
+        <a class="link" href="{{ download_logs.download_path }}" download="{{ download_logs.filename }}">
+          {{ download_logs.button_label }}
+          <i class="material-icons">file_upload</i>
+        </a>
+      </div>
+    {% endif %}
   </div>
 {% endblock %}
 
 {% block buttons_inner %}
-  <button class="btn btn-lg btn-default" type="button">
+  <a class="btn btn-lg btn-default" href="{{ exit_link }}">
     <i class="material-icons">exit_to_app</i>
     {{ 'Exit'|trans({}) }}
-  </button>
+  </a>
 
-  <button class="btn btn-lg btn-primary" type="button">
+  <a class="btn btn-lg btn-primary" type="button" href="{{ dev_doc_link }}" target="_blank">
     <i class="material-icons">launch</i>
     {{ 'Open developer documentation'|trans({}) }}
-  </button>
+  </a>
 {% endblock %}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add post restore page
| Type?             |  new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | @PrestaShopCorp
| How to test?      | You can try to access directly with parameter `&new-ui=1&route=restore-page-post-restore` but without the restore task you can't access logs.
