### PR TITLE
Add `id_product` in customer_message for v9

### DIFF
--- a/upgrade/sql/9.0.0.sql
+++ b/upgrade/sql/9.0.0.sql
@@ -323,3 +323,7 @@ ALTER TABLE `PREFIX_attachment_lang` MODIFY COLUMN `name` varchar(255) DEFAULT N
 /* Fix category thumbnail images */
 /* https://github.com/PrestaShop/PrestaShop/pull/36877 */
 /* PHP:ps_900_migrate_category_images(); */;
+
+/* Add id_product in customer message table */
+/* https://github.com/PrestaShop/PrestaShop/pull/37861 */
+/* PHP:add_column('customer_message', 'id_product', 'INT UNSIGNED DEFAULT NULL AFTER `id_employee`'); */;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add `id_product` in customer_message table for v9.<br>Related to https://github.com/PrestaShop/PrestaShop/pull/37861
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Sponsor company   | PrestaShop SA
| How to test?      | ~
