### PR TITLE
[NEW UI] add entry in employee menu to access release notes

### DIFF
--- a/autoupgrade.php
+++ b/autoupgrade.php
@@ -193,7 +193,7 @@ class Autoupgrade extends Module
      *
      * @return void
      */
-    public function hookDisplayBackOfficeEmployeeMenu(array $params): void
+    public function hookDisplayBackOfficeEmployeeMenu(array $params)
     {
         if (
             !class_exists(\PrestaShop\PrestaShop\Core\Action\ActionsBarButtonsCollection::class)

--- a/autoupgrade.php
+++ b/autoupgrade.php
@@ -186,6 +186,13 @@ class Autoupgrade extends Module
         return $translator->trans($id, $parameters);
     }
 
+    /**
+     * Only available from PS8.
+     *
+     * @param array{links: \PrestaShop\PrestaShop\Core\Action\ActionsBarButtonsCollection} $params
+     *
+     * @return void
+     */
     public function hookDisplayBackOfficeEmployeeMenu(array $params): void
     {
         if (

--- a/autoupgrade.php
+++ b/autoupgrade.php
@@ -97,7 +97,7 @@ class Autoupgrade extends Module
             }
         }
 
-        return parent::install();
+        return parent::install() && $this->registerHook('displayBackOfficeEmployeeMenu');
     }
 
     /**
@@ -184,5 +184,28 @@ class Autoupgrade extends Module
         );
 
         return $translator->trans($id, $parameters);
+    }
+
+    public function hookDisplayBackOfficeEmployeeMenu(array $params): void
+    {
+        if (
+            !class_exists(\PrestaShop\PrestaShop\Core\Action\ActionsBarButtonsCollection::class)
+            || !class_exists(\PrestaShop\PrestaShop\Core\Action\ActionsBarButton::class)
+            || !($params['links'] instanceof \PrestaShop\PrestaShop\Core\Action\ActionsBarButtonsCollection)
+        ) {
+            return;
+        }
+
+        $params['links']->add(
+            new \PrestaShop\PrestaShop\Core\Action\ActionsBarButton(
+                __CLASS__,
+                [
+                    'link' => 'https://build.prestashop-project.org/tag/releases/',
+                    'icon' => 'history',
+                    'isExternalLink' => true,
+                ],
+                $this->trans('Discover the latest releases')
+            )
+        );
     }
 }

--- a/tests/phpstan/phpstan-1.7.2.5.neon
+++ b/tests/phpstan/phpstan-1.7.2.5.neon
@@ -23,6 +23,7 @@ parameters:
 		- "#^Property PrestaShop\\\\Module\\\\AutoUpgrade\\\\UpgradeTools\\\\Module\\\\ModuleAdapter\\:\\:\\$commandBus has unknown class PrestaShop\\\\PrestaShop\\\\Core\\\\CommandBus\\\\CommandBusInterface as its type\\.$#"
 		- '#Instantiated class AdminKernel not found\.#'
 		- "#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(int\\)\\: mixed\\)\\|null, 'add_quotes' given\\.$#"
+		- '#Parameter \$params of method Autoupgrade::hookDisplayBackOfficeEmployeeMenu\(\) has invalid type PrestaShop\\PrestaShop\\Core\\Action\\ActionsBarButtonsCollection.#'
 		-
 			identifier: booleanAnd.rightAlwaysTrue
 			path: ./../../classes/UpgradeSelfCheck.php

--- a/tests/phpstan/phpstan-1.7.3.4.neon
+++ b/tests/phpstan/phpstan-1.7.3.4.neon
@@ -24,6 +24,7 @@ parameters:
 		- '#Call to method getContainer\(\) on an unknown class AdminKernel.#'
 		- '#Instantiated class AdminKernel not found\.#'
 		- "#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(int\\)\\: mixed\\)\\|null, 'add_quotes' given\\.$#"
+		- '#Parameter \$params of method Autoupgrade::hookDisplayBackOfficeEmployeeMenu\(\) has invalid type PrestaShop\\PrestaShop\\Core\\Action\\ActionsBarButtonsCollection.#'
 		-
 			identifier: booleanAnd.rightAlwaysTrue
 			path: ./../../classes/UpgradeSelfCheck.php

--- a/tests/phpstan/phpstan-1.7.4.4.neon
+++ b/tests/phpstan/phpstan-1.7.4.4.neon
@@ -19,6 +19,7 @@ parameters:
 		- "#^Property PrestaShop\\\\Module\\\\AutoUpgrade\\\\UpgradeTools\\\\Module\\\\ModuleAdapter\\:\\:\\$commandBus has unknown class PrestaShop\\\\PrestaShop\\\\Core\\\\CommandBus\\\\CommandBusInterface as its type\\.$#"
 		- '#Instantiated class AdminKernel not found\.#'
 		- "#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(int\\)\\: mixed\\)\\|null, 'add_quotes' given\\.$#"
+		- '#Parameter \$params of method Autoupgrade::hookDisplayBackOfficeEmployeeMenu\(\) has invalid type PrestaShop\\PrestaShop\\Core\\Action\\ActionsBarButtonsCollection.#'
 		-
 			identifier: booleanAnd.rightAlwaysTrue
 			path: ./../../classes/UpgradeSelfCheck.php

--- a/tests/phpstan/phpstan-1.7.5.1.neon
+++ b/tests/phpstan/phpstan-1.7.5.1.neon
@@ -13,6 +13,7 @@ parameters:
 		- "#^Class PrestaShop\\\\Module\\\\AutoUpgrade\\\\Parameters\\\\RestoreConfiguration @extends tag contains incompatible type Doctrine\\\\Common\\\\Collections\\\\ArrayCollection&iterable\\<string, mixed\\>\\.$#"
 		- '#Instantiated class AdminKernel not found\.#'
 		- "#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(int\\)\\: mixed\\)\\|null, 'add_quotes' given\\.$#"
+		- '#Parameter \$params of method Autoupgrade::hookDisplayBackOfficeEmployeeMenu\(\) has invalid type PrestaShop\\PrestaShop\\Core\\Action\\ActionsBarButtonsCollection.#'
 		-
 			identifier: booleanAnd.rightAlwaysTrue
 			path: ./../../classes/UpgradeSelfCheck.php

--- a/tests/phpstan/phpstan-1.7.6.neon
+++ b/tests/phpstan/phpstan-1.7.6.neon
@@ -14,6 +14,7 @@ parameters:
 		- "#^Class PrestaShop\\\\Module\\\\AutoUpgrade\\\\Parameters\\\\RestoreConfiguration @extends tag contains incompatible type Doctrine\\\\Common\\\\Collections\\\\ArrayCollection&iterable\\<string, mixed\\>\\.$#"
 		- '#Instantiated class AdminKernel not found\.#'
 		- "#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(int\\)\\: mixed\\)\\|null, 'add_quotes' given\\.$#"
+		- '#Parameter \$params of method Autoupgrade::hookDisplayBackOfficeEmployeeMenu\(\) has invalid type PrestaShop\\PrestaShop\\Core\\Action\\ActionsBarButtonsCollection.#'
 		-
 			identifier: booleanAnd.rightAlwaysTrue
 			path: ./../../classes/UpgradeSelfCheck.php

--- a/tests/phpstan/phpstan-1.7.7.neon
+++ b/tests/phpstan/phpstan-1.7.7.neon
@@ -12,6 +12,7 @@ parameters:
 		- "#^Parameter \\$moduleRepository of method PrestaShop\\\\Module\\\\AutoUpgrade\\\\UpgradeTools\\\\Module\\\\ModuleAdapter\\:\\:disableNonNativeModules80\\(\\) has invalid type PrestaShop\\\\PrestaShop\\\\Adapter\\\\Module\\\\Repository\\\\ModuleRepository\\.$#"
 		- '#Instantiated class AdminKernel not found\.#'
 		- "#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(int\\)\\: mixed\\)\\|null, 'add_quotes' given\\.$#"
+		- '#Parameter \$params of method Autoupgrade::hookDisplayBackOfficeEmployeeMenu\(\) has invalid type PrestaShop\\PrestaShop\\Core\\Action\\ActionsBarButtonsCollection.#'
 		-
 			identifier: booleanAnd.rightAlwaysTrue
 			path: ./../../classes/UpgradeSelfCheck.php

--- a/tests/phpstan/phpstan-1.7.8.neon
+++ b/tests/phpstan/phpstan-1.7.8.neon
@@ -11,6 +11,7 @@ parameters:
 		- '#Method PrestaShop\\Module\\AutoUpgrade\\UpgradeTools\\SymfonyAdapter::initKernel\(\) has invalid return type AdminKernel.#'
 		- '#Instantiated class AdminKernel not found\.#'
 		- "#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(int\\)\\: mixed\\)\\|null, 'add_quotes' given\\.$#"
+		- '#Parameter \$params of method Autoupgrade::hookDisplayBackOfficeEmployeeMenu\(\) has invalid type PrestaShop\\PrestaShop\\Core\\Action\\ActionsBarButtonsCollection.#'
 		-
 			identifier: booleanAnd.rightAlwaysTrue
 			path: ./../../classes/UpgradeSelfCheck.php


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add link to employee menu to access release notes. I used `hookDisplayBackOfficeEmployeeMenu` only available from version 8 of PrestaShop
| Type?             |  new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | @PrestaShopCorp
| How to test?      | Install module on V8 or more and check the employee menu on top right in BO, you need to have a new link targeting release notes.