### PR TITLE
Update lifecycle of state and configuration files

### DIFF
--- a/classes/Commands/AbstractCommand.php
+++ b/classes/Commands/AbstractCommand.php
@@ -98,6 +98,13 @@ abstract class AbstractCommand extends Command
      */
     protected function loadConfiguration(?string $configPath): int
     {
+        $updateConfiguration = $this->upgradeContainer->getUpdateConfiguration();
+        if (!$updateConfiguration->hasAllTheShopConfiguration()) {
+            $this->upgradeContainer->initPrestaShopCore();
+            $this->upgradeContainer->getPrestaShopConfiguration()->fillInUpdateConfiguration($updateConfiguration);
+        }
+        $this->upgradeContainer->getConfigurationStorage()->save($updateConfiguration);
+
         $controller = new UpdateConfig($this->upgradeContainer);
 
         $configurationData = [];
@@ -130,6 +137,7 @@ abstract class AbstractCommand extends Command
 
             return $controller->run();
         }
+
 
         return ExitCode::SUCCESS;
     }

--- a/classes/Commands/AbstractCommand.php
+++ b/classes/Commands/AbstractCommand.php
@@ -138,7 +138,6 @@ abstract class AbstractCommand extends Command
             return $controller->run();
         }
 
-
         return ExitCode::SUCCESS;
     }
 }

--- a/classes/Commands/CheckRequirementsCommand.php
+++ b/classes/Commands/CheckRequirementsCommand.php
@@ -32,7 +32,6 @@ use PrestaShop\Module\AutoUpgrade\Exceptions\DistributionApiException;
 use PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\Task\ExitCode;
-use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 use PrestaShop\Module\AutoUpgrade\UpgradeSelfCheck;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -88,7 +87,6 @@ class CheckRequirementsCommand extends AbstractCommand
 
             $this->upgradeContainer->initPrestaShopAutoloader();
             $this->upgradeContainer->initPrestaShopCore();
-            $this->upgradeContainer->getUpdateState()->initDefault($this->upgradeContainer->getProperty(UpgradeContainer::PS_VERSION), $this->upgradeContainer->getUpgrader()->getDestinationVersion());
 
             $output->writeln('Result of prerequisite checks:');
             $this->exitCode = ExitCode::SUCCESS;

--- a/classes/Commands/CreateBackupCommand.php
+++ b/classes/Commands/CreateBackupCommand.php
@@ -66,7 +66,6 @@ class CreateBackupCommand extends AbstractCommand
 
             $this->loadConfiguration($configPath);
 
-            $this->upgradeContainer->getFileStorage()->cleanAllBackupFiles();
             $controller = new AllBackupTasks($this->upgradeContainer);
             $controller->init();
             $exitCode = $controller->run();

--- a/classes/Commands/RestoreCommand.php
+++ b/classes/Commands/RestoreCommand.php
@@ -77,7 +77,6 @@ class RestoreCommand extends AbstractBackupCommand
                     return ExitCode::SUCCESS;
                 }
             }
-            $this->upgradeContainer->getFileStorage()->cleanAllRestoreFiles();
             $controller = new AllRestoreTasks($this->upgradeContainer);
             $controller->setOptions([
                 RestoreConfiguration::BACKUP_NAME => $backup,

--- a/classes/Commands/UpdateCommand.php
+++ b/classes/Commands/UpdateCommand.php
@@ -35,6 +35,7 @@ use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeFileNames;
 use PrestaShop\Module\AutoUpgrade\Task\ExitCode;
 use PrestaShop\Module\AutoUpgrade\Task\Runner\AllUpdateTasks;
 use PrestaShop\Module\AutoUpgrade\Task\TaskName;
+use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -95,6 +96,13 @@ class UpdateCommand extends AbstractCommand
                 $exitCode = $this->loadConfiguration($configPath);
                 if ($exitCode !== ExitCode::SUCCESS) {
                     return $exitCode;
+                }
+            } else {
+                $updateState = $this->upgradeContainer->getUpdateState();
+                // In the special case the user inits the process from a specific task that is not the initialization,
+                // we need to initialize the state manually.
+                if (!$updateState->isInitialized()) {
+                    $updateState->initDefault($this->upgradeContainer->getProperty(UpgradeContainer::PS_VERSION), $this->upgradeContainer->getUpgrader(), $this->upgradeContainer->getUpdateConfiguration());
                 }
             }
 

--- a/classes/Commands/UpdateCommand.php
+++ b/classes/Commands/UpdateCommand.php
@@ -87,8 +87,7 @@ class UpdateCommand extends AbstractCommand
 
             // if we are in the 1st step of the update, we update the configuration
             if ($action === null || $action === TaskName::TASK_UPDATE_INITIALIZATION) {
-                $this->logger->debug('Cleaning previous state files.');
-                $this->upgradeContainer->getFileStorage()->cleanAllUpdateFiles();
+                $this->logger->debug('Cleaning previous configuration file.');
                 $this->upgradeContainer->getFileStorage()->clean(UpgradeFileNames::UPDATE_CONFIG_FILENAME);
 
                 $this->processConsoleInputConfiguration($input);

--- a/classes/Parameters/UpgradeConfiguration.php
+++ b/classes/Parameters/UpgradeConfiguration.php
@@ -49,6 +49,9 @@ class UpgradeConfiguration extends ArrayCollection
     const ARCHIVE_ZIP = 'archive_zip';
     const ARCHIVE_XML = 'archive_xml';
     const ARCHIVE_VERSION_NUM = 'archive_version_num';
+    const ONLINE_VERSION_NUM = 'online_version_num';
+    const BACKUP_COMPLETED = 'backup_completed';
+    const INSTALLED_LANGUAGES = 'installed_languages';
 
     const CHANNEL_ONLINE = 'online';
     const CHANNEL_LOCAL = 'local';
@@ -72,6 +75,11 @@ class UpgradeConfiguration extends ArrayCollection
         self::PS_AUTOUP_REGEN_EMAIL => true,
         self::PS_AUTOUP_BACKUP => true,
         self::PS_AUTOUP_KEEP_IMAGES => true,
+        self::BACKUP_COMPLETED => false,
+    ];
+
+    const CONFIGURATION_KEYS_ABOUT_SHOP = [
+        self::INSTALLED_LANGUAGES,
     ];
 
     const DEFAULT_CHANNEL = self::CHANNEL_ONLINE;
@@ -120,6 +128,14 @@ class UpgradeConfiguration extends ArrayCollection
     }
 
     /**
+     * Get the cached version number of the online release.
+     */
+    public function getOnlineChannelVersion(): ?string
+    {
+        return $this->get(self::ONLINE_VERSION_NUM);
+    }
+
+    /**
      * Get channel selected on config panel (Minor, major ...).
      *
      * @return UpgradeConfiguration::CHANNEL_*|null
@@ -145,6 +161,19 @@ class UpgradeConfiguration extends ArrayCollection
     public function isChannelOnline(): bool
     {
         return $this->getChannelOrDefault() === UpgradeConfiguration::CHANNEL_ONLINE;
+    }
+
+    public function isBackupCompleted(): bool
+    {
+        return $this->computeBooleanConfiguration(self::BACKUP_COMPLETED);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getInstalledLanguagesIsoCode(): array
+    {
+        return $this->get(self::INSTALLED_LANGUAGES);
     }
 
     /**
@@ -264,5 +293,16 @@ class UpgradeConfiguration extends ArrayCollection
         foreach ($array as $key => $value) {
             $this->set($key, $value);
         }
+    }
+
+    public function hasAllTheShopConfiguration(): bool
+    {
+        foreach (self::CONFIGURATION_KEYS_ABOUT_SHOP as $key) {
+            if ($this->get($key) === null) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/classes/Parameters/UpgradeConfiguration.php
+++ b/classes/Parameters/UpgradeConfiguration.php
@@ -49,7 +49,6 @@ class UpgradeConfiguration extends ArrayCollection
     const ARCHIVE_ZIP = 'archive_zip';
     const ARCHIVE_XML = 'archive_xml';
     const ARCHIVE_VERSION_NUM = 'archive_version_num';
-    const ONLINE_VERSION_NUM = 'online_version_num';
     const BACKUP_COMPLETED = 'backup_completed';
     const INSTALLED_LANGUAGES = 'installed_languages';
 
@@ -125,14 +124,6 @@ class UpgradeConfiguration extends ArrayCollection
     public function getLocalChannelVersion(): ?string
     {
         return $this->get(self::ARCHIVE_VERSION_NUM);
-    }
-
-    /**
-     * Get the cached version number of the online release.
-     */
-    public function getOnlineChannelVersion(): ?string
-    {
-        return $this->get(self::ONLINE_VERSION_NUM);
     }
 
     /**

--- a/classes/PrestashopConfiguration.php
+++ b/classes/PrestashopConfiguration.php
@@ -28,6 +28,7 @@
 namespace PrestaShop\Module\AutoUpgrade;
 
 use Exception;
+use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 
 class PrestashopConfiguration
 {
@@ -115,5 +116,25 @@ class PrestashopConfiguration
         }
 
         return null;
+    }
+
+    /**
+     * Rely on installed languages to merge translations files
+     *
+     * @return string[]
+     */
+    public function getInstalledLanguages(): array
+    {
+        return array_map(
+            function ($v) { return $v['iso_code']; },
+            \Language::getIsoIds(false)
+        );
+    }
+
+    public function fillInUpdateConfiguration(UpgradeConfiguration $upgradeConfiguration): void
+    {
+        $upgradeConfiguration->merge([
+            UpgradeConfiguration::INSTALLED_LANGUAGES => $this->getInstalledLanguages(),
+        ]);
     }
 }

--- a/classes/State/AbstractState.php
+++ b/classes/State/AbstractState.php
@@ -30,6 +30,12 @@ namespace PrestaShop\Module\AutoUpgrade\State;
 use PrestaShop\Module\AutoUpgrade\Parameters\FileStorage;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeFileNames;
 
+/**
+ * The State is used to keep track of the remaining operations to do on the shop during a process.
+ * Its lifespan is strictly linked to a running process, it has no use outside it.
+ *
+ * @see PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration to prepare data that will be needed during an update.
+ */
 abstract class AbstractState
 {
     /** @var bool */

--- a/classes/State/UpdateState.php
+++ b/classes/State/UpdateState.php
@@ -27,7 +27,9 @@
 
 namespace PrestaShop\Module\AutoUpgrade\State;
 
+use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeFileNames;
+use PrestaShop\Module\AutoUpgrade\Upgrader;
 
 class UpdateState extends AbstractState
 {
@@ -54,11 +56,6 @@ class UpdateState extends AbstractState
     protected $installedLanguagesIso = [];
 
     /**
-     * @var bool Marks the backup done during the update configuration
-     */
-    protected $backupCompleted = false;
-
-    /**
      * @var bool Determining if all steps went totally successfully
      *
      * @deprecated To remove with the old UI
@@ -70,18 +67,13 @@ class UpdateState extends AbstractState
         return UpgradeFileNames::STATE_UPDATE_FILENAME;
     }
 
-    public function initDefault(string $currentVersion, ?string $destinationVersion): void
+    public function initDefault(string $currentVersion, Upgrader $upgrader, UpgradeConfiguration $updateConfiguration): void
     {
         $this->disableSave = true;
-        // installedLanguagesIso is used to merge translations files
-        $installedLanguagesIso = array_map(
-            function ($v) { return $v['iso_code']; },
-            \Language::getIsoIds(false)
-        );
-        $this->setInstalledLanguagesIso($installedLanguagesIso);
+        $this->setInstalledLanguagesIso($updateConfiguration->getInstalledLanguagesIsoCode());
 
         $this->setCurrentVersion($currentVersion);
-        $this->setDestinationVersion($destinationVersion);
+        $this->setDestinationVersion($upgrader->getDestinationVersion());
         $this->disableSave = false;
         $this->save();
     }
@@ -124,19 +116,6 @@ class UpdateState extends AbstractState
     public function setInstalledLanguagesIso(array $installedLanguagesIso): self
     {
         $this->installedLanguagesIso = $installedLanguagesIso;
-        $this->save();
-
-        return $this;
-    }
-
-    public function isBackupCompleted(): bool
-    {
-        return $this->backupCompleted;
-    }
-
-    public function setBackupCompleted(bool $completed): self
-    {
-        $this->backupCompleted = $completed;
         $this->save();
 
         return $this;

--- a/classes/Task/AbstractTask.php
+++ b/classes/Task/AbstractTask.php
@@ -206,11 +206,6 @@ abstract class AbstractTask
             $archiveXml = $updateConfiguration->getLocalChannelXml();
             $this->container->getFileLoader()->addXmlMd5File($this->container->getUpgrader()->getDestinationVersion(), $this->container->getProperty(UpgradeContainer::DOWNLOAD_PATH) . DIRECTORY_SEPARATOR . $archiveXml);
         }
-
-        if ($this::TASK_TYPE !== TaskType::TASK_TYPE_RESTORE && !$this->container->getUpdateState()->isInitialized()) {
-            $this->container->getUpdateState()->initDefault($this->container->getProperty(UpgradeContainer::PS_VERSION), $this->container->getUpgrader()->getDestinationVersion());
-            $this->logger->debug($this->translator->trans('Successfully initialized update state.'));
-        }
     }
 
     abstract public function run(): int;

--- a/classes/Task/Backup/BackupComplete.php
+++ b/classes/Task/Backup/BackupComplete.php
@@ -29,6 +29,7 @@ namespace PrestaShop\Module\AutoUpgrade\Task\Backup;
 
 use Exception;
 use PrestaShop\Module\AutoUpgrade\Analytics;
+use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\Task\AbstractTask;
 use PrestaShop\Module\AutoUpgrade\Task\ExitCode;
 use PrestaShop\Module\AutoUpgrade\Task\TaskName;
@@ -51,7 +52,10 @@ class BackupComplete extends AbstractTask
         $this->next = TaskName::TASK_COMPLETE;
 
         $this->container->getFileStorage()->cleanAllBackupFiles();
-        $this->container->getUpdateState()->setBackupCompleted(true);
+        $updateConfiguration = $this->container->getUpdateConfiguration();
+        $updateConfiguration->merge([UpgradeConfiguration::BACKUP_COMPLETED => true]);
+        $this->container->getConfigurationStorage()->save($updateConfiguration);
+
         $this->container->getAnalytics()->track('Backup Succeeded', Analytics::WITH_BACKUP_PROPERTIES);
 
         $this->logger->info($this->translator->trans('Backup completed successfully.'));

--- a/classes/Task/Backup/BackupInitialization.php
+++ b/classes/Task/Backup/BackupInitialization.php
@@ -44,6 +44,7 @@ class BackupInitialization extends AbstractTask
      */
     public function run(): int
     {
+        $this->container->getFileStorage()->cleanAllBackupFiles();
         $this->container->getBackupState()->initDefault(
             $this->container->getProperty(UpgradeContainer::PS_VERSION)
         );

--- a/classes/Task/Restore/RestoreComplete.php
+++ b/classes/Task/Restore/RestoreComplete.php
@@ -46,7 +46,6 @@ class RestoreComplete extends AbstractTask
         $this->next = TaskName::TASK_COMPLETE;
 
         $this->container->getFileStorage()->cleanAllRestoreFiles();
-        $this->container->getFileStorage()->cleanAllUpdateFiles();
         $this->container->getAnalytics()->track('Restore Succeeded', Analytics::WITH_RESTORE_PROPERTIES);
 
         $this->container->getRestoreState()->setProgressPercentage(

--- a/classes/Task/Restore/RestoreInitialization.php
+++ b/classes/Task/Restore/RestoreInitialization.php
@@ -49,6 +49,7 @@ class RestoreInitialization extends AbstractTask
      */
     public function run(): int
     {
+        $this->container->getFileStorage()->cleanAllRestoreFiles();
         $restoreConfiguration = $this->container->getRestoreConfiguration();
         $state = $this->container->getRestoreState();
         $state->initDefault($restoreConfiguration);

--- a/classes/Task/Update/UpdateInitialization.php
+++ b/classes/Task/Update/UpdateInitialization.php
@@ -34,6 +34,7 @@ use PrestaShop\Module\AutoUpgrade\Task\AbstractTask;
 use PrestaShop\Module\AutoUpgrade\Task\ExitCode;
 use PrestaShop\Module\AutoUpgrade\Task\TaskName;
 use PrestaShop\Module\AutoUpgrade\Task\TaskType;
+use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 
 /**
  * very first step of the upgrade process. The only thing done is the selection
@@ -50,6 +51,12 @@ class UpdateInitialization extends AbstractTask
     {
         $this->logger->info($this->translator->trans('Starting update...'));
         $this->container->getFileStorage()->cleanAllUpdateFiles();
+
+        $this->container->getUpdateState()->initDefault(
+            $this->container->getProperty(UpgradeContainer::PS_VERSION),
+            $this->container->getUpgrader(),
+            $this->container->getUpdateConfiguration()
+        );
         $this->container->getUpdateState()->setProgressPercentage(
             $this->container->getCompletionCalculator()->getBasePercentageOfTask(self::class)
         );

--- a/classes/Task/Update/UpdateInitialization.php
+++ b/classes/Task/Update/UpdateInitialization.php
@@ -49,6 +49,7 @@ class UpdateInitialization extends AbstractTask
     public function run(): int
     {
         $this->logger->info($this->translator->trans('Starting update...'));
+        $this->container->getFileStorage()->cleanAllUpdateFiles();
         $this->container->getUpdateState()->setProgressPercentage(
             $this->container->getCompletionCalculator()->getBasePercentageOfTask(self::class)
         );

--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -821,7 +821,6 @@ class UpgradeContainer
 
             $this->upgradeSelfCheck = new UpgradeSelfCheck(
                 $this->getUpgrader(),
-                $this->getUpdateState(),
                 $this->getUpdateConfiguration(),
                 $this->getPrestaShopConfiguration(),
                 $this->getTranslator(),
@@ -829,7 +828,8 @@ class UpgradeContainer
                 $this->getChecksumCompare(),
                 $this->psRootDir,
                 $this->adminDir,
-                $this->getProperty(UpgradeContainer::WORKSPACE_PATH)
+                $this->getProperty(UpgradeContainer::WORKSPACE_PATH),
+                $this->getProperty(UpgradeContainer::PS_VERSION)
             );
         }
 

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -85,6 +85,8 @@ class UpgradeSelfCheck
     private $autoUpgradePath;
     /** @var string */
     private $currentVersion;
+    /** @var string */
+    private $destinationVersion;
     /** @var PrestashopConfiguration */
     private $prestashopConfiguration;
     /** @var UpgradeConfiguration */
@@ -143,6 +145,7 @@ class UpgradeSelfCheck
         $this->adminPath = $adminPath;
         $this->autoUpgradePath = $autoUpgradePath;
         $this->currentVersion = $currentVersion;
+        $this->destinationVersion = $upgrader->getDestinationVersion();
     }
 
     /**
@@ -208,7 +211,7 @@ class UpgradeSelfCheck
      */
     public function getRequirementWording(int $requirement, bool $isWebVersion = false): array
     {
-        $version = $this->upgrader->getDestinationVersion();
+        $version = $this->destinationVersion;
         $phpCompatibilityRange = $this->phpRequirementService->getPhpCompatibilityRange($version);
 
         switch ($requirement) {
@@ -579,7 +582,7 @@ class UpgradeSelfCheck
     public function checkKeyGeneration(): bool
     {
         // Check if key is needed on the version we are upgrading to, if lower, not needed
-        if (version_compare($this->upgrader->getDestinationVersion(), '8.1.0', '<')) {
+        if (version_compare($this->destinationVersion, '8.1.0', '<')) {
             return true;
         }
 
@@ -660,7 +663,7 @@ class UpgradeSelfCheck
 
     public function getPhpRequirementsState(): int
     {
-        $version = $this->upgrader->getDestinationVersion();
+        $version = $this->destinationVersion;
 
         return $this->phpRequirementService->getPhpRequirementsState(PHP_VERSION_ID, $version);
     }

--- a/classes/Upgrader.php
+++ b/classes/Upgrader.php
@@ -107,9 +107,6 @@ class Upgrader
     {
         if ($this->updateConfiguration->isChannelLocal()) {
             return $this->updateConfiguration->getLocalChannelVersion();
-        } elseif ($this->updateConfiguration->getOnlineChannelVersion()) {
-            // Version of online channel has been cached? Return it.
-            return $this->updateConfiguration->getOnlineChannelVersion();
         } else {
             return $this->getOnlineDestinationRelease() ? $this->getOnlineDestinationRelease()->getVersion() : null;
         }

--- a/classes/Upgrader.php
+++ b/classes/Upgrader.php
@@ -107,6 +107,9 @@ class Upgrader
     {
         if ($this->updateConfiguration->isChannelLocal()) {
             return $this->updateConfiguration->getLocalChannelVersion();
+        } elseif ($this->updateConfiguration->getOnlineChannelVersion()) {
+            // Version of online channel has been cached? Return it.
+            return $this->updateConfiguration->getOnlineChannelVersion();
         } else {
             return $this->getOnlineDestinationRelease() ? $this->getOnlineDestinationRelease()->getVersion() : null;
         }

--- a/controllers/admin/AdminSelfUpgradeController.php
+++ b/controllers/admin/AdminSelfUpgradeController.php
@@ -297,6 +297,10 @@ class AdminSelfUpgradeController extends ModuleAdminController
             empty($_REQUEST['params']) ? [] : $_REQUEST['params']
         );
 
+        $this->upgradeContainer->getFileStorage()->cleanAllUpdateFiles();
+        $this->upgradeContainer->getFileStorage()->cleanAllBackupFiles();
+        $this->upgradeContainer->getFileStorage()->cleanAllRestoreFiles();
+
         // TODO: Can be removed when the old UI is not needed anymore
         if (!$this->upgradeContainer->getUpdateState()->isInitialized()) {
             $this->upgradeContainer->getPrestaShopConfiguration()->fillInUpdateConfiguration(

--- a/controllers/admin/AdminSelfUpgradeController.php
+++ b/controllers/admin/AdminSelfUpgradeController.php
@@ -300,7 +300,8 @@ class AdminSelfUpgradeController extends ModuleAdminController
         if (!$this->upgradeContainer->getUpdateState()->isInitialized()) {
             $this->upgradeContainer->getUpdateState()->initDefault(
                 $this->upgradeContainer->getProperty(UpgradeContainer::PS_VERSION),
-                $this->upgradeContainer->getUpgrader()->getDestinationVersion()
+                $this->upgradeContainer->getUpgrader(),
+                $this->upgradeContainer->getUpdateConfiguration()
             );
         }
 

--- a/controllers/admin/AdminSelfUpgradeController.php
+++ b/controllers/admin/AdminSelfUpgradeController.php
@@ -297,7 +297,11 @@ class AdminSelfUpgradeController extends ModuleAdminController
             empty($_REQUEST['params']) ? [] : $_REQUEST['params']
         );
 
+        // TODO: Can be removed when the old UI is not needed anymore
         if (!$this->upgradeContainer->getUpdateState()->isInitialized()) {
+            $this->upgradeContainer->getPrestaShopConfiguration()->fillInUpdateConfiguration(
+                $this->upgradeContainer->getUpdateConfiguration()
+            );
             $this->upgradeContainer->getUpdateState()->initDefault(
                 $this->upgradeContainer->getProperty(UpgradeContainer::PS_VERSION),
                 $this->upgradeContainer->getUpgrader(),

--- a/controllers/admin/AdminSelfUpgradeController.php
+++ b/controllers/admin/AdminSelfUpgradeController.php
@@ -297,13 +297,6 @@ class AdminSelfUpgradeController extends ModuleAdminController
             empty($_REQUEST['params']) ? [] : $_REQUEST['params']
         );
 
-        if (!$this->ajax) {
-            // removing temporary files before init state to make sure state is already available
-            $this->upgradeContainer->getFileStorage()->cleanAllUpdateFiles();
-            $this->upgradeContainer->getFileStorage()->cleanAllBackupFiles();
-            $this->upgradeContainer->getFileStorage()->cleanAllRestoreFiles();
-        }
-
         if (!$this->upgradeContainer->getUpdateState()->isInitialized()) {
             $this->upgradeContainer->getUpdateState()->initDefault(
                 $this->upgradeContainer->getProperty(UpgradeContainer::PS_VERSION),

--- a/controllers/admin/self-managed/HomePageController.php
+++ b/controllers/admin/self-managed/HomePageController.php
@@ -58,6 +58,7 @@ class HomePageController extends AbstractPageController
 
         if ($routeChoice === self::FORM_OPTIONS['update_value']) {
             $this->upgradeContainer->getFileStorage()->clean(UpgradeFileNames::UPDATE_CONFIG_FILENAME);
+
             return AjaxResponseBuilder::nextRouteResponse(Routes::UPDATE_PAGE_VERSION_CHOICE);
         }
 
@@ -67,6 +68,7 @@ class HomePageController extends AbstractPageController
         }
 
         $this->upgradeContainer->getFileStorage()->clean(UpgradeFileNames::RESTORE_CONFIG_FILENAME);
+
         return AjaxResponseBuilder::nextRouteResponse(Routes::RESTORE_PAGE_BACKUP_SELECTION);
     }
 

--- a/controllers/admin/self-managed/HomePageController.php
+++ b/controllers/admin/self-managed/HomePageController.php
@@ -28,6 +28,7 @@
 namespace PrestaShop\Module\AutoUpgrade\Controller;
 
 use PrestaShop\Module\AutoUpgrade\AjaxResponseBuilder;
+use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeFileNames;
 use PrestaShop\Module\AutoUpgrade\Router\Routes;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
@@ -56,6 +57,7 @@ class HomePageController extends AbstractPageController
         $routeChoice = $this->request->request->get(self::FORM_FIELDS['route_choice']);
 
         if ($routeChoice === self::FORM_OPTIONS['update_value']) {
+            $this->upgradeContainer->getFileStorage()->clean(UpgradeFileNames::UPDATE_CONFIG_FILENAME);
             return AjaxResponseBuilder::nextRouteResponse(Routes::UPDATE_PAGE_VERSION_CHOICE);
         }
 
@@ -64,6 +66,7 @@ class HomePageController extends AbstractPageController
             return AjaxResponseBuilder::errorResponse('You can\'t access this route because you have no backups.', 401);
         }
 
+        $this->upgradeContainer->getFileStorage()->clean(UpgradeFileNames::RESTORE_CONFIG_FILENAME);
         return AjaxResponseBuilder::nextRouteResponse(Routes::RESTORE_PAGE_BACKUP_SELECTION);
     }
 

--- a/controllers/admin/self-managed/UpdatePageBackupOptionsController.php
+++ b/controllers/admin/self-managed/UpdatePageBackupOptionsController.php
@@ -68,7 +68,7 @@ class UpdatePageBackupOptionsController extends AbstractPageWithStepController
     public function submitUpdate(): JsonResponse
     {
         return $this->displayDialog('dialog-update', [
-            'backup_completed' => $this->upgradeContainer->getUpdateState()->isBackupCompleted(),
+            'backup_completed' => $this->upgradeContainer->getUpdateConfiguration()->isBackupCompleted(),
             'dialogId' => 'dialog-confirm-update',
 
             'form_route_to_confirm' => Routes::UPDATE_STEP_BACKUP_CONFIRM_UPDATE,
@@ -124,7 +124,7 @@ class UpdatePageBackupOptionsController extends AbstractPageWithStepController
         return array_merge(
             $updateSteps->getStepParams($this::CURRENT_STEP),
             [
-                'backup_completed' => $this->upgradeContainer->getUpdateState()->isBackupCompleted(),
+                'backup_completed' => $this->upgradeContainer->getUpdateConfiguration()->isBackupCompleted(),
                 'download_path' => $logsPath,
                 'filename' => basename($logsPath),
 

--- a/controllers/admin/self-managed/UpdatePageVersionChoiceController.php
+++ b/controllers/admin/self-managed/UpdatePageVersionChoiceController.php
@@ -193,8 +193,6 @@ class UpdatePageVersionChoiceController extends AbstractPageWithStepController
                 $file = $requestConfig[UpgradeConfiguration::ARCHIVE_ZIP];
                 $fullFilePath = $this->upgradeContainer->getProperty(UpgradeContainer::DOWNLOAD_PATH) . DIRECTORY_SEPARATOR . $file;
                 $requestConfig[UpgradeConfiguration::ARCHIVE_VERSION_NUM] = $this->upgradeContainer->getPrestashopVersionService()->extractPrestashopVersionFromZip($fullFilePath);
-            } else {
-                $requestConfig[UpgradeConfiguration::ONLINE_VERSION_NUM] = $this->upgradeContainer->getUpgrader()->getDestinationVersion();
             }
 
             $configurationStorage = $this->upgradeContainer->getConfigurationStorage();

--- a/controllers/admin/self-managed/UpdatePageVersionChoiceController.php
+++ b/controllers/admin/self-managed/UpdatePageVersionChoiceController.php
@@ -201,7 +201,9 @@ class UpdatePageVersionChoiceController extends AbstractPageWithStepController
             $config->merge($requestConfig);
 
             $configurationStorage->save($config);
-            $state = $this->upgradeContainer->getUpdateState()->setDestinationVersion($this->upgradeContainer->getUpgrader()->getDestinationVersion());
+            $state = $this->upgradeContainer->getUpdateState()
+                ->setDestinationVersion($this->upgradeContainer->getUpgrader()->getDestinationVersion())
+                ->setBackupCompleted(false);
             $state->save();
 
             if ($channel !== null) {

--- a/tests/unit/Parameters/UpgradeConfigurationTest.php
+++ b/tests/unit/Parameters/UpgradeConfigurationTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+namespace Parameters;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
+
+class UpgradeConfigurationTest extends TestCase
+{
+    public function testUpdateConfigurationConfigIsFilledWithPrestaShopOne(): void
+    {
+        $updateConfiguration = new UpgradeConfiguration();
+
+        $this->assertFalse($updateConfiguration->hasAllTheShopConfiguration());
+
+        // We can't use the class PrestaShopConfiguration directly because of its reliance on the Core.
+        // Reproduce its alterations below:
+        $updateConfiguration->merge([
+            UpgradeConfiguration::INSTALLED_LANGUAGES => ['fr', 'de', 'jp'],
+        ]);
+
+        $this->assertTrue($updateConfiguration->hasAllTheShopConfiguration());
+    }
+}

--- a/tests/unit/State/UpdateStateTest.php
+++ b/tests/unit/State/UpdateStateTest.php
@@ -27,10 +27,9 @@ class UpdateStateTest extends TestCase
             'currentVersion' => '1.7.8.6',
             'destinationVersion' => '9.0.0',
             'installedLanguagesIso' => [],
-            'backupCompleted' => false,
             'warning_exists' => false,
 
-            'progressPercentage' => '20',
+            'progressPercentage' => 20,
         ];
 
         $this->assertEquals($expected, $this->state->export());
@@ -95,7 +94,6 @@ class UpdateStateTest extends TestCase
 
         $this->assertEquals('1.6.1.24', $this->state->getCurrentVersion());
         $this->assertEquals('9.2.3', $this->state->getDestinationVersion());
-        $this->assertTrue($this->state->isBackupCompleted());
         $this->assertEquals(['fr', 'de'], $this->state->getInstalledLanguagesIso());
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Make sure the state is only defined while a process is run (update / backup / restore) and rely on the configuration class for the rest of the module use.
| Type?             | Refacto
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | <ul><li>Make a process fail : The next attempt must start from the beginning not where it stopped.</li><li>Starting over the update funel will reset the backup completion, displaying again the step asking for the merchant to backup its store.</li></ul>
