### PR TITLE
[FIX] use state version if initialized instead using core files

### DIFF
--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -282,7 +282,7 @@ class UpgradeContainer
             case self::ARCHIVE_FILEPATH:
                 return $this->getProperty(self::DOWNLOAD_PATH) . DIRECTORY_SEPARATOR . $this->getProperty(self::ARCHIVE_FILENAME);
             case self::PS_VERSION:
-                return $this->getPrestaShopConfiguration()->getPrestaShopVersion();
+                return $this->getCurrentPrestaShopVersion();
             default:
                 return '';
         }
@@ -359,6 +359,15 @@ class UpgradeContainer
         }
 
         return $this->checksumCompare;
+    }
+
+    public function getCurrentPrestaShopVersion(): string
+    {
+        if ($this->getUpdateState()->isInitialized()) {
+            return $this->getUpdateState()->getCurrentVersion();
+        }
+
+        return $this->getPrestaShopConfiguration()->getPrestaShopVersion();
     }
 
     public function getComposerService(): ComposerService


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Use state version if initialized instead using core files
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | @PrestaShopCorp
| How to test?      | You need to try and update from 1.7.8.4 to 9.0.0. You need to crash the update file in middle of process to reproduce ce bug. With the fix you won't have any more bug.