### PR TITLE
Do not initialize in tasks the Core by default, only when requested

### DIFF
--- a/classes/Task/AbstractTask.php
+++ b/classes/Task/AbstractTask.php
@@ -180,26 +180,8 @@ abstract class AbstractTask
         }
     }
 
-    /**
-     * @throws Exception
-     */
     public function init(): void
     {
-        $this->container->initPrestaShopCore();
-        $this->setupEnvironment();
-    }
-
-    /**
-     * @throws Exception
-     */
-    protected function setupEnvironment(): void
-    {
-        $updateConfiguration = $this->container->getUpdateConfiguration();
-
-        if ($this::TASK_TYPE === TaskType::TASK_TYPE_UPDATE && $updateConfiguration->isChannelLocal()) {
-            $archiveXml = $updateConfiguration->getLocalChannelXml();
-            $this->container->getFileLoader()->addXmlMd5File($this->container->getUpgrader()->getDestinationVersion(), $this->container->getProperty(UpgradeContainer::DOWNLOAD_PATH) . DIRECTORY_SEPARATOR . $archiveXml);
-        }
     }
 
     abstract public function run(): int;

--- a/classes/Task/Backup/BackupDatabase.php
+++ b/classes/Task/Backup/BackupDatabase.php
@@ -42,6 +42,14 @@ class BackupDatabase extends AbstractTask
     /**
      * @throws Exception
      */
+    public function init(): void
+    {
+        $this->container->initPrestaShopCore();
+    }
+
+    /**
+     * @throws Exception
+     */
     public function run(): int
     {
         $this->stepDone = false;

--- a/classes/Task/Restore/RestoreFiles.php
+++ b/classes/Task/Restore/RestoreFiles.php
@@ -124,9 +124,4 @@ class RestoreFiles extends AbstractTask
 
         return ExitCode::SUCCESS;
     }
-
-    public function init(): void
-    {
-        // Do nothing
-    }
 }

--- a/classes/Task/Restore/RestoreInitialization.php
+++ b/classes/Task/Restore/RestoreInitialization.php
@@ -110,9 +110,4 @@ class RestoreInitialization extends AbstractTask
 
         return ExitCode::SUCCESS;
     }
-
-    public function init(): void
-    {
-        // Do nothing
-    }
 }

--- a/classes/Task/Update/CleanDatabase.php
+++ b/classes/Task/Update/CleanDatabase.php
@@ -21,6 +21,7 @@
 
 namespace PrestaShop\Module\AutoUpgrade\Task\Update;
 
+use Exception;
 use PrestaShop\Module\AutoUpgrade\Task\AbstractTask;
 use PrestaShop\Module\AutoUpgrade\Task\ExitCode;
 use PrestaShop\Module\AutoUpgrade\Task\TaskName;
@@ -52,5 +53,13 @@ class CleanDatabase extends AbstractTask
         $this->logger->info($this->translator->trans('The database has been cleaned.'));
 
         return ExitCode::SUCCESS;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function init(): void
+    {
+        $this->container->initPrestaShopCore();
     }
 }

--- a/classes/Task/Update/Download.php
+++ b/classes/Task/Update/Download.php
@@ -40,6 +40,14 @@ class Download extends AbstractTask
     /**
      * @throws Exception
      */
+    public function init(): void
+    {
+        $this->container->initPrestaShopCore();
+    }
+
+    /**
+     * @throws Exception
+     */
     public function run(): int
     {
         if (!\ConfigurationTest::test_fopen() && !\ConfigurationTest::test_curl()) {

--- a/classes/Task/Update/Unzip.php
+++ b/classes/Task/Update/Unzip.php
@@ -39,6 +39,14 @@ class Unzip extends AbstractTask
     /**
      * @throws Exception
      */
+    public function init(): void
+    {
+        $this->container->initPrestaShopCore();
+    }
+
+    /**
+     * @throws Exception
+     */
     public function run(): int
     {
         $filepath = $this->container->getFilePath();

--- a/classes/Task/Update/UpdateDatabase.php
+++ b/classes/Task/Update/UpdateDatabase.php
@@ -117,7 +117,7 @@ class UpdateDatabase extends AbstractTask
 
         // Migrating settings file
         $this->container->initPrestaShopAutoloader();
-        parent::init();
+        $this->container->initPrestaShopCore();
     }
 
     /**

--- a/classes/Task/Update/UpdateFiles.php
+++ b/classes/Task/Update/UpdateFiles.php
@@ -196,6 +196,12 @@ class UpdateFiles extends AbstractTask
             $this->container->getCompletionCalculator()->getBasePercentageOfTask(self::class)
         );
 
+        $updateConfiguration = $this->container->getUpdateConfiguration();
+        if ($updateConfiguration->isChannelLocal()) {
+            $archiveXml = $updateConfiguration->getLocalChannelXml();
+            $this->container->getFileLoader()->addXmlMd5File($this->container->getUpgrader()->getDestinationVersion(), $this->container->getProperty(UpgradeContainer::DOWNLOAD_PATH) . DIRECTORY_SEPARATOR . $archiveXml);
+        }
+
         // Get path to the folder with release we will use to upgrade and check if it's valid
         $newReleasePath = $this->container->getProperty(UpgradeContainer::LATEST_PATH);
         if (!$this->container->getFilesystemAdapter()->isReleaseValid($newReleasePath)) {
@@ -273,10 +279,5 @@ class UpdateFiles extends AbstractTask
         $this->stepDone = false;
 
         return ExitCode::SUCCESS;
-    }
-
-    public function init(): void
-    {
-        $this->setupEnvironment();
     }
 }

--- a/classes/Task/Update/UpdateModules.php
+++ b/classes/Task/Update/UpdateModules.php
@@ -161,6 +161,14 @@ class UpdateModules extends AbstractTask
         return ExitCode::SUCCESS;
     }
 
+    /**
+     * @throws Exception
+     */
+    public function init(): void
+    {
+        $this->container->initPrestaShopCore();
+    }
+
     private function handleException(UpgradeException $e): void
     {
         if ($e->getSeverity() === UpgradeException::SEVERITY_ERROR) {


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | We had a weird implementation of a default initialization of the core, that would suppressed by each task if necessary. We should actually rely on the core ONLY when necessary, so only the task needing it to work will call the method `initPrestaShopCore()`. This PR also moves a XML initialization to a specific place instead of at the beginning of each update task.
| Type?             | bug fix + improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | /
| How to test?      | Backup, Updates and Restore are still possible, especially when using the local archive.