### PR TITLE
[NEW UI] clean old error web logger

### DIFF
--- a/_dev/src/ts/components/ProgressTracker.ts
+++ b/_dev/src/ts/components/ProgressTracker.ts
@@ -54,10 +54,6 @@ export default class ProgressTracker extends ComponentAbstract implements DomLif
     this.#logsSummary?.setLogsSummaryText(data.next_desc ?? '');
     this.#progressBar?.setProgressPercentage(data.nextParams?.progressPercentage || 0);
     this.#logsViewer.addLogs(data.nextQuickInfo);
-
-    if (data.nextErrors) {
-      this.#logsViewer.addLogs(data.nextErrors);
-    }
   };
 
   /**

--- a/classes/AjaxResponse.php
+++ b/classes/AjaxResponse.php
@@ -100,7 +100,7 @@ class AjaxResponse
             'next' => $this->next,
             'status' => $this->getStatus(),
             'next_desc' => $this->logger->getLastInfo(),
-            'nextQuickInfo' => $this->logger->getInfos(),
+            'nextQuickInfo' => $this->logger->getLogs(),
             'nextParams' => array_merge(
                 $this->nextParams,
                 $this->state->export(),

--- a/classes/AjaxResponse.php
+++ b/classes/AjaxResponse.php
@@ -101,7 +101,6 @@ class AjaxResponse
             'status' => $this->getStatus(),
             'next_desc' => $this->logger->getLastInfo(),
             'nextQuickInfo' => $this->logger->getInfos(),
-            'nextErrors' => $this->logger->getErrors(),
             'nextParams' => array_merge(
                 $this->nextParams,
                 $this->state->export(),

--- a/classes/ErrorHandler.php
+++ b/classes/ErrorHandler.php
@@ -125,7 +125,7 @@ class ErrorHandler
     public function generateJsonLog(string $log): string
     {
         return json_encode([
-            'nextQuickInfo' => array_merge($this->logger->getInfos(), [$log]),
+            'nextQuickInfo' => array_merge($this->logger->getLogs(), [$log]),
             'error' => true,
             'next' => 'error',
         ]);

--- a/classes/ErrorHandler.php
+++ b/classes/ErrorHandler.php
@@ -125,8 +125,7 @@ class ErrorHandler
     public function generateJsonLog(string $log): string
     {
         return json_encode([
-            'nextQuickInfo' => $this->logger->getInfos(),
-            'nextErrors' => array_merge($this->logger->getErrors(), [$log]),
+            'nextQuickInfo' => array_merge($this->logger->getInfos(), [$log]),
             'error' => true,
             'next' => 'error',
         ]);

--- a/classes/Log/Logger.php
+++ b/classes/Log/Logger.php
@@ -140,7 +140,7 @@ abstract class Logger implements LoggerInterface
      *
      * @return string[] Details on what happened during the execution. Verbose levels: DEBUG / INFO / WARNING
      */
-    public function getInfos(): array
+    public function getLogs(): array
     {
         return [];
     }

--- a/classes/Log/Logger.php
+++ b/classes/Log/Logger.php
@@ -135,17 +135,6 @@ abstract class Logger implements LoggerInterface
     }
 
     /**
-     * Equivalent of the old $nextErrors
-     * Used during upgrade. Will be displayed in the top right panel (not visible at the beginning).
-     *
-     * @return string[] Details of error which occured during the request. Verbose levels: ERROR
-     */
-    public function getErrors(): array
-    {
-        return [];
-    }
-
-    /**
      * Equivalent of the old $nextQuickInfo
      * Used during upgrade. Will be displayed in the lower panel.
      *

--- a/classes/Log/WebLogger.php
+++ b/classes/Log/WebLogger.php
@@ -44,7 +44,7 @@ class WebLogger extends Logger
      *
      * @return string[]
      */
-    public function getInfos(): array
+    public function getLogs(): array
     {
         return $this->normalMessages;
     }

--- a/classes/Log/WebLogger.php
+++ b/classes/Log/WebLogger.php
@@ -36,21 +36,8 @@ class WebLogger extends Logger
     /** @var string[] */
     protected $normalMessages = [];
 
-    /** @var string[] */
-    protected $severeMessages = [];
-
     /** @var ?string */
     protected $lastInfo;
-
-    /**
-     * {@inheritdoc}
-     *
-     * @return string[]
-     */
-    public function getErrors(): array
-    {
-        return $this->severeMessages;
-    }
 
     /**
      * {@inheritdoc}
@@ -96,10 +83,5 @@ class WebLogger extends Logger
         $log = $this->formatLog($level, $message);
 
         $this->normalMessages[] = $log;
-
-        // deprecated : todo need to be removed after NEW UI is completed.
-        if ($level > self::ERROR) {
-            $this->severeMessages[] = $log;
-        }
     }
 }

--- a/tests/unit/ErrorHandlerTest.php
+++ b/tests/unit/ErrorHandlerTest.php
@@ -45,7 +45,7 @@ class ErrorHandlerTest extends TestCase
 
     public function testDefaultContentIsEmpty()
     {
-        $this->assertEmpty($this->logger->getInfos());
+        $this->assertEmpty($this->logger->getLogs());
     }
 
     public function testCheckExceptionAndContent()
@@ -58,7 +58,7 @@ class ErrorHandlerTest extends TestCase
         $this->errorHandler->exceptionHandler($exception);
         ob_end_clean();
 
-        $infos = $this->logger->getInfos();
+        $infos = $this->logger->getLogs();
         $this->assertCount(1, $infos);
         $this->assertContains(__FILE__ . ' line ' . $line . ' - Exception: ERMAGHERD', end($infos));
     }
@@ -67,7 +67,7 @@ class ErrorHandlerTest extends TestCase
     {
         $line = __LINE__;
         $this->errorHandler->errorHandler(E_WARNING, 'Trololo', __FILE__, $line);
-        $msgs = $this->logger->getInfos();
+        $msgs = $this->logger->getLogs();
         $this->assertCount(1, $msgs);
         $this->assertSame(end($msgs), 'WARNING - ' . __FILE__ . ' line ' . $line . ' - Trololo');
     }

--- a/tests/unit/ErrorHandlerTest.php
+++ b/tests/unit/ErrorHandlerTest.php
@@ -45,7 +45,7 @@ class ErrorHandlerTest extends TestCase
 
     public function testDefaultContentIsEmpty()
     {
-        $this->assertEmpty($this->logger->getErrors());
+        $this->assertEmpty($this->logger->getInfos());
     }
 
     public function testCheckExceptionAndContent()
@@ -58,9 +58,9 @@ class ErrorHandlerTest extends TestCase
         $this->errorHandler->exceptionHandler($exception);
         ob_end_clean();
 
-        $errors = $this->logger->getErrors();
-        $this->assertCount(1, $errors);
-        $this->assertContains(__FILE__ . ' line ' . $line . ' - Exception: ERMAGHERD', end($errors));
+        $infos = $this->logger->getInfos();
+        $this->assertCount(1, $infos);
+        $this->assertContains(__FILE__ . ' line ' . $line . ' - Exception: ERMAGHERD', end($infos));
     }
 
     public function testWarningInErrorHandler()
@@ -68,7 +68,6 @@ class ErrorHandlerTest extends TestCase
         $line = __LINE__;
         $this->errorHandler->errorHandler(E_WARNING, 'Trololo', __FILE__, $line);
         $msgs = $this->logger->getInfos();
-        $this->assertCount(0, $this->logger->getErrors());
         $this->assertCount(1, $msgs);
         $this->assertSame(end($msgs), 'WARNING - ' . __FILE__ . ' line ' . $line . ' - Trololo');
     }

--- a/tests/unit/Log/WebLoggerTest.php
+++ b/tests/unit/Log/WebLoggerTest.php
@@ -43,7 +43,7 @@ class WebLoggerTest extends TestCase
         $logger->log(WebLogger::INFO, 'Good bye');
 
         $this->assertSame('Good bye', $logger->getLastInfo());
-        $infos = $logger->getInfos();
+        $infos = $logger->getLogs();
         $this->assertSame([
             'INFO - Hello',
             'INFO - Good bye',
@@ -86,6 +86,6 @@ class WebLoggerTest extends TestCase
             'WARNING - Oh no',
             'WARNING - Oh no 2',
             'INFO - INFO #2',
-        ], $logger->getInfos());
+        ], $logger->getLogs());
     }
 }

--- a/tests/unit/Log/WebLoggerTest.php
+++ b/tests/unit/Log/WebLoggerTest.php
@@ -51,28 +51,6 @@ class WebLoggerTest extends TestCase
         $this->assertCount(2, $infos);
     }
 
-    public function testErrorIsRegistered()
-    {
-        $logger = new WebLogger();
-        $logger->log(WebLogger::CRITICAL, 'Ach!!!');
-
-        $errors = $logger->getErrors();
-        $this->assertCount(1, $errors);
-        $this->assertCount(1, $logger->getInfos());
-        $this->assertSame('CRITICAL - Ach!!!', end($errors));
-    }
-
-    public function testMessageIsRegistered()
-    {
-        $logger = new WebLogger();
-        $logger->log(WebLogger::DEBUG, 'Some stuff happened');
-
-        $messages = $logger->getInfos();
-        $this->assertCount(1, $messages);
-        $this->assertCount(0, $logger->getErrors());
-        $this->assertSame('DEBUG - Some stuff happened', end($messages));
-    }
-
     public function testSensitiveDataAreReplaced()
     {
         $logger = new WebLogger();


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Remove old error web logger no more necessary
| Type?             | refactor
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | @PrestaShopCorp
| How to test?      | Try a process (update, backup, restore) with an error and check if the error is displayed as expected.