### PR TITLE
Refactoring of the admin/autoupgrade directory structure

### DIFF
--- a/classes/Task/Update/Download.php
+++ b/classes/Task/Update/Download.php
@@ -51,7 +51,7 @@ class Download extends AbstractTask
     public function run(): int
     {
         if (!\ConfigurationTest::test_fopen() && !\ConfigurationTest::test_curl()) {
-            $this->logger->error($this->translator->trans('You need allow_url_fopen or cURL enabled for automatic download to work. You can also manually upload it in filepath %s.', [$this->container->getFilePath()]));
+            $this->logger->error($this->translator->trans('You need allow_url_fopen or cURL enabled for automatic download to work. You can also manually upload it in filepath %s.', [$this->container->getArchiveFilePath()]));
             $this->next = TaskName::TASK_ERROR;
 
             return ExitCode::FAIL;
@@ -62,25 +62,19 @@ class Download extends AbstractTask
         );
 
         $this->logger->debug($this->translator->trans('Downloading from %s', [$this->container->getUpgrader()->getOnlineDestinationRelease()->getZipDownloadUrl()]));
-        $this->logger->debug($this->translator->trans('File will be saved in %s', [$this->container->getFilePath()]));
+        $this->logger->debug($this->translator->trans('File will be saved in %s', [$this->container->getArchiveFilePath()]));
 
-        $downloadPath = $this->container->getProperty(UpgradeContainer::DOWNLOAD_PATH);
-
-        if ($this->container->getFileSystem()->exists($downloadPath)) {
-            foreach (scandir($downloadPath) as $item) {
-                if ($item !== '.' && $item !== '..') {
-                    $path = $downloadPath . DIRECTORY_SEPARATOR . $item;
-                    $this->container->getFileSystem()->remove($path);
-                }
-            }
+        $releasesDir = $this->container->getProperty(UpgradeContainer::TMP_RELEASES_DIR);
+        if ($this->container->getFilesystemAdapter()->clearDirectory($releasesDir)) {
             $this->logger->debug($this->translator->trans('Download directory has been emptied'));
         }
+
         $report = '';
-        $relative_download_path = str_replace(_PS_ROOT_DIR_, '', $downloadPath);
+        $relative_download_path = str_replace(_PS_ROOT_DIR_, '', $releasesDir);
         if (\ConfigurationTest::test_dir($relative_download_path, false, $report)) {
             $this->downloadArchive();
         } else {
-            $this->logger->error($this->translator->trans('Download directory %s is not writable.', [$this->container->getProperty(UpgradeContainer::DOWNLOAD_PATH)]));
+            $this->logger->error($this->translator->trans('Download directory %s is not writable.', [$this->container->getProperty(UpgradeContainer::TMP_RELEASES_DIR)]));
             $this->next = TaskName::TASK_ERROR;
         }
 
@@ -94,7 +88,7 @@ class Download extends AbstractTask
      */
     public function downloadArchive(): void
     {
-        $destPath = realpath($this->container->getProperty(UpgradeContainer::DOWNLOAD_PATH)) . DIRECTORY_SEPARATOR . $this->container->getProperty(UpgradeContainer::ARCHIVE_FILENAME);
+        $destPath = realpath($this->container->getProperty(UpgradeContainer::TMP_RELEASES_DIR)) . DIRECTORY_SEPARATOR . $this->container->getProperty(UpgradeContainer::ARCHIVE_FILENAME);
         $archiveUrl = $this->container->getUpgrader()->getOnlineDestinationRelease()->getZipDownloadUrl();
 
         try {

--- a/classes/Task/Update/Unzip.php
+++ b/classes/Task/Update/Unzip.php
@@ -57,7 +57,7 @@ class Unzip extends AbstractTask
         );
 
         if ($this->container->getFilesystemAdapter()->clearDirectory($destExtract)) {
-            $this->logger->debug($this->translator->trans('files directory has been emptied'));
+            $this->logger->debug($this->translator->trans('Temporary files directory has been emptied'));
         }
         $relative_extract_path = str_replace(_PS_ROOT_DIR_, '', $destExtract);
         $report = '';

--- a/classes/Task/Update/Unzip.php
+++ b/classes/Task/Update/Unzip.php
@@ -49,22 +49,15 @@ class Unzip extends AbstractTask
      */
     public function run(): int
     {
-        $filepath = $this->container->getFilePath();
-        $destExtract = $this->container->getProperty(UpgradeContainer::LATEST_PATH);
+        $filepath = $this->container->getArchiveFilePath();
+        $destExtract = $this->container->getProperty(UpgradeContainer::TMP_FILES_PATH);
 
         $this->container->getUpdateState()->setProgressPercentage(
             $this->container->getCompletionCalculator()->getBasePercentageOfTask(self::class)
         );
 
-        if ($this->container->getFileSystem()->exists($destExtract)) {
-            foreach (scandir($destExtract) as $item) {
-                if ($item !== '.' && $item !== '..') {
-                    $path = $destExtract . DIRECTORY_SEPARATOR . $item;
-                    $this->container->getFileSystem()->remove($path);
-                }
-            }
-
-            $this->logger->debug($this->translator->trans('"/latest" directory has been emptied'));
+        if ($this->container->getFilesystemAdapter()->clearDirectory($destExtract)) {
+            $this->logger->debug($this->translator->trans('files directory has been emptied'));
         }
         $relative_extract_path = str_replace(_PS_ROOT_DIR_, '', $destExtract);
         $report = '';

--- a/classes/Task/Update/UpdateComplete.php
+++ b/classes/Task/Update/UpdateComplete.php
@@ -58,8 +58,8 @@ class UpdateComplete extends AbstractTask
         $this->next = TaskName::TASK_COMPLETE;
 
         $filesystem = $this->container->getFileSystem();
-        $filePath = $this->container->getFilePath();
-        $latestPath = $this->container->getProperty(UpgradeContainer::LATEST_PATH);
+        $filePath = $this->container->getArchiveFilePath();
+        $latestPath = $this->container->getProperty(UpgradeContainer::TMP_FILES_PATH);
 
         if ($filesystem->exists($filePath)) {
             if ($this->container->getUpdateConfiguration()->isChannelOnline()) {
@@ -77,6 +77,11 @@ class UpdateComplete extends AbstractTask
         $this->container->getFileStorage()->clean(UpgradeFileNames::UPDATE_CONFIG_FILENAME);
 
         // removing temporary files
+        $tmpModulePath = $this->container->getProperty(UpgradeContainer::TMP_MODULES_PATH);
+        if ($this->container->getFilesystemAdapter()->clearDirectory($tmpModulePath)) {
+            $this->logger->debug($this->translator->trans('The temporary directory of modules has been emptied'));
+        }
+
         $this->container->getFileStorage()->cleanAllUpdateFiles();
         $this->container->getAnalytics()->track('Upgrade Succeeded', Analytics::WITH_UPDATE_PROPERTIES);
 

--- a/classes/Task/Update/UpdateFiles.php
+++ b/classes/Task/Update/UpdateFiles.php
@@ -106,7 +106,7 @@ class UpdateFiles extends AbstractTask
         // later, we could handle customization with some kind of diff functions
         // for now, just copy $file in str_replace($this->latestRootDir,_PS_ROOT_DIR_)
 
-        $file = str_replace($this->container->getProperty(UpgradeContainer::LATEST_PATH), '', $orig);
+        $file = str_replace($this->container->getProperty(UpgradeContainer::TMP_FILES_PATH), '', $orig);
 
         // The path to the file in our prestashop directory
         $dest = $this->destUpgradePath . $file;
@@ -203,7 +203,7 @@ class UpdateFiles extends AbstractTask
         }
 
         // Get path to the folder with release we will use to upgrade and check if it's valid
-        $newReleasePath = $this->container->getProperty(UpgradeContainer::LATEST_PATH);
+        $newReleasePath = $this->container->getProperty(UpgradeContainer::TMP_FILES_PATH);
         if (!$this->container->getFilesystemAdapter()->isReleaseValid($newReleasePath)) {
             $this->logger->error($this->translator->trans('Could not assert the folder %s contains a valid PrestaShop release, exiting.', [$newReleasePath]));
             $this->logger->error($this->translator->trans('A file may be missing, or the release is stored in a subfolder by mistake.'));

--- a/classes/Task/Update/UpdateModules.php
+++ b/classes/Task/Update/UpdateModules.php
@@ -60,9 +60,9 @@ class UpdateModules extends AbstractTask
         $modulesPath = $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH) . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR;
 
         $moduleSourceList = new ModuleSourceAggregate($this->container->getModuleSourceProviders());
-        $moduleDownloader = new ModuleDownloader($this->container->getDownloadService(), $this->translator, $this->logger, $this->container->getProperty(UpgradeContainer::TMP_PATH));
+        $moduleDownloader = new ModuleDownloader($this->container->getDownloadService(), $this->translator, $this->logger, $this->container->getProperty(UpgradeContainer::TMP_MODULES_DIR));
         $moduleUnzipper = new ModuleUnzipper($this->translator, $this->container->getZipAction(), $modulesPath);
-        $moduleMigration = new ModuleMigration($this->container->getFileSystem(), $this->translator, $this->logger, $this->container->getProperty(UpgradeContainer::TMP_PATH));
+        $moduleMigration = new ModuleMigration($this->container->getFileSystem(), $this->translator, $this->logger, $this->container->getProperty(UpgradeContainer::TMP_MODULES_DIR));
 
         if ($listModules->getRemainingTotal()) {
             $moduleInfos = $listModules->getNext();

--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -80,16 +80,23 @@ use Twig_Loader_Filesystem;
  */
 class UpgradeContainer
 {
-    const WORKSPACE_PATH = 'workspace'; // AdminSelfUpgrade::$autoupgradePath
+    const WORKSPACE_PATH = 'workspace';
     const BACKUP_PATH = 'backup';
     const DOWNLOAD_PATH = 'download';
-    const LATEST_PATH = 'latest'; // AdminSelfUpgrade::$latestRootDir
-    const LATEST_DIR = 'latest/';
     const LOGS_PATH = 'logs';
+
+    // temporary folders
     const TMP_PATH = 'tmp';
+    const TMP_FILES_PATH = 'files';
+    const TMP_FILES_DIR = 'files/';
+    const TMP_MODULES_PATH = 'modules';
+    const TMP_MODULES_DIR = 'modules/';
+    const TMP_RELEASES_PATH = 'releases';
+    const TMP_RELEASES_DIR = 'releases/';
+
     const PS_ADMIN_PATH = 'ps_admin';
     const PS_ADMIN_SUBDIR = 'ps_admin_subdir';
-    const PS_ROOT_PATH = 'ps_root'; // AdminSelfUpgrade::$prodRootDir
+    const PS_ROOT_PATH = 'ps_root';
     const ARCHIVE_FILENAME = 'destDownloadFilename';
     const ARCHIVE_FILEPATH = 'destDownloadFilepath';
     const PS_VERSION = 'version';
@@ -279,23 +286,45 @@ class UpgradeContainer
                 return $this->autoupgradeWorkDir . DIRECTORY_SEPARATOR . 'backup';
             case self::DOWNLOAD_PATH:
                 return $this->autoupgradeWorkDir . DIRECTORY_SEPARATOR . 'download';
-            case self::LATEST_PATH:
-                return $this->autoupgradeWorkDir . DIRECTORY_SEPARATOR . 'latest';
-            case self::LATEST_DIR:
-                return $this->autoupgradeWorkDir . DIRECTORY_SEPARATOR . 'latest' . DIRECTORY_SEPARATOR;
             case self::TMP_PATH:
                 return $this->autoupgradeWorkDir . DIRECTORY_SEPARATOR . 'tmp';
+            case self::TMP_MODULES_PATH:
+                return $this->getProperty(self::TMP_PATH) . DIRECTORY_SEPARATOR . 'modules';
+            case self::TMP_MODULES_DIR:
+                return $this->getProperty(self::TMP_MODULES_PATH) . DIRECTORY_SEPARATOR;
+            case self::TMP_RELEASES_PATH:
+                return $this->getProperty(self::TMP_PATH) . DIRECTORY_SEPARATOR . 'releases';
+            case self::TMP_RELEASES_DIR:
+                return $this->getProperty(self::TMP_RELEASES_PATH) . DIRECTORY_SEPARATOR;
+            case self::TMP_FILES_PATH:
+                return $this->getProperty(self::TMP_PATH) . DIRECTORY_SEPARATOR . 'files';
+            case self::TMP_FILES_DIR:
+                return $this->getProperty(self::TMP_FILES_PATH) . DIRECTORY_SEPARATOR;
             case self::LOGS_PATH:
                 return $this->autoupgradeWorkDir . DIRECTORY_SEPARATOR . 'logs';
             case self::ARCHIVE_FILENAME:
                 return $this->getUpdateConfiguration()->getChannelZip();
             case self::ARCHIVE_FILEPATH:
-                return $this->getProperty(self::DOWNLOAD_PATH) . DIRECTORY_SEPARATOR . $this->getProperty(self::ARCHIVE_FILENAME);
+                return $this->getArchiveFilePath();
             case self::PS_VERSION:
                 return $this->getCurrentPrestaShopVersion();
             default:
                 return '';
         }
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function getArchiveFilePath(): ?string
+    {
+        $fileName = $this->getProperty(self::ARCHIVE_FILENAME);
+
+        if ($this->getUpdateConfiguration()->isChannelLocal()) {
+            return $this->getProperty(self::DOWNLOAD_PATH) . DIRECTORY_SEPARATOR . $fileName;
+        }
+
+        return $this->getProperty(self::TMP_RELEASES_DIR) . $fileName;
     }
 
     public function getAnalytics(): Analytics
@@ -406,16 +435,6 @@ class UpgradeContainer
     public function getDb(): \Db
     {
         return \Db::getInstance();
-    }
-
-    /**
-     * Return the path to the zipfile containing prestashop.
-     *
-     * @throws Exception
-     */
-    public function getFilePath(): string
-    {
-        return $this->getProperty(self::ARCHIVE_FILEPATH);
     }
 
     public function getFileStorage(): FileStorage
@@ -560,7 +579,7 @@ class UpgradeContainer
             $this->moduleSourceProviders = [
                 new LocalSourceProvider($this->getProperty(self::WORKSPACE_PATH) . DIRECTORY_SEPARATOR . 'modules', $this->getFileStorage()),
                 new MarketplaceSourceProvider($this->getUpdateState()->getDestinationVersion(), $this->getProperty(self::PS_ROOT_PATH), $this->getFileLoader(), $this->getFileStorage()),
-                new ComposerSourceProvider($this->getProperty(self::LATEST_PATH), $this->getComposerService(), $this->getFileStorage()),
+                new ComposerSourceProvider($this->getProperty(self::TMP_FILES_PATH), $this->getComposerService(), $this->getFileStorage()),
                 // Other providers
             ];
         }
@@ -839,9 +858,11 @@ class UpgradeContainer
                 self::WORKSPACE_PATH,
                 self::BACKUP_PATH,
                 self::DOWNLOAD_PATH,
-                self::LATEST_PATH,
+                self::TMP_FILES_PATH,
                 self::LOGS_PATH,
                 self::TMP_PATH,
+                self::TMP_MODULES_DIR,
+                self::TMP_RELEASES_DIR,
             ];
 
             foreach ($properties as $property) {

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -92,7 +92,7 @@ abstract class CoreUpgrader
         $this->fileSystem = $this->container->getFileSystem();
         $this->logger = $logger;
         $this->destinationUpgradeVersion = $this->container->getUpdateState()->getDestinationVersion();
-        $this->pathToInstallFolder = realpath($this->container->getProperty(UpgradeContainer::LATEST_PATH) . DIRECTORY_SEPARATOR . 'install');
+        $this->pathToInstallFolder = realpath($this->container->getProperty(UpgradeContainer::TMP_FILES_PATH) . DIRECTORY_SEPARATOR . 'install');
         $this->pathToUpgradeScripts = dirname(__DIR__, 3) . '/upgrade/';
         if ($this->fileSystem->exists($this->pathToInstallFolder . DIRECTORY_SEPARATOR . 'autoload.php')) {
             require_once $this->pathToInstallFolder . DIRECTORY_SEPARATOR . 'autoload.php';

--- a/classes/UpgradeTools/FilesystemAdapter.php
+++ b/classes/UpgradeTools/FilesystemAdapter.php
@@ -229,22 +229,6 @@ class FilesystemAdapter
         return true;
     }
 
-    public function clearDirectory(string $folderToClear): bool
-    {
-        if ($this->filesystem->exists($folderToClear)) {
-            foreach (scandir($folderToClear) as $item) {
-                if ($item !== '.' && $item !== '..' && $item !== 'index.php') {
-                    $path = $folderToClear . DIRECTORY_SEPARATOR . $item;
-                    $this->filesystem->remove($path);
-
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
     /**
      * Clears the contents of a given directory, optionally deleting the directory itself.
      *

--- a/classes/UpgradeTools/FilesystemAdapter.php
+++ b/classes/UpgradeTools/FilesystemAdapter.php
@@ -71,7 +71,6 @@ class FilesystemAdapter
     ) {
         $this->filesystem = $filesystem;
         $this->fileFilter = $fileFilter;
-
         $this->autoupgradeDir = $autoupgradeDir;
         $this->adminSubDir = $adminSubDir;
         $this->prodRootDir = $prodRootDir;
@@ -228,6 +227,22 @@ class FilesystemAdapter
         }
 
         return true;
+    }
+
+    public function clearDirectory(string $folderToClear): bool
+    {
+        if ($this->filesystem->exists($folderToClear)) {
+            foreach (scandir($folderToClear) as $item) {
+                if ($item !== '.' && $item !== '..' && $item !== 'index.php') {
+                    $path = $folderToClear . DIRECTORY_SEPARATOR . $item;
+                    $this->filesystem->remove($path);
+
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/unit/UpgradeContainer/FilesystemAdapterTest.php
+++ b/tests/unit/UpgradeContainer/FilesystemAdapterTest.php
@@ -180,9 +180,9 @@ class FilesystemAdapterTest extends TestCase
         $this->assertTrue(
             $this->filesystemAdapter->isFileSkipped(
                 $file,
-                $this->container->getProperty(UpgradeContainer::LATEST_PATH) . $fullpath,
+                $this->container->getProperty(UpgradeContainer::TMP_FILES_PATH) . $fullpath,
                 $process,
-                $this->container->getProperty(UpgradeContainer::LATEST_PATH)
+                $this->container->getProperty(UpgradeContainer::TMP_FILES_PATH)
             )
         );
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | see below
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | -
| How to test?      | -

This PR reorganizes the admin/autoupgrade directory structure to improve temporary file management and prevent accidental overwriting of local releases.

### Changes introduced:

- The `download` folder no longer stores the downloaded release in online mode and is no longer erased in certain scenarios, preventing the loss of locally stored releases.
- The `latest` folder, which contained the extracted destination release, has been renamed to `files` and moved to `tmp/`.
- A new `tmp/releases` folder has been created to store the downloaded release in online mode.
- A new `tmp/modules` folder has been created to store module ZIP files and migration scripts (previously located at the root of `tmp/`).
- Module migration scripts are now deleted at the end of the update process.

These changes enhance the reliability of the update process and optimize the organization of temporary files.
### Directory structure before/after:
#### Before:
```
admin/autoupgrade/
 ├── download/              (contained the downloaded release and local archives)
 ├── latest/                (contained extracted destination release)
 ├── tmp/                   (contained module zip files and migration scripts)
 ```
 
 
 #### After:
```
 admin/autoupgrade/
 ├── download/              (no longer stores downloaded releases, is now only present for local archives)
 ├── tmp/
 │   ├── files/             (previously "latest", deleted at the end of the update process)
 │   ├── releases/          (stores downloaded releases in online mode, emptied at the end of the update process)
 │   ├── modules/           (stores module zip files and migration scripts, emptied at the end of the update process)
 ```
