### PR TITLE
Fix translator path in autoupgrade.php

### DIFF
--- a/autoupgrade.php
+++ b/autoupgrade.php
@@ -185,7 +185,7 @@ class Autoupgrade extends Module
         require_once _PS_ROOT_DIR_ . '/modules/autoupgrade/classes/UpgradeTools/Translator.php';
 
         $translator = new \PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator(
-            _PS_ROOT_DIR_ . 'modules' . DIRECTORY_SEPARATOR . 'autoupgrade' . DIRECTORY_SEPARATOR . 'translations' . DIRECTORY_SEPARATOR,
+            _PS_ROOT_DIR_ . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR . 'autoupgrade' . DIRECTORY_SEPARATOR . 'translations' . DIRECTORY_SEPARATOR,
             \Context::getContext()->language->iso_code
         );
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | see below
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | -
| How to test?      | -

Users reported path issues when using the module (https://github.com/PrestaShop/PrestaShop/issues/37071#issuecomment-2548653159). It appears that a separator was missing. On other uses of this constant, there are separators each time https://github.com/PrestaShop/autoupgrade/blob/d33561cb93dabf708090d4b9492b80680df9b88a/autoupgrade.php#L185 https://github.com/PrestaShop/autoupgrade/blob/3921299be2a063278f62fc0106883b813f0d65c3/ajax-upgradetabconfig.php#L64 https://github.com/PrestaShop/autoupgrade/blob/b083f9a8b46fee4d48d4150b73aa83c94cc01a52/classes/UpgradeContainer.php#L691
