### PR TITLE
[FIX] stepper to check init stepper again if it change.

### DIFF
--- a/_dev/src/ts/utils/Stepper.ts
+++ b/_dev/src/ts/utils/Stepper.ts
@@ -19,36 +19,38 @@
 import type { Step } from '../types/Stepper';
 
 export default class Stepper {
-  private stepper: HTMLDivElement;
-  private steps: Step[];
+  #stepper: HTMLDivElement | null = null;
+  #steps: Step[] = [];
 
-  private baseClass = 'stepper__step';
-  private currentClass = `${this.baseClass}--current`;
-  private doneClass = `${this.baseClass}--done`;
-  private normalClass = `${this.baseClass}--normal`;
+  #baseClass = 'stepper__step';
+  #currentClass = `${this.#baseClass}--current`;
+  #doneClass = `${this.#baseClass}--done`;
+  #normalClass = `${this.#baseClass}--normal`;
+
+  constructor() {
+    this.#initStepper();
+  }
 
   /**
-   * @constructor
-   * @throws Will throw an error if the stepper or its steps are not found in the DOM.
+   * @private
+   * @throws Error Will throw an error if the stepper or its steps are not found in the DOM.
    * @description Initializes the Stepper by finding the parent element in the DOM and setting up the steps.
    */
-  constructor() {
-    const stepper = document.getElementById(
+  #initStepper = (): void => {
+    this.#stepper = document.getElementById(
       window.AutoUpgradeVariables.stepper_parent_id
     ) as HTMLDivElement | null;
-    if (!stepper) {
+    if (!this.#stepper) {
       throw new Error("The stepper wasn't found inside DOM. stepper can't be initiated properly");
     }
 
-    this.stepper = stepper;
-
-    const domSteps = Array.from(this.stepper.children) as HTMLElement[];
+    const domSteps = Array.from(this.#stepper.children) as HTMLElement[];
 
     if (!domSteps.length) {
       throw new Error("The stepper hasn't steps inside DOM. stepper can't be initiated properly");
     }
 
-    this.steps = domSteps.map((step) => {
+    this.#steps = domSteps.map((step) => {
       const stepCode = step.dataset.stepCode;
       if (!stepCode) {
         throw new Error(
@@ -60,7 +62,7 @@ export default class Stepper {
         element: step
       };
     });
-  }
+  };
 
   /**
    * @public
@@ -68,35 +70,44 @@ export default class Stepper {
    * @description Sets the current step in the stepper and updates the classes for each step accordingly.
    */
   public setCurrentStep = (currentStep: string) => {
-    const stepIndex = this.steps.findIndex((step) => step.code === currentStep);
+    if (this.#getStepIndex(currentStep) === -1) {
+      this.#initStepper();
+    }
+
+    const stepIndex = this.#getStepIndex(currentStep);
 
     if (stepIndex === -1) {
       console.debug(`Step ${currentStep} not found in list.`);
       return;
     }
-    this.stepper.classList.add('stepper--hydration');
 
-    this.steps.forEach((step, i) => {
+    this.#stepper?.classList.add('stepper--hydration');
+
+    this.#steps.forEach((step, i) => {
       const { element } = step;
 
       const newClass = this.#getClassOfStep(stepIndex, i);
 
       if (!element.classList.contains(newClass)) {
-        element.classList.remove(this.currentClass, this.doneClass, this.normalClass);
+        element.classList.remove(this.#currentClass, this.#doneClass, this.#normalClass);
         element.classList.add(newClass);
       }
     });
   };
 
+  #getStepIndex = (stepToGetIndex: string): number => {
+    return this.#steps.findIndex((step) => step.code === stepToGetIndex);
+  };
+
   #getClassOfStep(referenceIndex: number, currentIndex: number): string {
     if (currentIndex === referenceIndex) {
-      return this.currentClass;
+      return this.#currentClass;
     }
 
     if (currentIndex < referenceIndex) {
-      return this.doneClass;
+      return this.#doneClass;
     }
 
-    return this.normalClass;
+    return this.#normalClass;
   }
 }

--- a/_dev/src/ts/utils/Stepper.ts
+++ b/_dev/src/ts/utils/Stepper.ts
@@ -26,6 +26,7 @@ export default class Stepper {
   #currentClass = `${this.#baseClass}--current`;
   #doneClass = `${this.#baseClass}--done`;
   #normalClass = `${this.#baseClass}--normal`;
+  #stepperHydrationClass = 'stepper--hydration';
 
   constructor() {
     this.#initStepper();
@@ -81,7 +82,7 @@ export default class Stepper {
       return;
     }
 
-    this.#stepper?.classList.add('stepper--hydration');
+    this.#stepper?.classList.add(this.#stepperHydrationClass);
 
     this.#steps.forEach((step, i) => {
       const { element } = step;

--- a/_dev/tests/utils/Stepper.test.ts
+++ b/_dev/tests/utils/Stepper.test.ts
@@ -44,17 +44,6 @@ describe('Stepper', () => {
     createMockStepperHTML();
   });
 
-  it('should initialize stepper with all steps', () => {
-    const stepper = new Stepper();
-
-    expect(stepper['steps'].length).toBe(5);
-    expect(stepper['steps'][0].code).toBe('version-choice');
-    expect(stepper['steps'][1].code).toBe('update-options');
-    expect(stepper['steps'][2].code).toBe('backup');
-    expect(stepper['steps'][3].code).toBe('update');
-    expect(stepper['steps'][4].code).toBe('post-update');
-  });
-
   it('should throw an error if the stepper is not found in the DOM', () => {
     document.body.innerHTML = '';
 


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | If you come from update page to restore page with hydration, the stepper doesn't work anymore.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | @PrestaShopCorp
| How to test?      | You have to make and update with fail, click on restore after fail. If you the step on stepper change on restore the fix worked.