### PR TITLE
[NEW UI] before destroy logs viewer

### DIFF
--- a/_dev/src/ts/components/LogsViewer.ts
+++ b/_dev/src/ts/components/LogsViewer.ts
@@ -45,7 +45,7 @@ export default class LogsViewer extends ComponentAbstract implements DomLifecycl
   }
 
   public mount = () => {
-    this.#logsScroll.addEventListener('scroll', this.#debouncedRefreshView);
+    this.#logsScroll.addEventListener('scroll', this.#debouncedRefreshView.debounced);
 
     // delay needed because of side menu toggle on small screens
     // we set width to prevent the modification of the height of
@@ -57,8 +57,9 @@ export default class LogsViewer extends ComponentAbstract implements DomLifecycl
 
   public beforeDestroy = () => {
     logStore.clearLogs();
-    this.#logsScroll.removeEventListener('scroll', this.#debouncedRefreshView);
+    this.#logsScroll.removeEventListener('scroll', this.#debouncedRefreshView.debounced);
     this.#logsSummary.removeEventListener('click', this.#handleLinkEvent);
+    this.#debouncedRefreshView.cancel();
   };
 
   /**

--- a/_dev/src/ts/utils/logsUtils.ts
+++ b/_dev/src/ts/utils/logsUtils.ts
@@ -50,18 +50,22 @@ export function parseLogWithSeverity(log: string): LogEntry {
 
 /**
  * @public
- * @param {T} func
- * @param {number} wait
- * @return {(...args: Parameters<T>) => void}
- * @description
+ * @template T
+ * @param {T} func - The function to debounce.
+ * @param {number} wait - The delay in milliseconds before the function is executed.
+ * @return {(...args: Parameters<T>) => void & { clear: () => void }} - A debounced function
+ * that delays the execution of `func` and provides a `clear` method to cancel any pending execution.
+ * @description Creates a debounced version of the given function, ensuring it is executed
+ * only after the specified delay has elapsed since the last invocation.
+ * The returned function also includes a `clear` method to cancel any pending executions.
  */
 export function debounce<T extends Procedure>(
   func: T,
   wait: number
-): (...args: Parameters<T>) => void {
+): { debounced: (...args: Parameters<T>) => void; cancel: () => void } {
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
-  return (...args: Parameters<T>): void => {
+  const debounced = (...args: Parameters<T>): void => {
     if (timeoutId) {
       clearTimeout(timeoutId);
     }
@@ -70,6 +74,15 @@ export function debounce<T extends Procedure>(
       func(...args);
     }, wait);
   };
+
+  const cancel = (): void => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+      timeoutId = undefined;
+    }
+  };
+
+  return { debounced, cancel };
 }
 
 /**


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | At the end of the execution of a step we can be redirected, if this redirection is fast and the DOM is changed we can have the debounce of the logsViewer which will try to execute a script which no longer has any reason to exist because the element no longer exists.
| Type?             | bug fix 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | Your company or customer's name goes here (if applicable).
| How to test?      | You can try the backup task from UI and check the console, without the fix you have an error on console, with the fix all is good !