### PR TITLE
[FIX] old ci to use latest version of packages

### DIFF
--- a/.github/workflows/checksUI.yml
+++ b/.github/workflows/checksUI.yml
@@ -19,16 +19,16 @@ jobs:
 
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright/
           key: ${{ runner.os }}-browsers
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -46,16 +46,16 @@ jobs:
 
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright/
           key: ${{ runner.os }}-browsers
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@v4
 
       - name: PHP syntax checker 7.1
         uses: prestashop/github-action-php-lint/7.1@master
@@ -53,10 +53,10 @@ jobs:
           php-version: '7.1'
 
       - name: Checkout
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@v4
 
       - name: Cache dependencies
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v4
         with:
           path: vendor
           key: php-${{ hashFiles('composer.lock') }}
@@ -79,7 +79,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv, ext-zip
-      - uses: actions/checkout@v4.1.3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -95,7 +95,7 @@ jobs:
         presta-versions: ['1.7.2.5', '1.7.3.4', '1.7.4.4', '1.7.5.1', '1.7.6', '1.7.7', '1.7.8', '8.0.0', 'latest']
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@v4
 
       - run: composer install
 
@@ -111,7 +111,7 @@ jobs:
     name: PHP 5.6 Syntax Check
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
     needs: create_artifact
     steps:
       - name: Download built artifact
-        uses: actions/download-artifact@v4.1.0
+        uses: actions/download-artifact@v4
         with:
           name: ${{ github.event.repository.name }}
 


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | We got some issue on CI (see php workflow fail on dev branch), I updated all packages to run as expected.
| Type?             | bug fix
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | @PrestaShopCorp
| How to test?      | CI on green !
