### PR TITLE
Avoid files as scandir() parameter

### DIFF
--- a/classes/UpgradeTools/CacheCleaner.php
+++ b/classes/UpgradeTools/CacheCleaner.php
@@ -71,13 +71,8 @@ class CacheCleaner
                 $this->logger->debug($this->container->getTranslator()->trans('Directory "%s" does not exist and cannot be emptied.', [str_replace($this->container->getProperty(UpgradeContainer::PS_ROOT_PATH), '', $dir)]));
                 continue;
             }
-            foreach (scandir($dir) as $file) {
-                if ($file[0] === '.' || $file === 'index.php') {
-                    continue;
-                }
-                $this->container->getFilesystemAdapter()->clearDirectory($dir . $file, true);
-                $this->logger->debug($this->container->getTranslator()->trans('File %s removed', [$file]));
-            }
+            $this->container->getFilesystemAdapter()->clearDirectory($dir);
+            $this->logger->debug($this->container->getTranslator()->trans('Directory %s emptied', [$dir]));
         }
     }
 }

--- a/classes/UpgradeTools/FilesystemAdapter.php
+++ b/classes/UpgradeTools/FilesystemAdapter.php
@@ -236,11 +236,10 @@ class FilesystemAdapter
      * @throws IOException if the removal of a file or directory fails
      *
      * @param string $folderToClear the absolute path of the directory to be cleared
-     * @param bool $deleteFolder whether to delete the entire directory after clearing its contents
      *
-     * @return bool returns `true` if any files or the directory itself were deleted, `false` otherwise
+     * @return bool returns `true` if any files/folders were deleted, `false` otherwise
      */
-    public function clearDirectory(string $folderToClear, bool $deleteFolder = false): bool
+    public function clearDirectory(string $folderToClear): bool
     {
         $hasDeletedItems = false;
 
@@ -252,11 +251,6 @@ class FilesystemAdapter
 
                     $hasDeletedItems = true;
                 }
-            }
-
-            if ($deleteFolder) {
-                $this->filesystem->remove($folderToClear);
-                $hasDeletedItems = true;
             }
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Avoid two recursive levels of calls to the scandir() method, because it would send files as parameters, triggering PHP errors.<br/><br/>I've also removed the second parameter of the method `clearDirectory` because its value as `true` would equals to a simple call to `Filesystem::remove()`.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/38087
| Sponsor company   | @PrestaShopCorp
| How to test?      | Remove warnings at the end of the update process when cleaning operational folders.