### PR TITLE
Refactor Codebase to Use Symfony Filesystem Instead of Native PHP Functions

### DIFF
--- a/classes/Parameters/FileStorage.php
+++ b/classes/Parameters/FileStorage.php
@@ -47,10 +47,10 @@ class FileStorage
      */
     private $filesystem;
 
-    public function __construct(string $path)
+    public function __construct(Filesystem $filesystem, string $path)
     {
+        $this->filesystem = $filesystem;
         $this->configPath = $path;
-        $this->filesystem = new Filesystem();
     }
 
     /**
@@ -65,7 +65,7 @@ class FileStorage
         $configFilePath = $this->configPath . $fileName;
         $config = [];
 
-        if (file_exists($configFilePath)) {
+        if ($this->filesystem->exists($configFilePath)) {
             $config = @unserialize(base64_decode(Tools14::file_get_contents($configFilePath)));
         }
 

--- a/classes/PrestashopConfiguration.php
+++ b/classes/PrestashopConfiguration.php
@@ -29,9 +29,14 @@ namespace PrestaShop\Module\AutoUpgrade;
 
 use Exception;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
+use Symfony\Component\Filesystem\Filesystem;
 
 class PrestashopConfiguration
 {
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
     // Variables used for cache
     /**
      * @var string
@@ -44,8 +49,9 @@ class PrestashopConfiguration
      */
     private $psRootDir;
 
-    public function __construct(string $psRootDir)
+    public function __construct(Filesystem $filesystem, string $psRootDir)
     {
+        $this->filesystem = $filesystem;
         $this->psRootDir = $psRootDir;
     }
 
@@ -61,7 +67,7 @@ class PrestashopConfiguration
         // TODO: to be moved as property class in order to make tests possible
         $path = _PS_ROOT_DIR_ . '/modules/autoupgrade/config.xml';
 
-        if (file_exists($path)
+        if ($this->filesystem->exists($path)
             && $xml_module_version = simplexml_load_file($path)
         ) {
             $this->moduleVersion = (string) $xml_module_version->version;
@@ -85,7 +91,7 @@ class PrestashopConfiguration
             $this->psRootDir . '/src/Core/Version.php',
         ];
         foreach ($files as $file) {
-            if (!file_exists($file)) {
+            if (!$this->filesystem->exists($file)) {
                 continue;
             }
             $version = $this->findPrestaShopVersionInFile(file_get_contents($file));

--- a/classes/Services/ComposerService.php
+++ b/classes/Services/ComposerService.php
@@ -27,9 +27,21 @@
 
 namespace PrestaShop\Module\AutoUpgrade\Services;
 
+use Symfony\Component\Filesystem\Filesystem;
+
 class ComposerService
 {
     const COMPOSER_PACKAGE_TYPE = 'prestashop-module';
+
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    public function __construct(Filesystem $filesystem)
+    {
+        $this->filesystem = $filesystem;
+    }
 
     /**
      * Returns packages defined as PrestaShop modules in composer.lock
@@ -38,7 +50,7 @@ class ComposerService
      */
     public function getModulesInComposerLock(string $composerFile): array
     {
-        if (!file_exists($composerFile)) {
+        if (!$this->filesystem->exists($composerFile)) {
             return [];
         }
         // Native modules are the one integrated in PrestaShop release via composer
@@ -52,7 +64,8 @@ class ComposerService
         $modules = array_filter($content['packages'], function (array $package) {
             return self::COMPOSER_PACKAGE_TYPE === $package['type'] && !empty($package['name']);
         });
-        $modules = array_map(function (array $package) {
+
+        return array_map(function (array $package) {
             $vendorName = explode('/', $package['name']);
 
             return [
@@ -60,7 +73,5 @@ class ComposerService
                 'version' => ltrim($package['version'], 'v'),
             ];
         }, $modules);
-
-        return $modules;
     }
 }

--- a/classes/Task/Backup/BackupDatabase.php
+++ b/classes/Task/Backup/BackupDatabase.php
@@ -118,8 +118,8 @@ class BackupDatabase extends AbstractTask
                     !(isset($schema[0]['Table'], $schema[0]['Create Table'])
                         || isset($schema[0]['View'], $schema[0]['Create View']))) {
                     fclose($fp);
-                    if (file_exists($backupfile)) {
-                        unlink($backupfile);
+                    if ($this->container->getFileSystem()->exists($backupfile)) {
+                        $this->container->getFileSystem()->remove($backupfile);
                     }
                     $this->logger->error($this->translator->trans('An error occurred while backing up. Unable to obtain the schema of %s', [$table]));
                     $this->logger->info($this->translator->trans('Error during database backup.'));
@@ -279,7 +279,7 @@ class BackupDatabase extends AbstractTask
         }
 
         if (!is_dir($this->container->getProperty(UpgradeContainer::BACKUP_PATH) . DIRECTORY_SEPARATOR . $state->getBackupName())) {
-            mkdir($this->container->getProperty(UpgradeContainer::BACKUP_PATH) . DIRECTORY_SEPARATOR . $state->getBackupName());
+            $this->container->getFileSystem()->mkdir($this->container->getProperty(UpgradeContainer::BACKUP_PATH) . DIRECTORY_SEPARATOR . $state->getBackupName());
         }
         $state->setDbStep(0);
         $listOfTables = $this->filterTablesToSync(
@@ -345,7 +345,7 @@ class BackupDatabase extends AbstractTask
     private function openPartialBackupFile(string $backupfile)
     {
         // Figure out what compression is available and open the file
-        if (file_exists($backupfile)) {
+        if ($this->container->getFileSystem()->exists($backupfile)) {
             throw (new UpgradeException($this->translator->trans('Backup file %s already exists. Operation aborted.', [$backupfile])))->setSeverity(UpgradeException::SEVERITY_ERROR);
         }
 

--- a/classes/Task/Backup/BackupFiles.php
+++ b/classes/Task/Backup/BackupFiles.php
@@ -71,8 +71,8 @@ class BackupFiles extends AbstractTask
             }
 
             // delete old backup, create new
-            if (file_exists($this->container->getProperty(UpgradeContainer::BACKUP_PATH) . DIRECTORY_SEPARATOR . $backupFilesFilename)) {
-                unlink($this->container->getProperty(UpgradeContainer::BACKUP_PATH) . DIRECTORY_SEPARATOR . $backupFilesFilename);
+            if ($this->container->getFileSystem()->exists($this->container->getProperty(UpgradeContainer::BACKUP_PATH) . DIRECTORY_SEPARATOR . $backupFilesFilename)) {
+                $this->container->getFileSystem()->remove($this->container->getProperty(UpgradeContainer::BACKUP_PATH) . DIRECTORY_SEPARATOR . $backupFilesFilename);
             }
 
             $this->logger->debug($this->translator->trans('Backup files initialized in %s', [$backupFilesFilename]));

--- a/classes/Task/Restore/RestoreFiles.php
+++ b/classes/Task/Restore/RestoreFiles.php
@@ -55,8 +55,8 @@ class RestoreFiles extends AbstractTask
 
         // loop
         $this->next = TaskName::TASK_RESTORE_FILES;
-        if (!file_exists($this->container->getProperty(UpgradeContainer::WORKSPACE_PATH) . DIRECTORY_SEPARATOR . UpgradeFileNames::FILES_FROM_ARCHIVE_LIST)
-            || !file_exists($this->container->getProperty(UpgradeContainer::WORKSPACE_PATH) . DIRECTORY_SEPARATOR . UpgradeFileNames::FILES_TO_REMOVE_LIST)) {
+        if (!$this->container->getFileSystem()->exists($this->container->getProperty(UpgradeContainer::WORKSPACE_PATH) . DIRECTORY_SEPARATOR . UpgradeFileNames::FILES_FROM_ARCHIVE_LIST)
+            || !$this->container->getFileSystem()->exists($this->container->getProperty(UpgradeContainer::WORKSPACE_PATH) . DIRECTORY_SEPARATOR . UpgradeFileNames::FILES_TO_REMOVE_LIST)) {
             // cleanup current PS tree
             $fromArchive = $this->container->getZipAction()->listContent($this->container->getProperty(UpgradeContainer::BACKUP_PATH) . DIRECTORY_SEPARATOR . $state->getRestoreFilesFilename());
             foreach ($fromArchive as $k => $v) {
@@ -119,7 +119,7 @@ class RestoreFiles extends AbstractTask
 
             if (!empty($toRemoveOnly)) {
                 foreach ($toRemoveOnly as $fileToRemove) {
-                    @unlink($this->container->getProperty(UpgradeContainer::PS_ROOT_PATH) . $fileToRemove);
+                    $this->container->getFileSystem()->remove($this->container->getProperty(UpgradeContainer::PS_ROOT_PATH) . $fileToRemove);
                 }
             }
 

--- a/classes/Task/Restore/RestoreInitialization.php
+++ b/classes/Task/Restore/RestoreInitialization.php
@@ -105,11 +105,11 @@ class RestoreInitialization extends AbstractTask
         $this->next = TaskName::TASK_RESTORE_FILES;
         $this->logger->info($this->translator->trans('Restoring files ...'));
         // remove tmp files related to restoreFiles
-        if (file_exists($this->container->getProperty(UpgradeContainer::WORKSPACE_PATH) . DIRECTORY_SEPARATOR . UpgradeFileNames::FILES_FROM_ARCHIVE_LIST)) {
-            unlink($this->container->getProperty(UpgradeContainer::WORKSPACE_PATH) . DIRECTORY_SEPARATOR . UpgradeFileNames::FILES_FROM_ARCHIVE_LIST);
+        if ($this->container->getFileSystem()->exists($this->container->getProperty(UpgradeContainer::WORKSPACE_PATH) . DIRECTORY_SEPARATOR . UpgradeFileNames::FILES_FROM_ARCHIVE_LIST)) {
+            $this->container->getFileSystem()->remove($this->container->getProperty(UpgradeContainer::WORKSPACE_PATH) . DIRECTORY_SEPARATOR . UpgradeFileNames::FILES_FROM_ARCHIVE_LIST);
         }
-        if (file_exists($this->container->getProperty(UpgradeContainer::WORKSPACE_PATH) . DIRECTORY_SEPARATOR . UpgradeFileNames::FILES_TO_REMOVE_LIST)) {
-            unlink($this->container->getProperty(UpgradeContainer::WORKSPACE_PATH) . DIRECTORY_SEPARATOR . UpgradeFileNames::FILES_TO_REMOVE_LIST);
+        if ($this->container->getFileSystem()->exists($this->container->getProperty(UpgradeContainer::WORKSPACE_PATH) . DIRECTORY_SEPARATOR . UpgradeFileNames::FILES_TO_REMOVE_LIST)) {
+            $this->container->getFileSystem()->remove($this->container->getProperty(UpgradeContainer::WORKSPACE_PATH) . DIRECTORY_SEPARATOR . UpgradeFileNames::FILES_TO_REMOVE_LIST);
         }
 
         $this->container->getAnalytics()->track('Restore Launched', Analytics::WITH_RESTORE_PROPERTIES);

--- a/classes/Task/Update/Unzip.php
+++ b/classes/Task/Update/Unzip.php
@@ -34,8 +34,6 @@ use PrestaShop\Module\AutoUpgrade\Task\ExitCode;
 use PrestaShop\Module\AutoUpgrade\Task\TaskName;
 use PrestaShop\Module\AutoUpgrade\Task\TaskType;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
-use PrestaShop\Module\AutoUpgrade\UpgradeTools\FilesystemAdapter;
-use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * extract chosen version into $this->upgradeClass->latestPath directory.
@@ -56,8 +54,14 @@ class Unzip extends AbstractTask
             $this->container->getCompletionCalculator()->getBasePercentageOfTask(self::class)
         );
 
-        if (file_exists($destExtract)) {
-            FilesystemAdapter::deleteDirectory($destExtract, false);
+        if ($this->container->getFileSystem()->exists($destExtract)) {
+            foreach (scandir($destExtract) as $item) {
+                if ($item !== '.' && $item !== '..') {
+                    $path = $destExtract . DIRECTORY_SEPARATOR . $item;
+                    $this->container->getFileSystem()->remove($path);
+                }
+            }
+
             $this->logger->debug($this->translator->trans('"/latest" directory has been emptied'));
         }
         $relative_extract_path = str_replace(_PS_ROOT_DIR_, '', $destExtract);
@@ -89,10 +93,11 @@ class Unzip extends AbstractTask
         // From PrestaShop 1.7, we zip all the files in another package
         // which must be unzipped too
         $newZip = $destExtract . DIRECTORY_SEPARATOR . 'prestashop.zip';
-        if (file_exists($newZip)) {
-            @unlink($destExtract . DIRECTORY_SEPARATOR . '/index.php');
-            @unlink($destExtract . DIRECTORY_SEPARATOR . '/Install_PrestaShop.html');
-
+        if ($this->container->getFileSystem()->exists($newZip)) {
+            $this->container->getFileSystem()->remove([
+                $destExtract . DIRECTORY_SEPARATOR . '/index.php',
+                $destExtract . DIRECTORY_SEPARATOR . '/Install_PrestaShop.html',
+            ]);
             $subRes = $this->container->getZipAction()->extract($newZip, $destExtract);
             if (!$subRes) {
                 $this->next = TaskName::TASK_ERROR;
@@ -107,7 +112,6 @@ class Unzip extends AbstractTask
                 return ExitCode::FAIL;
             }
         } else {
-            $filesystem = new Filesystem();
             $zipSubfolder = $destExtract . '/prestashop/';
             if (!is_dir($zipSubfolder)) {
                 $this->next = TaskName::TASK_ERROR;
@@ -121,7 +125,7 @@ class Unzip extends AbstractTask
                 if ($file[0] === '.') {
                     continue;
                 }
-                $filesystem->rename($zipSubfolder . $file, $destExtract . '/' . $file);
+                $this->container->getFileSystem()->rename($zipSubfolder . $file, $destExtract . '/' . $file);
             }
         }
 
@@ -130,7 +134,7 @@ class Unzip extends AbstractTask
 
         $this->container->getAnalytics()->track('Backup Launched', Analytics::WITH_BACKUP_PROPERTIES);
 
-        @unlink($newZip);
+        $this->container->getFileSystem()->remove($newZip);
 
         return ExitCode::SUCCESS;
     }

--- a/classes/Task/Update/UpdateFiles.php
+++ b/classes/Task/Update/UpdateFiles.php
@@ -35,7 +35,7 @@ use PrestaShop\Module\AutoUpgrade\Task\ExitCode;
 use PrestaShop\Module\AutoUpgrade\Task\TaskName;
 use PrestaShop\Module\AutoUpgrade\Task\TaskType;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
-use PrestaShop\Module\AutoUpgrade\UpgradeTools\FilesystemAdapter;
+use Symfony\Component\Filesystem\Exception\IOException;
 
 class UpdateFiles extends AbstractTask
 {
@@ -126,18 +126,19 @@ class UpdateFiles extends AbstractTask
         }
         if (is_dir($orig)) {
             // if $dest is not a directory (that can happen), just remove that file
-            if (!is_dir($dest) && file_exists($dest)) {
-                unlink($dest);
+            if (!is_dir($dest) && $this->container->getFileSystem()->exists($dest)) {
+                $this->container->getFileSystem()->remove($dest);
                 $this->logger->debug($this->translator->trans('File %1$s has been deleted.', [$file]));
             }
-            if (!file_exists($dest)) {
-                if (mkdir($dest)) {
+            if (!$this->container->getFileSystem()->exists($dest)) {
+                try {
+                    $this->container->getFileSystem()->mkdir($dest);
                     $this->logger->debug($this->translator->trans('Directory %1$s created.', [$file]));
 
                     return true;
-                } else {
+                } catch (IOException $e) {
                     $this->next = TaskName::TASK_ERROR;
-                    $this->logger->error($this->translator->trans('Error while creating directory %s.', [$dest]));
+                    $this->logger->error($this->translator->trans('Error while creating directory %s: %s.', [$dest, $e->getMessage()]));
 
                     return false;
                 }
@@ -148,7 +149,7 @@ class UpdateFiles extends AbstractTask
             }
         } elseif (is_file($orig)) {
             $translationAdapter = $this->container->getTranslationAdapter();
-            if ($translationAdapter->isTranslationFile($file) && file_exists($dest)) {
+            if ($translationAdapter->isTranslationFile($file) && $this->container->getFileSystem()->exists($dest)) {
                 $type_trad = $translationAdapter->getTranslationFileType($file);
                 if ($translationAdapter->mergeTranslationFile($orig, $dest, $type_trad)) {
                     $this->logger->info($this->translator->trans('The translation files have been merged into file %s.', [$dest]));
@@ -163,25 +164,24 @@ class UpdateFiles extends AbstractTask
 
             // upgrade exception were above. This part now process all files that have to be upgraded (means to modify or to remove)
             // delete before updating (and this will also remove deprecated files)
-            if (copy($orig, $dest)) {
+            try {
+                $this->container->getFileSystem()->copy($orig, $dest);
                 $this->logger->debug($this->translator->trans('Copied %1$s.', [$file]));
 
                 return true;
-            } else {
+            } catch (IOException $e) {
                 $this->next = TaskName::TASK_ERROR;
-                $this->logger->error($this->translator->trans('Error while copying file %s', [$file]));
+                $this->logger->error($this->translator->trans('Error while copying file %s: %s', [$file, $e->getMessage()]));
 
                 return false;
             }
         } elseif (is_file($dest)) {
-            if (file_exists($dest)) {
-                unlink($dest);
-            }
+            $this->container->getFileSystem()->remove($dest);
             $this->logger->debug(sprintf('Removed file %1$s.', $file));
 
             return true;
         } elseif (is_dir($dest)) {
-            FilesystemAdapter::deleteDirectory($dest);
+            $this->container->getFileSystem()->remove($dest);
             $this->logger->debug(sprintf('Removed dir %1$s.', $file));
 
             return true;
@@ -214,15 +214,15 @@ class UpdateFiles extends AbstractTask
 
         // Replace the name of the admin folder inside the release to match our admin folder name
         $admin_dir = str_replace($this->container->getProperty(UpgradeContainer::PS_ROOT_PATH) . DIRECTORY_SEPARATOR, '', $this->container->getProperty(UpgradeContainer::PS_ADMIN_PATH));
-        if (file_exists($newReleasePath . DIRECTORY_SEPARATOR . 'admin')) {
-            rename($newReleasePath . DIRECTORY_SEPARATOR . 'admin', $newReleasePath . DIRECTORY_SEPARATOR . $admin_dir);
-        } elseif (file_exists($newReleasePath . DIRECTORY_SEPARATOR . 'admin-dev')) {
-            rename($newReleasePath . DIRECTORY_SEPARATOR . 'admin-dev', $newReleasePath . DIRECTORY_SEPARATOR . $admin_dir);
+        if ($this->container->getFileSystem()->exists($newReleasePath . DIRECTORY_SEPARATOR . 'admin')) {
+            $this->container->getFileSystem()->rename($newReleasePath . DIRECTORY_SEPARATOR . 'admin', $newReleasePath . DIRECTORY_SEPARATOR . $admin_dir);
+        } elseif ($this->container->getFileSystem()->exists($newReleasePath . DIRECTORY_SEPARATOR . 'admin-dev')) {
+            $this->container->getFileSystem()->rename($newReleasePath . DIRECTORY_SEPARATOR . 'admin-dev', $newReleasePath . DIRECTORY_SEPARATOR . $admin_dir);
         }
 
         // Rename develop installer directory, it would be ignored anyway because it's present in getFilesToIgnoreOnUpgrade()
-        if (file_exists($newReleasePath . DIRECTORY_SEPARATOR . 'install-dev')) {
-            rename($newReleasePath . DIRECTORY_SEPARATOR . 'install-dev', $newReleasePath . DIRECTORY_SEPARATOR . 'install');
+        if ($this->container->getFileSystem()->exists($newReleasePath . DIRECTORY_SEPARATOR . 'install-dev')) {
+            $this->container->getFileSystem()->rename($newReleasePath . DIRECTORY_SEPARATOR . 'install-dev', $newReleasePath . DIRECTORY_SEPARATOR . 'install');
         }
 
         $destinationVersion = $state->getDestinationVersion();

--- a/classes/Task/Update/UpdateFiles.php
+++ b/classes/Task/Update/UpdateFiles.php
@@ -165,7 +165,7 @@ class UpdateFiles extends AbstractTask
             // upgrade exception were above. This part now process all files that have to be upgraded (means to modify or to remove)
             // delete before updating (and this will also remove deprecated files)
             try {
-                $this->container->getFileSystem()->copy($orig, $dest);
+                $this->container->getFileSystem()->copy($orig, $dest, true);
                 $this->logger->debug($this->translator->trans('Copied %1$s.', [$file]));
 
                 return true;

--- a/classes/Task/Update/UpdateModules.php
+++ b/classes/Task/Update/UpdateModules.php
@@ -44,7 +44,6 @@ use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\ModuleUnzipper;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\ModuleUnzipperContext;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\ModuleVersionAdapter;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\Source\ModuleSourceAggregate;
-use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * Upgrade all partners modules according to the installed prestashop version.
@@ -69,7 +68,7 @@ class UpdateModules extends AbstractTask
         $moduleSourceList = new ModuleSourceAggregate($this->container->getModuleSourceProviders());
         $moduleDownloader = new ModuleDownloader($this->container->getDownloadService(), $this->translator, $this->logger, $this->container->getProperty(UpgradeContainer::TMP_PATH));
         $moduleUnzipper = new ModuleUnzipper($this->translator, $this->container->getZipAction(), $modulesPath);
-        $moduleMigration = new ModuleMigration($this->translator, $this->logger, $this->container->getProperty(UpgradeContainer::TMP_PATH));
+        $moduleMigration = new ModuleMigration($this->container->getFileSystem(), $this->translator, $this->logger, $this->container->getProperty(UpgradeContainer::TMP_PATH));
 
         if ($listModules->getRemainingTotal()) {
             $moduleInfos = $listModules->getNext();
@@ -112,7 +111,7 @@ class UpdateModules extends AbstractTask
             } finally {
                 // Cleanup of module assets
                 if (!empty($moduleDownloaderContext) && !empty($moduleDownloaderContext->getPathToModuleUpdate())) {
-                    (new Filesystem())->remove([$moduleDownloaderContext->getPathToModuleUpdate()]);
+                    $this->container->getFileSystem()->remove([$moduleDownloaderContext->getPathToModuleUpdate()]);
                 }
             }
         }

--- a/classes/Tools14.php
+++ b/classes/Tools14.php
@@ -117,38 +117,6 @@ class Tools14
     }
 
     /**
-     * Delete directory and subdirectories.
-     *
-     * @param string $dirname Directory name
-     */
-    public static function deleteDirectory(string $dirname, bool $delete_self = true): bool
-    {
-        $dirname = rtrim($dirname, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
-        if (file_exists($dirname)) {
-            if ($files = scandir($dirname)) {
-                foreach ($files as $file) {
-                    if ($file != '.' && $file != '..' && $file != '.svn') {
-                        if (is_file($dirname . $file)) {
-                            unlink($dirname . $file);
-                        } elseif (is_dir($dirname . $file . DIRECTORY_SEPARATOR)) {
-                            self::deleteDirectory($dirname . $file . DIRECTORY_SEPARATOR, true);
-                        }
-                    }
-                }
-                if ($delete_self && file_exists($dirname)) {
-                    if (!rmdir($dirname)) {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
      * Check if submit has been posted.
      *
      * @param string $submit submit name

--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -98,9 +98,7 @@ class UpgradeContainer
     const ARCHIVE_FILEPATH = 'destDownloadFilepath';
     const PS_VERSION = 'version';
 
-    /**
-     * @var Analytics
-     */
+    /** @var Analytics */
     private $analytics;
 
     /** @var BackupFinder */
@@ -109,186 +107,126 @@ class UpgradeContainer
     /** @var BackupManager */
     private $backupManager;
 
-    /**
-     * @var CacheCleaner
-     */
+    /** @var CacheCleaner */
     private $cacheCleaner;
 
-    /**
-     * @var ChecksumCompare
-     */
+    /** @var ChecksumCompare */
     private $checksumCompare;
 
     /** @var ComposerService */
     private $composerService;
 
-    /**
-     * @var Cookie
-     */
+    /** @var Cookie */
     private $cookie;
 
-    /**
-     * @var \Db
-     */
+    /** @var \Db */
     public $db;
 
-    /**
-     * @var FileStorage
-     */
+    /** @var FileStorage */
     private $fileStorage;
 
-    /**
-     * @var FileFilter
-     */
+    /** @var FileFilter */
     private $fileFilter;
 
-    /**
-     * @var PrestashopConfiguration
-     */
+    /** @var PrestashopConfiguration */
     private $prestashopConfiguration;
 
-    /**
-     * @var ConfigurationStorage
-     */
+    /** @var ConfigurationStorage */
     private $configurationStorage;
 
-    /**
-     * @var UpgradeConfiguration
-     */
+    /** @var UpgradeConfiguration */
     private $updateConfiguration;
 
-    /**
-     * @var RestoreConfiguration
-     */
+    /** @var RestoreConfiguration */
     private $restoreConfiguration;
 
-    /**
-     * @var FilesystemAdapter
-     */
+    /** @var FilesystemAdapter */
     private $filesystemAdapter;
 
-    /**
-     * @var FileLoader
-     */
+    /** @var FileLoader */
     private $fileLoader;
 
-    /**
-     * @var Logger
-     */
+    /** @var Logger */
     private $logger;
 
-    /**
-     * @var LogsService
-     */
+    /** @var LogsService */
     private $logsService;
 
-    /**
-     * @var ModuleAdapter
-     */
+    /** @var ModuleAdapter */
     private $moduleAdapter;
 
-    /**
-     * @var AbstractModuleSourceProvider[]
-     */
+    /** @var AbstractModuleSourceProvider[] */
     private $moduleSourceProviders;
 
-    /**
-     * @var CompletionCalculator
-     */
+    /** @var CompletionCalculator */
     private $completionCalculator;
 
-    /**
-     * @var Twig_Environment|\Twig\Environment
-     */
+    /** @var Twig_Environment|\Twig\Environment */
     private $twig;
 
-    /**
-     * @var BackupState
-     */
+    /** @var BackupState */
     private $backupState;
 
-    /**
-     * @var LogsState
-     */
+    /** @var LogsState */
     private $logsState;
 
-    /**
-     * @var RestoreState
-     */
+    /** @var RestoreState */
     private $restoreState;
 
-    /**
-     * @var UpdateState
-     */
+    /** @var UpdateState */
     private $updateState;
 
-    /**
-     * @var SymfonyAdapter
-     */
+    /** @var SymfonyAdapter */
     private $symfonyAdapter;
 
-    /**
-     * @var Upgrader
-     */
+    /** @var Upgrader */
     private $upgrader;
 
-    /**
-     * @var Workspace
-     */
+    /** @var Workspace */
     private $workspace;
 
-    /**
-     * @var ZipAction
-     */
+    /** @var ZipAction */
     private $zipAction;
 
-    /**
-     * @var LocalArchiveRepository
-     */
+    /** @var LocalArchiveRepository */
     private $localArchiveRepository;
 
-    /**
-     * @var AssetsEnvironment
-     */
+    /** @var AssetsEnvironment */
     private $assetsEnvironment;
 
-    /**
-     * @var ConfigurationValidator
-     */
+    /** @var ConfigurationValidator */
     private $configurationValidator;
 
-    /**
-     * @var LocalChannelConfigurationValidator
-     */
+    /** @var LocalChannelConfigurationValidator */
     private $localChannelConfigurationValidator;
 
-    /**
-     * @var PrestashopVersionService
-     */
+    /** @var PrestashopVersionService */
     private $prestashopVersionService;
 
-    /**
-     * @var UpgradeSelfCheck
-     */
+    /** @var UpgradeSelfCheck */
     private $upgradeSelfCheck;
+
+    /** @var PhpVersionResolverService */
+    private $phpVersionResolverService;
+
+    /** @var DistributionApiService */
+    private $distributionApiService;
+
+    /** @var Filesystem */
+    private $filesystem;
+
+    /** @var Translator */
+    private $translator;
+
+    /** @var Translation */
+    private $translation;
+
+    /** @var DownloadService */
+    private $downloadService;
 
     /** @var UrlGenerator */
     private $urlGenerator;
 
-    /**
-     * @var PhpVersionResolverService
-     */
-    private $phpVersionResolverService;
-
-    /**
-     * @var DistributionApiService
-     */
-    private $distributionApiService;
-
-    /**
-     * @var DownloadService
-     */
-    private $downloadService;
     /**
      * AdminSelfUpgrade::$autoupgradePath
      * Ex.: /var/www/html/PrestaShop/admin-dev/autoupgrade.
@@ -313,7 +251,7 @@ class UpgradeContainer
         $this->adminDir = $adminDir;
         $this->psRootDir = $psRootDir;
 
-        if (file_exists($psRootDir . '/modules/autoupgrade/.env')) {
+        if ($this->getFileSystem()->exists($psRootDir . '/modules/autoupgrade/.env')) {
             $dotenv = new Dotenv();
             $dotenv->load($psRootDir . '/modules/autoupgrade/.env');
         }
@@ -432,7 +370,7 @@ class UpgradeContainer
     public function getComposerService(): ComposerService
     {
         if (null === $this->composerService) {
-            $this->composerService = new ComposerService();
+            $this->composerService = new ComposerService($this->getFileSystem());
         }
 
         return $this->composerService;
@@ -470,7 +408,7 @@ class UpgradeContainer
     public function getFileStorage(): FileStorage
     {
         if (null === $this->fileStorage) {
-            $this->fileStorage = new FileStorage($this->getProperty(self::WORKSPACE_PATH) . DIRECTORY_SEPARATOR);
+            $this->fileStorage = new FileStorage($this->getFileSystem(), $this->getProperty(self::WORKSPACE_PATH) . DIRECTORY_SEPARATOR);
         }
 
         return $this->fileStorage;
@@ -505,6 +443,8 @@ class UpgradeContainer
             $upgrader = new Upgrader(
                 $this->getPhpVersionResolverService(),
                 $this->getUpdateConfiguration(),
+                $this->getFileSystem(),
+                $this->getFileLoader(),
                 $this->getProperty(self::PS_VERSION)
             );
 
@@ -541,7 +481,7 @@ class UpgradeContainer
     public function getFileLoader(): FileLoader
     {
         if (null === $this->fileLoader) {
-            $this->fileLoader = new FileLoader();
+            $this->fileLoader = new FileLoader($this->getFileSystem());
         }
 
         return $this->fileLoader;
@@ -686,21 +626,32 @@ class UpgradeContainer
      */
     public function getTranslationAdapter(): Translation
     {
-        return new Translation($this->getTranslator(), $this->getLogger(), $this->getUpdateState()->getInstalledLanguagesIso());
-    }
-
-    public function getTranslator(): Translator
-    {
-        $locale = null;
-        // @phpstan-ignore booleanAnd.rightAlwaysTrue (If PrestaShop core is not instantiated properly, do not try to translate)
-        if (method_exists('\Context', 'getContext') && \Context::getContext()->language) {
-            $locale = \Context::getContext()->language->iso_code;
+        if (null === $this->translation) {
+            $this->translation = new Translation($this->getTranslator(), $this->getFileSystem(), $this->getLogger(), $this->getUpdateState()->getInstalledLanguagesIso());
         }
 
-        return new Translator(
-            $this->getProperty(self::PS_ROOT_PATH) . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR . 'autoupgrade' . DIRECTORY_SEPARATOR . 'translations' . DIRECTORY_SEPARATOR,
-            $locale
-        );
+        return $this->translation;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function getTranslator(): Translator
+    {
+        if (null === $this->translator) {
+            $locale = null;
+            // @phpstan-ignore booleanAnd.rightAlwaysTrue (If PrestaShop core is not instantiated properly, do not try to translate)
+            if (method_exists('\Context', 'getContext') && \Context::getContext()->language) {
+                $locale = \Context::getContext()->language->iso_code;
+            }
+
+            $this->translator = new Translator(
+                $this->getProperty(self::PS_ROOT_PATH) . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR . 'autoupgrade' . DIRECTORY_SEPARATOR . 'translations' . DIRECTORY_SEPARATOR,
+                $locale
+            );
+        }
+
+        return $this->translator;
     }
 
     /**
@@ -739,6 +690,7 @@ class UpgradeContainer
     {
         if (null === $this->prestashopConfiguration) {
             $this->prestashopConfiguration = new PrestashopConfiguration(
+                $this->getFileSystem(),
                 $this->getProperty(self::PS_ROOT_PATH)
             );
         }
@@ -863,7 +815,7 @@ class UpgradeContainer
 
             $this->workspace = new Workspace(
                 $this->getTranslator(),
-                new Filesystem(),
+                $this->getFileSystem(),
                 $paths
             );
         }
@@ -878,6 +830,7 @@ class UpgradeContainer
     {
         if (null === $this->zipAction) {
             $this->zipAction = new ZipAction(
+                $this->getFileSystem(),
                 $this->getTranslator(),
                 $this->getLogger(),
                 $this->getUpdateConfiguration(),
@@ -949,10 +902,19 @@ class UpgradeContainer
     public function getPrestashopVersionService(): PrestashopVersionService
     {
         if (null === $this->prestashopVersionService) {
-            $this->prestashopVersionService = new PrestashopVersionService($this->getZipAction());
+            $this->prestashopVersionService = new PrestashopVersionService($this->getZipAction(), $this->getFileSystem());
         }
 
         return $this->prestashopVersionService;
+    }
+
+    public function getFileSystem(): Filesystem
+    {
+        if (null === $this->filesystem) {
+            $this->filesystem = new Filesystem();
+        }
+
+        return $this->filesystem;
     }
 
     /**
@@ -990,7 +952,7 @@ class UpgradeContainer
     public function initPrestaShopAutoloader(): void
     {
         $autoloader = $this->getProperty(self::PS_ROOT_PATH) . '/vendor/autoload.php';
-        if (file_exists($autoloader)) {
+        if ($this->getFileSystem()->exists($autoloader)) {
             require_once $autoloader;
         }
 

--- a/classes/UpgradeTools/CacheCleaner.php
+++ b/classes/UpgradeTools/CacheCleaner.php
@@ -73,7 +73,7 @@ class CacheCleaner
         }
 
         foreach ($dirsToClean as $dir) {
-            if (!file_exists($dir)) {
+            if (!$this->container->getFileSystem()->exists($dir)) {
                 $this->logger->debug($this->container->getTranslator()->trans('Directory "%s" does not exist and cannot be emptied.', [str_replace($this->container->getProperty(UpgradeContainer::PS_ROOT_PATH), '', $dir)]));
                 continue;
             }
@@ -81,12 +81,7 @@ class CacheCleaner
                 if ($file[0] === '.' || $file === 'index.php') {
                     continue;
                 }
-                // ToDo: Use Filesystem instead ?
-                if (is_file($dir . $file)) {
-                    unlink($dir . $file);
-                } elseif (is_dir($dir . $file . DIRECTORY_SEPARATOR)) {
-                    FilesystemAdapter::deleteDirectory($dir . $file . DIRECTORY_SEPARATOR);
-                }
+                $this->container->getFileSystem()->remove($dir . $file);
                 $this->logger->debug($this->container->getTranslator()->trans('File %s removed', [$file]));
             }
         }

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -67,11 +67,6 @@ abstract class CoreUpgrader
     protected $logger;
 
     /**
-     * @var Filesystem
-     */
-    private $filesystem;
-
-    /**
      * Version PrestaShop is upgraded to.
      *
      * @var string
@@ -92,15 +87,20 @@ abstract class CoreUpgrader
      */
     protected $pathToUpgradeScripts;
 
+    /**
+     * @var Filesystem
+     */
+    protected $fileSystem;
+
     public function __construct(UpgradeContainer $container, LoggerInterface $logger)
     {
         $this->container = $container;
+        $this->fileSystem = $this->container->getFileSystem();
         $this->logger = $logger;
-        $this->filesystem = new Filesystem();
         $this->destinationUpgradeVersion = $this->container->getUpdateState()->getDestinationVersion();
         $this->pathToInstallFolder = realpath($this->container->getProperty(UpgradeContainer::LATEST_PATH) . DIRECTORY_SEPARATOR . 'install');
         $this->pathToUpgradeScripts = dirname(__DIR__, 3) . '/upgrade/';
-        if (file_exists($this->pathToInstallFolder . DIRECTORY_SEPARATOR . 'autoload.php')) {
+        if ($this->fileSystem->exists($this->pathToInstallFolder . DIRECTORY_SEPARATOR . 'autoload.php')) {
             require_once $this->pathToInstallFolder . DIRECTORY_SEPARATOR . 'autoload.php';
         }
         $this->db = \Db::getInstance();
@@ -271,7 +271,7 @@ abstract class CoreUpgrader
      */
     protected function getUpgradeSqlFilesListToApply(string $upgrade_dir_sql, string $oldversion): array
     {
-        if (!file_exists($upgrade_dir_sql)) {
+        if (!$this->fileSystem->exists($upgrade_dir_sql)) {
             throw new UpgradeException($this->container->getTranslator()->trans('Unable to find upgrade directory in the installation path.'));
         }
 
@@ -424,7 +424,7 @@ abstract class CoreUpgrader
             $func_name = str_replace($stringParameters, '', $php[0]);
             $pathToPhpDirectory = $this->pathToUpgradeScripts . 'php/';
 
-            if (!file_exists($pathToPhpDirectory . strtolower($func_name) . '.php')) {
+            if (!$this->fileSystem->exists($pathToPhpDirectory . strtolower($func_name) . '.php')) {
                 $this->logMissingFileError($pathToPhpDirectory, $func_name, $query);
 
                 return;
@@ -566,7 +566,7 @@ abstract class CoreUpgrader
     {
         $this->loadEntityInterface();
 
-        if (file_exists(_PS_ROOT_DIR_ . '/classes/Tools.php')) {
+        if ($this->fileSystem->exists(_PS_ROOT_DIR_ . '/classes/Tools.php')) {
             require_once _PS_ROOT_DIR_ . '/classes/Tools.php';
         }
 
@@ -583,105 +583,105 @@ abstract class CoreUpgrader
             define('_PS_USE_SQL_SLAVE_', false);
         }
 
-        if (file_exists(_PS_ROOT_DIR_ . '/classes/ObjectModel.php')) {
+        if ($this->fileSystem->exists(_PS_ROOT_DIR_ . '/classes/ObjectModel.php')) {
             require_once _PS_ROOT_DIR_ . '/classes/ObjectModel.php';
         }
         if (!class_exists('ObjectModel', false) && class_exists('ObjectModelCore')) {
             eval('abstract class ObjectModel extends ObjectModelCore{}');
         }
 
-        if (file_exists(_PS_ROOT_DIR_ . '/classes/Configuration.php')) {
+        if ($this->fileSystem->exists(_PS_ROOT_DIR_ . '/classes/Configuration.php')) {
             require_once _PS_ROOT_DIR_ . '/classes/Configuration.php';
         }
         if (!class_exists('Configuration', false) && class_exists('ConfigurationCore')) {
             eval('class Configuration extends ConfigurationCore{}');
         }
 
-        if (file_exists(_PS_ROOT_DIR_ . '/classes/cache/Cache.php')) {
+        if ($this->fileSystem->exists(_PS_ROOT_DIR_ . '/classes/cache/Cache.php')) {
             require_once _PS_ROOT_DIR_ . '/classes/cache/Cache.php';
         }
         if (!class_exists('Cache', false) && class_exists('CacheCore')) {
             eval('abstract class Cache extends CacheCore{}');
         }
 
-        if (file_exists(_PS_ROOT_DIR_ . '/classes/PrestaShopCollection.php')) {
+        if ($this->fileSystem->exists(_PS_ROOT_DIR_ . '/classes/PrestaShopCollection.php')) {
             require_once _PS_ROOT_DIR_ . '/classes/PrestaShopCollection.php';
         }
         if (!class_exists('PrestaShopCollection', false) && class_exists('PrestaShopCollectionCore')) {
             eval('class PrestaShopCollection extends PrestaShopCollectionCore{}');
         }
 
-        if (file_exists(_PS_ROOT_DIR_ . '/classes/shop/ShopUrl.php')) {
+        if ($this->fileSystem->exists(_PS_ROOT_DIR_ . '/classes/shop/ShopUrl.php')) {
             require_once _PS_ROOT_DIR_ . '/classes/shop/ShopUrl.php';
         }
         if (!class_exists('ShopUrl', false) && class_exists('ShopUrlCore')) {
             eval('class ShopUrl extends ShopUrlCore{}');
         }
 
-        if (file_exists(_PS_ROOT_DIR_ . '/classes/shop/Shop.php')) {
+        if ($this->fileSystem->exists(_PS_ROOT_DIR_ . '/classes/shop/Shop.php')) {
             require_once _PS_ROOT_DIR_ . '/classes/shop/Shop.php';
         }
         if (!class_exists('Shop', false) && class_exists('ShopCore')) {
             eval('class Shop extends ShopCore{}');
         }
 
-        if (file_exists(_PS_ROOT_DIR_ . '/classes/Translate.php')) {
+        if ($this->fileSystem->exists(_PS_ROOT_DIR_ . '/classes/Translate.php')) {
             require_once _PS_ROOT_DIR_ . '/classes/Translate.php';
         }
         if (!class_exists('Translate', false) && class_exists('TranslateCore')) {
             eval('class Translate extends TranslateCore{}');
         }
 
-        if (file_exists(_PS_ROOT_DIR_ . '/classes/module/Module.php')) {
+        if ($this->fileSystem->exists(_PS_ROOT_DIR_ . '/classes/module/Module.php')) {
             require_once _PS_ROOT_DIR_ . '/classes/module/Module.php';
         }
         if (!class_exists('Module', false) && class_exists('ModuleCore')) {
             eval('class Module extends ModuleCore{}');
         }
 
-        if (file_exists(_PS_ROOT_DIR_ . '/classes/Validate.php')) {
+        if ($this->fileSystem->exists(_PS_ROOT_DIR_ . '/classes/Validate.php')) {
             require_once _PS_ROOT_DIR_ . '/classes/Validate.php';
         }
         if (!class_exists('Validate', false) && class_exists('ValidateCore')) {
             eval('class Validate extends ValidateCore{}');
         }
 
-        if (file_exists(_PS_ROOT_DIR_ . '/classes/Language.php')) {
+        if ($this->fileSystem->exists(_PS_ROOT_DIR_ . '/classes/Language.php')) {
             require_once _PS_ROOT_DIR_ . '/classes/Language.php';
         }
         if (!class_exists('Language', false) && class_exists('LanguageCore')) {
             eval('class Language extends LanguageCore{}');
         }
 
-        if (file_exists(_PS_ROOT_DIR_ . '/classes/Tab.php')) {
+        if ($this->fileSystem->exists(_PS_ROOT_DIR_ . '/classes/Tab.php')) {
             require_once _PS_ROOT_DIR_ . '/classes/Tab.php';
         }
         if (!class_exists('Tab', false) && class_exists('TabCore')) {
             eval('class Tab extends TabCore{}');
         }
 
-        if (file_exists(_PS_ROOT_DIR_ . '/classes/Dispatcher.php')) {
+        if ($this->fileSystem->exists(_PS_ROOT_DIR_ . '/classes/Dispatcher.php')) {
             require_once _PS_ROOT_DIR_ . '/classes/Dispatcher.php';
         }
         if (!class_exists('Dispatcher', false) && class_exists('DispatcherCore')) {
             eval('class Dispatcher extends DispatcherCore{}');
         }
 
-        if (file_exists(_PS_ROOT_DIR_ . '/classes/Hook.php')) {
+        if ($this->fileSystem->exists(_PS_ROOT_DIR_ . '/classes/Hook.php')) {
             require_once _PS_ROOT_DIR_ . '/classes/Hook.php';
         }
         if (!class_exists('Hook', false) && class_exists('HookCore')) {
             eval('class Hook extends HookCore{}');
         }
 
-        if (file_exists(_PS_ROOT_DIR_ . '/classes/Context.php')) {
+        if ($this->fileSystem->exists(_PS_ROOT_DIR_ . '/classes/Context.php')) {
             require_once _PS_ROOT_DIR_ . '/classes/Context.php';
         }
         if (!class_exists('Context', false) && class_exists('ContextCore')) {
             eval('class Context extends ContextCore{}');
         }
 
-        if (file_exists(_PS_ROOT_DIR_ . '/classes/Group.php')) {
+        if ($this->fileSystem->exists(_PS_ROOT_DIR_ . '/classes/Group.php')) {
             require_once _PS_ROOT_DIR_ . '/classes/Group.php';
         }
         if (!class_exists('Group', false) && class_exists('GroupCore')) {
@@ -718,8 +718,8 @@ abstract class CoreUpgrader
             _PS_ROOT_DIR_ . '/var/cache/prod/class_index.php',
         ];
         foreach ($files as $path) {
-            if (file_exists($path)) {
-                unlink($path);
+            if ($this->fileSystem->exists($path)) {
+                $this->fileSystem->remove($path);
             }
         }
     }
@@ -834,7 +834,7 @@ abstract class CoreUpgrader
     {
         foreach ($themes as $theme) {
             $files = $this->container->getFilesystemAdapter()->listSampleFiles($theme['directory'], '_rtl.css');
-            $this->filesystem->remove($files);
+            $this->fileSystem->remove($files);
         }
     }
 

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
@@ -55,8 +55,8 @@ class CoreUpgrader80 extends CoreUpgrader
         ];
 
         foreach ($filesToForceRemove as $file) {
-            if (file_exists(_PS_ROOT_DIR_ . $file)) {
-                unlink(_PS_ROOT_DIR_ . $file);
+            if ($this->fileSystem->exists(_PS_ROOT_DIR_ . $file)) {
+                $this->fileSystem->remove(_PS_ROOT_DIR_ . $file);
             }
         }
     }

--- a/classes/UpgradeTools/FilesystemAdapter.php
+++ b/classes/UpgradeTools/FilesystemAdapter.php
@@ -28,7 +28,6 @@
 namespace PrestaShop\Module\AutoUpgrade\UpgradeTools;
 
 use FilesystemIterator;
-use PrestaShop\Module\AutoUpgrade\Tools14;
 use RecursiveCallbackFilterIterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -83,16 +82,6 @@ class FilesystemAdapter
         $this->autoupgradeDir = $autoupgradeDir;
         $this->adminSubDir = $adminSubDir;
         $this->prodRootDir = $prodRootDir;
-    }
-
-    /**
-     * Delete directory and subdirectories.
-     *
-     * @param string $dirname Directory name
-     */
-    public static function deleteDirectory(string $dirname, bool $delete_self = true): bool
-    {
-        return Tools14::deleteDirectory($dirname, $delete_self);
     }
 
     /**

--- a/classes/UpgradeTools/Translation.php
+++ b/classes/UpgradeTools/Translation.php
@@ -29,6 +29,7 @@ namespace PrestaShop\Module\AutoUpgrade\UpgradeTools;
 
 use PrestaShop\Module\AutoUpgrade\Log\LoggerInterface;
 use PrestaShop\Module\AutoUpgrade\Tools14;
+use Symfony\Component\Filesystem\Filesystem;
 
 class Translation
 {
@@ -38,14 +39,17 @@ class Translation
     private $logger;
     /** @var Translator */
     private $translator;
+    /** @var Filesystem */
+    private $filesystem;
 
     /**
      * @param string[] $installedLanguagesIso
      */
-    public function __construct(Translator $translator, LoggerInterface $logger, array $installedLanguagesIso)
+    public function __construct(Translator $translator, Filesystem $filesystem, LoggerInterface $logger, array $installedLanguagesIso)
     {
         $this->logger = $logger;
         $this->translator = $translator;
+        $this->filesystem = $filesystem;
         $this->installedLanguagesIso = $installedLanguagesIso;
     }
 
@@ -120,7 +124,7 @@ class Translation
                 return false;
         }
 
-        if (!file_exists($orig)) {
+        if (!$this->filesystem->exists($orig)) {
             $this->logger->notice($this->translator->trans('File %s does not exist, merge skipped.', [$orig]));
 
             return true;
@@ -139,7 +143,7 @@ class Translation
         }
         $var_orig = $$var_name;
 
-        if (!file_exists($dest)) {
+        if (!$this->filesystem->exists($dest)) {
             $this->logger->notice($this->translator->trans('File %s does not exist, merge skipped.', [$dest]));
 
             return false;
@@ -149,7 +153,7 @@ class Translation
             // in that particular case : file exists, but variable missing, we need to delete that file
             // (if not, this invalid file will be copied in /translations during upgradeDb process)
             if ('module' == $type) {
-                unlink($dest);
+                $this->filesystem->remove($dest);
             }
             $this->logger->warning($this->translator->trans(
                 '%variablename% variable missing in file %filename%. File %filename% deleted and merge skipped.',

--- a/classes/Workspace.php
+++ b/classes/Workspace.php
@@ -54,12 +54,18 @@ class Workspace
         $this->paths = $paths;
     }
 
+    /**
+     * @throws IOException
+     */
     public function createFolders(): void
     {
         foreach ($this->paths as $path) {
-            if (!file_exists($path) && !@mkdir($path)) {
-                throw new IOException($this->translator->trans('Unable to create directory %s', [$path]));
+            try {
+                $this->filesystem->mkdir($path);
+            } catch (IOException $e) {
+                throw new IOException($this->translator->trans('Unable to create directory %s: %s', [$path, $e->getMessage()]));
             }
+
             if (!is_writable($path)) {
                 throw new IOException($this->translator->trans('Cannot write to the directory. Please ensure you have the necessary write permissions on "%s".', [$path]));
             }

--- a/tests/unit/AnalyticsTest.php
+++ b/tests/unit/AnalyticsTest.php
@@ -30,6 +30,7 @@ use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\State\RestoreState;
 use PrestaShop\Module\AutoUpgrade\State\UpdateState;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
+use Symfony\Component\Filesystem\Filesystem;
 
 class AnalyticsTest extends TestCase
 {
@@ -43,7 +44,7 @@ class AnalyticsTest extends TestCase
     public function testProperties()
     {
         $fixturesDir = __DIR__ . '/../../fixtures/config/';
-        $fileStorage = new FileStorage($fixturesDir);
+        $fileStorage = new FileStorage(new Filesystem(), $fixturesDir);
 
         $restoreState = (new RestoreState($fileStorage))
             ->setRestoreName('V1.2.3_blablabla-🐶');

--- a/tests/unit/PrestashopConfiguration/PrestaShopConfigurationTest.php
+++ b/tests/unit/PrestashopConfiguration/PrestaShopConfigurationTest.php
@@ -25,12 +25,13 @@
  */
 use PHPUnit\Framework\TestCase;
 use PrestaShop\Module\AutoUpgrade\PrestashopConfiguration;
+use Symfony\Component\Filesystem\Filesystem;
 
 class PrestaShopConfigurationTest extends TestCase
 {
     public function testPrestaShopVersionInFile()
     {
-        $class = new PrestashopConfiguration(__DIR__);
+        $class = new PrestashopConfiguration(new Filesystem(), __DIR__);
         $content = "<?php
 define('_DB_SERVER_', '127.0.0.1:3306');
 define('_DB_NAME_', 'prestashop');
@@ -56,7 +57,7 @@ define('_RIJNDAEL_IV_', 'fdfd==');";
      */
     public function testPrestaShopVersionInAppKernel()
     {
-        $class = new PrestashopConfiguration(__DIR__);
+        $class = new PrestashopConfiguration(new Filesystem(), __DIR__);
         $this->assertSame(
             '1.7.6.0',
             $class->findPrestaShopVersionInFile(

--- a/tests/unit/Services/PhpVersionResolverServiceTest.php
+++ b/tests/unit/Services/PhpVersionResolverServiceTest.php
@@ -87,6 +87,7 @@ class PhpVersionResolverServiceTest extends TestCase
     public function testGetLatestPrestashop17ReleaseWillReturnRelease()
     {
         $fileLoader = $this->getMockBuilder(FileLoader::class)
+            ->disableOriginalConstructor()
             ->setMethods(['getXmlChannel'])
             ->getMock();
 
@@ -123,6 +124,7 @@ class PhpVersionResolverServiceTest extends TestCase
     public function testGetLatestPrestashop17ReleaseWillReturnNull()
     {
         $fileLoader = $this->getMockBuilder(FileLoader::class)
+            ->disableOriginalConstructor()
             ->setMethods(['getXmlChannel'])
             ->getMock();
 
@@ -148,6 +150,7 @@ class PhpVersionResolverServiceTest extends TestCase
     public function testGetPrestashopDestinationReleaseForPHP71()
     {
         $fileLoader = $this->getMockBuilder(FileLoader::class)
+            ->disableOriginalConstructor()
             ->setMethods(['getXmlChannel'])
             ->getMock();
 
@@ -185,6 +188,7 @@ class PhpVersionResolverServiceTest extends TestCase
     public function testGetPrestashopDestinationReleaseForPHP73()
     {
         $fileLoader = $this->getMockBuilder(FileLoader::class)
+            ->disableOriginalConstructor()
             ->setMethods(['getXmlChannel'])
             ->getMock();
 
@@ -236,6 +240,7 @@ class PhpVersionResolverServiceTest extends TestCase
     public function testGetPrestashopDestinationReleaseWithNoMatchingChannelXml()
     {
         $fileLoader = $this->getMockBuilder(FileLoader::class)
+            ->disableOriginalConstructor()
             ->setMethods(['getXmlChannel'])
             ->getMock();
 
@@ -288,6 +293,7 @@ class PhpVersionResolverServiceTest extends TestCase
     public function testGetPrestashopDestinationReleaseWithCurrentVersionUpToDate()
     {
         $fileLoader = $this->getMockBuilder(FileLoader::class)
+            ->disableOriginalConstructor()
             ->setMethods(['getXmlChannel'])
             ->getMock();
 
@@ -339,6 +345,7 @@ class PhpVersionResolverServiceTest extends TestCase
     public function testGetPrestashopDestinationReleaseWhenAPIReturnEmptyResponse()
     {
         $fileLoader = $this->getMockBuilder(FileLoader::class)
+            ->disableOriginalConstructor()
             ->setMethods(['getXmlChannel'])
             ->getMock();
 

--- a/tests/unit/Services/PrestashopVersionServiceTest.php
+++ b/tests/unit/Services/PrestashopVersionServiceTest.php
@@ -4,6 +4,7 @@ use PHPUnit\Framework\TestCase;
 use PrestaShop\Module\AutoUpgrade\Services\PrestashopVersionService;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 use Symfony\Component\Filesystem\Exception\FileNotFoundException;
+use Symfony\Component\Filesystem\Filesystem;
 
 class PrestashopVersionServiceTest extends TestCase
 {
@@ -18,7 +19,7 @@ class PrestashopVersionServiceTest extends TestCase
 
         $this->fixturePath = __DIR__ . '/../../fixtures/localChannel/';
 
-        $this->versionService = new PrestashopVersionService($this->container->getZipAction());
+        $this->versionService = new PrestashopVersionService($this->container->getZipAction(), new Filesystem());
     }
 
     public function testExtractPrestashopVersionFromZipFileNotFound(): void

--- a/tests/unit/UpgradeTools/Module/ModuleMigrationTest.php
+++ b/tests/unit/UpgradeTools/Module/ModuleMigrationTest.php
@@ -29,6 +29,7 @@ use PrestaShop\Module\AutoUpgrade\Log\Logger;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\ModuleMigration;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\ModuleMigrationContext;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator;
+use Symfony\Component\Filesystem\Filesystem;
 
 class ModuleMigrationTest extends TestCase
 {
@@ -72,7 +73,7 @@ class ModuleMigrationTest extends TestCase
             });
 
         $this->logger = $this->createMock(Logger::class);
-        $this->moduleMigration = new ModuleMigration($translator, $this->logger, self::$fixtureFolder);
+        $this->moduleMigration = new ModuleMigration(new Filesystem(), $translator, $this->logger, self::$fixtureFolder);
     }
 
     public function testNeedMigrationWithSameVersion()

--- a/tests/unit/UpgradeTools/Module/Source/Provider/ComposerSourceProviderTest.php
+++ b/tests/unit/UpgradeTools/Module/Source/Provider/ComposerSourceProviderTest.php
@@ -29,6 +29,7 @@ use PrestaShop\Module\AutoUpgrade\Parameters\FileStorage;
 use PrestaShop\Module\AutoUpgrade\Services\ComposerService;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\Source\ModuleSource;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\Source\Provider\ComposerSourceProvider;
+use Symfony\Component\Filesystem\Filesystem;
 
 class ComposerSourceProviderTest extends TestCase
 {
@@ -37,7 +38,7 @@ class ComposerSourceProviderTest extends TestCase
         $prestashopContents = realpath(__DIR__ . '/../../../../../fixtures/prestashop-release');
         $fileConfigurationStorageMock = $this->createMock(FileStorage::class);
 
-        $sourceProvider = new ComposerSourceProvider($prestashopContents, new ComposerService(), $fileConfigurationStorageMock);
+        $sourceProvider = new ComposerSourceProvider($prestashopContents, new ComposerService(new Filesystem()), $fileConfigurationStorageMock);
 
         $fileConfigurationStorageMock->expects($this->once())->method('exists');
         $fileConfigurationStorageMock->expects($this->once())->method('save');
@@ -58,7 +59,7 @@ class ComposerSourceProviderTest extends TestCase
         $prestashopContents = realpath(__DIR__ . '/../../../../../../');
         $fileConfigurationStorageMock = $this->createMock(FileStorage::class);
 
-        $sourceProvider = new ComposerSourceProvider($prestashopContents, new ComposerService(), $fileConfigurationStorageMock);
+        $sourceProvider = new ComposerSourceProvider($prestashopContents, new ComposerService(new Filesystem()), $fileConfigurationStorageMock);
 
         $fileConfigurationStorageMock->expects($this->once())->method('exists');
         $fileConfigurationStorageMock->expects($this->once())->method('save');
@@ -75,7 +76,7 @@ class ComposerSourceProviderTest extends TestCase
         $fileConfigurationStorageMock->method('exists')->willReturn(true);
         $fileConfigurationStorageMock->method('load')->willReturn([]);
 
-        $sourceProvider = new ComposerSourceProvider($prestashopContents, new ComposerService(), $fileConfigurationStorageMock);
+        $sourceProvider = new ComposerSourceProvider($prestashopContents, new ComposerService(new Filesystem()), $fileConfigurationStorageMock);
 
         $fileConfigurationStorageMock->expects($this->once())->method('exists');
         $fileConfigurationStorageMock->expects($this->once())->method('load');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | see beelow
| Type?             | refactor
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   |-
| How to test?      | the refactoring of this PR affects all file-related operations, such as directory creation, copying or file deletion. It is therefore necessary to ensure that the operations on the files during the various processes have not had any degradation.

### Description
This pull request refactors the codebase to replace the usage of native PHP filesystem functions (e.g., file_exists, unlink, mkdir, etc.) with the Symfony Filesystem component. This change improves code readability, consistency, and reliability by leveraging Symfony's robust and well-tested API for filesystem operations. 

Key changes include:

- Replacing direct calls to native filesystem functions with equivalent methods from the Symfony Filesystem component.
- Injecting the Symfony Filesystem service where applicable to ensure better testability and adherence to dependency injection principles.
- Updating existing tests to account for the refactored implementation.

This refactor aligns with best practices and enhances compatibility with modern Symfony projects.