### PR TITLE
Do not overwrite configuration

### DIFF
--- a/upgrade/php/add_configuration_if_not_exists.php
+++ b/upgrade/php/add_configuration_if_not_exists.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+use PrestaShop\Module\AutoUpgrade\DbWrapper;
+
+/**
+ * @return void
+ *
+ * @throws \PrestaShop\Module\AutoUpgrade\Exceptions\UpdateDatabaseException
+ */
+function add_configuration_if_not_exists($name, $value)
+{
+    // Check if this record already exists
+    $entry_exists = DbWrapper::executeS('SELECT * FROM `' . _DB_PREFIX_ . "configuration` WHERE name = '" . $name . "'");
+
+    // If no rows were found, insert a new entry
+    if (empty($entry_exists)) {
+        DbWrapper::execute(
+            'INSERT INTO `' . _DB_PREFIX_ . 'configuration` (`name`, `value`, `date_add`, `date_upd`)
+            VALUES (\'' . pSQL($name) . '\', \'' . pSQL($value) . '\', NOW(), NOW())'
+        );
+    }
+}

--- a/upgrade/php/add_configuration_if_not_exists.php
+++ b/upgrade/php/add_configuration_if_not_exists.php
@@ -18,7 +18,7 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */
 
-use PrestaShop\Module\AutoUpgrade\DbWrapper;
+use PrestaShop\Module\AutoUpgrade\Database\DbWrapper;
 
 /**
  * @return void

--- a/upgrade/sql/1.7.7.0.sql
+++ b/upgrade/sql/1.7.7.0.sql
@@ -3,13 +3,11 @@ SET NAMES 'utf8';
 
 ALTER DATABASE `DB_NAME` CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci;
 
-INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES
-    ('PS_DISPLAY_MANUFACTURERS', '1', NOW(), NOW()),
-    ('PS_ORDER_PRODUCTS_NB_PER_PAGE', '8', NOW(), NOW()),
-    ('PS_SEARCH_FUZZY', '1', NOW(), NOW()),
-    ('PS_SEARCH_FUZZY_MAX_LOOP', '4', NOW(), NOW()),
-    ('PS_SEARCH_MAX_WORD_LENGTH', '15', NOW(), NOW())
-;
+/* PHP:add_configuration_if_not_exists('PS_DISPLAY_MANUFACTURERS', '1'); */;
+/* PHP:add_configuration_if_not_exists('PS_ORDER_PRODUCTS_NB_PER_PAGE', '8'); */;
+/* PHP:add_configuration_if_not_exists('PS_SEARCH_FUZZY', '1'); */;
+/* PHP:add_configuration_if_not_exists('PS_SEARCH_FUZZY_MAX_LOOP', '4'); */;
+/* PHP:add_configuration_if_not_exists('PS_SEARCH_MAX_WORD_LENGTH', '15'); */;
 
 /* Add field MPN to tables and assign empty values */
 /* PHP:add_column('order_detail', 'product_mpn', 'VARCHAR(40) NULL AFTER `product_upc`'); */;

--- a/upgrade/sql/1.7.8.0.sql
+++ b/upgrade/sql/1.7.8.0.sql
@@ -138,11 +138,9 @@ ON DUPLICATE KEY UPDATE `title` = VALUES(`title`), `description` = VALUES(`descr
 
 /* PHP:add_column('employee', 'has_enabled_gravatar', 'TINYINT UNSIGNED DEFAULT 0 NOT NULL'); */;
 
-INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES
-    ('PS_COOKIE_SAMESITE', 'Lax', NOW(), NOW()),
-    ('PS_SHOW_LABEL_OOS_LISTING_PAGES', '1', NOW(), NOW()),
-    ('ADDONS_API_MODULE_CHANNEL', 'stable', NOW(), NOW())
-;
+/* PHP:add_configuration_if_not_exists('PS_COOKIE_SAMESITE', 'Lax'); */;
+/* PHP:add_configuration_if_not_exists('PS_SHOW_LABEL_OOS_LISTING_PAGES', '1'); */;
+/* PHP:add_configuration_if_not_exists('ADDONS_API_MODULE_CHANNEL', 'stable'); */;
 
 /* PHP:add_column('hook', 'active', 'TINYINT(1) UNSIGNED DEFAULT 1 NOT NULL AFTER `description`'); */;
 

--- a/upgrade/sql/8.0.0.sql
+++ b/upgrade/sql/8.0.0.sql
@@ -22,14 +22,12 @@ DELETE FROM `PREFIX_access`
 DELETE FROM `PREFIX_configuration`
   WHERE `name` IN ('PS_REFERRERS_CACHE_LIKE', 'PS_REFERRERS_CACHE_DATE');
 
-INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES
-    ('PS_MAIL_DKIM_ENABLE', '0', NOW(), NOW()),
-    ('PS_MAIL_DKIM_DOMAIN', '', NOW(), NOW()),
-    ('PS_MAIL_DKIM_SELECTOR', '', NOW(), NOW()),
-    ('PS_MAIL_DKIM_KEY', '', NOW(), NOW()),
-    ('PS_WEBP_QUALITY', '80', NOW(), NOW()),
-    ('PS_SECURITY_TOKEN', '1', NOW(), NOW())
-;
+/* PHP:add_configuration_if_not_exists('PS_MAIL_DKIM_ENABLE', '0'); */;
+/* PHP:add_configuration_if_not_exists('PS_MAIL_DKIM_DOMAIN', ''); */;
+/* PHP:add_configuration_if_not_exists('PS_MAIL_DKIM_SELECTOR', ''); */;
+/* PHP:add_configuration_if_not_exists('PS_MAIL_DKIM_KEY', ''); */;
+/* PHP:add_configuration_if_not_exists('PS_WEBP_QUALITY', '80'); */;
+/* PHP:add_configuration_if_not_exists('PS_SECURITY_TOKEN', '1'); */;
 
 INSERT INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES
   (NULL, 'actionValidateOrderAfter', 'New Order', 'This hook is called after validating an order by core', '1'),
@@ -223,11 +221,9 @@ UPDATE `PREFIX_tab` SET wording = 'New & Experimental Features' WHERE `class_nam
 UPDATE `PREFIX_quick_access` SET `link` = 'index.php/sell/orders' WHERE `link` = 'index.php?controller=AdminOrders';
 
 /* Insert new password policy configuration values */
-INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES
-  ('PS_SECURITY_PASSWORD_POLICY_MAXIMUM_LENGTH', '72', NOW(), NOW()),
-  ('PS_SECURITY_PASSWORD_POLICY_MINIMUM_LENGTH', '8', NOW(), NOW()),
-  ('PS_SECURITY_PASSWORD_POLICY_MINIMUM_SCORE', '3', NOW(), NOW())
-;
+/* PHP:add_configuration_if_not_exists('PS_SECURITY_PASSWORD_POLICY_MAXIMUM_LENGTH', '72'); */;
+/* PHP:add_configuration_if_not_exists('PS_SECURITY_PASSWORD_POLICY_MINIMUM_LENGTH', '8'); */;
+/* PHP:add_configuration_if_not_exists('PS_SECURITY_PASSWORD_POLICY_MINIMUM_SCORE', '3'); */;
 
 UPDATE `PREFIX_carrier` SET `name` = 'Click and collect' WHERE `name` = '0';
 

--- a/upgrade/sql/8.1.0.sql
+++ b/upgrade/sql/8.1.0.sql
@@ -17,12 +17,10 @@ INSERT INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`
 ON DUPLICATE KEY UPDATE `title` = VALUES(`title`), `description` = VALUES(`description`);
 
 /* Default configuration for backorder, in order to keep behavior */
-INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES
-  ('PS_ENABLE_BACKORDER_STATUS', '1', NOW(), NOW());
+/* PHP:add_configuration_if_not_exists('PS_ENABLE_BACKORDER_STATUS', '1'); */;
 
 /* Keep sending e-mails with prefixed subject to avoid behaviour change */
-INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES
-  ('PS_MAIL_SUBJECT_PREFIX', '1', NOW(), NOW());
+/* PHP:add_configuration_if_not_exists('PS_MAIL_SUBJECT_PREFIX', '1'); */;
 
 /* Add new product_attribute_lang table and fill it with data */
 CREATE TABLE IF NOT EXISTS `PREFIX_product_attribute_lang` (
@@ -39,12 +37,10 @@ SELECT pa.id_product_attribute, l.id_lang, '', ''
 FROM `PREFIX_product_attribute` pa CROSS JOIN `PREFIX_lang` l;
 
 /* Add default redirect configuration */
-INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES
-  ('PS_PRODUCT_REDIRECTION_DEFAULT', '404', NOW(), NOW()),
-  ('PS_MAINTENANCE_ALLOW_ADMINS', 1, NOW(), NOW()),
-  ('PS_AVIF_QUALITY', '90', NOW(), NOW()),
-  ('PS_IMAGE_FORMAT', 'jpg', NOW(), NOW())
-;
+/* PHP:add_configuration_if_not_exists('PS_PRODUCT_REDIRECTION_DEFAULT', '404'); */;
+/* PHP:add_configuration_if_not_exists('PS_MAINTENANCE_ALLOW_ADMINS', '1'); */;
+/* PHP:add_configuration_if_not_exists('PS_AVIF_QUALITY', '90'); */;
+/* PHP:add_configuration_if_not_exists('PS_IMAGE_FORMAT', 'jpg'); */;
 
 /* Update ENUM values in both tables*/
 ALTER TABLE `PREFIX_product` MODIFY COLUMN `redirect_type` ENUM(

--- a/upgrade/sql/9.0.0.sql
+++ b/upgrade/sql/9.0.0.sql
@@ -3,13 +3,11 @@ SET NAMES 'utf8mb4';
 
 /* Add a file separator input to the sql manager settings - https://github.com/PrestaShop/PrestaShop/pull/35843 */
 /* Allow configuring maximum word difference - https://github.com/PrestaShop/PrestaShop/pull/37261 */
-INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES
-  ('PS_DEBUG_COOKIE_NAME', '', NOW(), NOW()),
-  ('PS_DEBUG_COOKIE_VALUE', '', NOW(), NOW()),
-  ('PS_SEPARATOR_FILE_MANAGER_SQL', ';', NOW(), NOW()),
-  ('PS_PRODUCT_BREADCRUMB_CATEGORY', 'default', NOW(), NOW()),
-  ('PS_SEARCH_FUZZY_MAX_DIFFERENCE', 5, NOW(), NOW())
-;
+/* PHP:add_configuration_if_not_exists('PS_DEBUG_COOKIE_NAME', ''); */;
+/* PHP:add_configuration_if_not_exists('PS_DEBUG_COOKIE_VALUE', ''); */;
+/* PHP:add_configuration_if_not_exists('PS_SEPARATOR_FILE_MANAGER_SQL', ';'); */;
+/* PHP:add_configuration_if_not_exists('PS_PRODUCT_BREADCRUMB_CATEGORY', 'default'); */;
+/* PHP:add_configuration_if_not_exists('PS_SEARCH_FUZZY_MAX_DIFFERENCE', 5); */;
 
 /* Enable controlling of default language URL prefix - https://github.com/PrestaShop/PrestaShop/pull/37236 */
 /* PHP:ps_900_set_url_lang_prefix(); */;
@@ -65,7 +63,7 @@ UPDATE `PREFIX_module_shop` SET `enable_device` = '7';
 
 /* Allow cover configuration */
 /* https://github.com/PrestaShop/PrestaShop/pull/33363 */
-INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES ('PS_USE_COMBINATION_IMAGE_IN_LISTING', '0', NOW(), NOW());
+/* PHP:add_configuration_if_not_exists('PS_USE_COMBINATION_IMAGE_IN_LISTING', '0'); */;
 
 /* Remove purpose of store */
 /* https://github.com/PrestaShop/PrestaShop/pull/33232 */
@@ -320,7 +318,7 @@ DELETE FROM `PREFIX_hook_module_exceptions` WHERE `id_hook` NOT IN (SELECT id_ho
 /* Feature value position */
 /* https://github.com/PrestaShop/PrestaShop/pull/37042 */
 /* PHP:add_column('feature_value', 'position', 'int(10) unsigned NOT NULL DEFAULT \'0\''); */;
-INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES ('PS_FEATURE_VALUES_ORDER', 'name', NOW(), NOW());
+/* PHP:add_configuration_if_not_exists('PS_FEATURE_VALUES_ORDER', 'name'); */;
 
 /* Upgrade attachment names length */
 /* https://github.com/PrestaShop/PrestaShop/pull/37598 */


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Adds a bit more resiliency to the upgrade process. If a shop has backported some logic from newer versions, this will prevent the attempts of overwriting the configuration keys, if they are already in the database. `I did not check, but it would either fail or insert a duplicate entry.`
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     |
| Sponsor company   | 
| How to test?      | 
