### PR TITLE
[MIDDLEWARE] Page update backup

### DIFF
--- a/classes/Router/Middlewares/AbstractMiddleware.php
+++ b/classes/Router/Middlewares/AbstractMiddleware.php
@@ -2,8 +2,8 @@
 
 namespace PrestaShop\Module\AutoUpgrade\Router\Middlewares;
 
-use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 use PrestaShop\Module\AutoUpgrade\Router\Routes;
+use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 
 abstract class AbstractMiddleware
 {

--- a/classes/Router/Middlewares/AbstractMiddleware.php
+++ b/classes/Router/Middlewares/AbstractMiddleware.php
@@ -3,6 +3,7 @@
 namespace PrestaShop\Module\AutoUpgrade\Router\Middlewares;
 
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
+use PrestaShop\Module\AutoUpgrade\Router\Routes;
 
 abstract class AbstractMiddleware
 {
@@ -16,5 +17,10 @@ abstract class AbstractMiddleware
         $this->upgradeContainer = $upgradeContainer;
     }
 
+    /**
+     * @return Routes::*|null
+     *
+     * @throws \Exception
+     */
     abstract public function process(): ?string;
 }

--- a/classes/Router/Middlewares/LocalChannelXmlAndZipAreValid.php
+++ b/classes/Router/Middlewares/LocalChannelXmlAndZipAreValid.php
@@ -4,13 +4,8 @@ namespace PrestaShop\Module\AutoUpgrade\Router\Middlewares;
 
 use PrestaShop\Module\AutoUpgrade\Router\Routes;
 
-class LocalChannelXmlAndZipExist extends AbstractMiddleware
+class LocalChannelXmlAndZipAreValid extends AbstractMiddleware
 {
-    /**
-     * @return Routes::*|null
-     *
-     * @throws \Exception
-     */
     public function process(): ?string
     {
         $updateConfiguration = $this->upgradeContainer->getUpdateConfiguration();

--- a/classes/Router/RoutesConfig.php
+++ b/classes/Router/RoutesConfig.php
@@ -82,6 +82,10 @@ class RoutesConfig
             Routes::UPDATE_PAGE_BACKUP_OPTIONS => [
                 'controller' => UpdatePageBackupOptionsController::class,
                 'method' => 'index',
+                'middleware' => [
+                    UpdateIsConfigured::class,
+                    LocalChannelXmlAndZipExist::class,
+                ],
             ],
             Routes::UPDATE_STEP_BACKUP_OPTIONS => [
                 'controller' => UpdatePageBackupOptionsController::class,

--- a/classes/Router/RoutesConfig.php
+++ b/classes/Router/RoutesConfig.php
@@ -15,7 +15,7 @@ use PrestaShop\Module\AutoUpgrade\Controller\UpdatePagePostUpdateController;
 use PrestaShop\Module\AutoUpgrade\Controller\UpdatePageUpdateController;
 use PrestaShop\Module\AutoUpgrade\Controller\UpdatePageUpdateOptionsController;
 use PrestaShop\Module\AutoUpgrade\Controller\UpdatePageVersionChoiceController;
-use PrestaShop\Module\AutoUpgrade\Router\Middlewares\LocalChannelXmlAndZipExist;
+use PrestaShop\Module\AutoUpgrade\Router\Middlewares\LocalChannelXmlAndZipAreValid;
 use PrestaShop\Module\AutoUpgrade\Router\Middlewares\UpdateIsConfigured;
 
 class RoutesConfig
@@ -63,7 +63,7 @@ class RoutesConfig
                 'method' => 'index',
                 'middleware' => [
                     UpdateIsConfigured::class,
-                    LocalChannelXmlAndZipExist::class,
+                    LocalChannelXmlAndZipAreValid::class,
                 ],
             ],
             Routes::UPDATE_STEP_UPDATE_OPTIONS => [
@@ -84,7 +84,7 @@ class RoutesConfig
                 'method' => 'index',
                 'middleware' => [
                     UpdateIsConfigured::class,
-                    LocalChannelXmlAndZipExist::class,
+                    LocalChannelXmlAndZipAreValid::class,
                 ],
             ],
             Routes::UPDATE_STEP_BACKUP_OPTIONS => [


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add middleware to page backup option: need to get valid configuration to access the page.
| Type?             |  feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | @PrestaShopCorp
| How to test?      | see bellow

### Test Steps for Update Options Page Redirection Logic

1. **Navigate to the module homepage**.
2. **Test without a version choice**:  
   - Go to the update version choice page without picking any version.
   - Manually change the `route` parameter in the URL to `update-page-backup-options` (replacing `update-page-version-choice`).
   - **Expected result**: You are redirected back to `update-page-version-choice`.

3. **Test with the online channel**:  
   - Select the online channel.
   - Change the `route` parameter in the URL to `update-page-backup-options`.
   - **Expected result**: You can access `update-page-backup-options`.

4. **Test with the local channel**:  
   - Return to `update-page-version-choice`.
   - Select the local channel.
   - Change the `route` parameter in the URL to `update-page-backup-options`.
   - **Expected result**: You can access `update-page-backup-options`.

5. **Test invalid file references**:  
   - Return to `update-page-version-choice`.
   - Without making any changes to the channel selection, delete the XML or ZIP file from your server that was previously picked.
   - Change the `route` parameter in the URL to `update-page-backup-options`.
   - **Expected result**: You are redirected back to `update-page-version-choice`.

**PS: If you have already a configuration set you can delete it manually from you server by removing `/admin-folder/autoupgrade/update_config.var`**
