### PR TITLE
Make sure to not update to patch versions if they are not in channel.xml file

### DIFF
--- a/classes/Services/PhpVersionResolverService.php
+++ b/classes/Services/PhpVersionResolverService.php
@@ -164,7 +164,7 @@ class PhpVersionResolverService
             if ($currentPhpVersion >= $versionMinWithoutPatch && $currentPhpVersion <= $versionMaxWithoutPatch) {
                 // verify channel.xml matching
                 $branch = VersionUtils::splitPrestaShopVersion($release->getVersion())['minor'];
-                if (isset($releasesFromChannelFile[$branch])) {
+                if (isset($releasesFromChannelFile[$branch]) && version_compare($releasesFromChannelFile[$branch]->getVersion(), $release->getVersion(), '>=')) {
                     $releaseNote = $releasesFromChannelFile[$branch]->getReleaseNoteUrl();
                     $release->setReleaseNoteUrl($releaseNote);
                     $validReleases[] = $release;

--- a/tests/unit/Services/PhpVersionResolverServiceTest.php
+++ b/tests/unit/Services/PhpVersionResolverServiceTest.php
@@ -265,6 +265,18 @@ class PhpVersionResolverServiceTest extends TestCase
                 '7.2.5'
             ),
             new PrestashopRelease(
+                '8.1.9',
+                'stable',
+                '8.1',
+                '7.2.5'
+            ),
+            new PrestashopRelease(
+                '8.2.1',
+                'stable',
+                '8.1',
+                '7.2.5'
+            ),
+            new PrestashopRelease(
                 '9.0.0',
                 'stable',
                 '8.1',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | We discovered the module suggest upgrades to PrestaShop 8.2.1 as soon it is being released, even though it is not present in the file [channel.xml](https://api.prestashop.com/xml/channel.xml).
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/38097
| Sponsor company   | @PrestaShopCorp
| How to test?      | The CI is green again, and upgrades target PrestaShop 8.2.0