### PR TITLE
remove safe_mode check

### DIFF
--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -51,8 +51,6 @@ class UpgradeSelfCheck
     private $localEnvironement;
     /** @var bool */
     private $cacheDisabled;
-    /** @var bool */
-    private $safeModeDisabled;
     /** @var bool|mixed */
     private $moduleVersionIsLatest;
     /** @var int */
@@ -96,7 +94,6 @@ class UpgradeSelfCheck
     const PHP_COMPATIBILITY_INVALID = 0;
     const ROOT_DIRECTORY_NOT_WRITABLE = 1;
     const ADMIN_UPGRADE_DIRECTORY_NOT_WRITABLE = 2;
-    const SAFE_MODE_ENABLED = 3;
     const F_OPEN_AND_CURL_DISABLED = 4;
     const ZIP_DISABLED = 5;
     const MAINTENANCE_MODE_DISABLED = 6;
@@ -152,8 +149,7 @@ class UpgradeSelfCheck
         $errors = [
             self::ROOT_DIRECTORY_NOT_WRITABLE => !$this->isRootDirectoryWritable(),
             self::ADMIN_UPGRADE_DIRECTORY_NOT_WRITABLE => !$this->isAdminAutoUpgradeDirectoryWritable(),
-            self::SAFE_MODE_ENABLED => !$this->isSafeModeDisabled(),
-            self::F_OPEN_AND_CURL_DISABLED => !$this->isFOpenOrCurlEnabled(),
+             self::F_OPEN_AND_CURL_DISABLED => !$this->isFOpenOrCurlEnabled(),
             self::ZIP_DISABLED => !$this->isZipEnabled(),
             self::MAINTENANCE_MODE_DISABLED => !$this->isLocalEnvironment() && !$this->isShopDeactivated(),
             self::CACHE_ENABLED => !$this->isCacheDisabled(),
@@ -232,11 +228,6 @@ class UpgradeSelfCheck
                         'The %s directory isn\'t writable. Provide write access to the user running PHP with appropriate permission & ownership.',
                         [$this->autoUpgradePath]
                     ),
-                ];
-
-            case self::SAFE_MODE_ENABLED:
-                return [
-                    'message' => $this->translator->trans('PHP\'s "Safe mode" needs to be disabled.'),
                 ];
 
             case self::F_OPEN_AND_CURL_DISABLED:
@@ -507,15 +498,6 @@ class UpgradeSelfCheck
         return $this->cacheDisabled = !(defined('_PS_CACHE_ENABLED_') && false != _PS_CACHE_ENABLED_);
     }
 
-    public function isSafeModeDisabled(): bool
-    {
-        if (null !== $this->safeModeDisabled) {
-            return $this->safeModeDisabled;
-        }
-
-        return $this->safeModeDisabled = $this->checkSafeModeIsDisabled();
-    }
-
     /**
      * @throws UpgradeException
      */
@@ -771,15 +753,6 @@ class UpgradeSelfCheck
         );
     }
 
-    private function checkSafeModeIsDisabled(): bool
-    {
-        $safeMode = @ini_get('safe_mode');
-        if (empty($safeMode)) {
-            $safeMode = '';
-        }
-
-        return !in_array(strtolower($safeMode), [1, 'on']);
-    }
 
     private function checkMaxExecutionTime(): int
     {

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -753,7 +753,6 @@ class UpgradeSelfCheck
         );
     }
 
-
     private function checkMaxExecutionTime(): int
     {
         return (int) @ini_get('max_execution_time');

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -149,7 +149,7 @@ class UpgradeSelfCheck
         $errors = [
             self::ROOT_DIRECTORY_NOT_WRITABLE => !$this->isRootDirectoryWritable(),
             self::ADMIN_UPGRADE_DIRECTORY_NOT_WRITABLE => !$this->isAdminAutoUpgradeDirectoryWritable(),
-             self::F_OPEN_AND_CURL_DISABLED => !$this->isFOpenOrCurlEnabled(),
+            self::F_OPEN_AND_CURL_DISABLED => !$this->isFOpenOrCurlEnabled(),
             self::ZIP_DISABLED => !$this->isZipEnabled(),
             self::MAINTENANCE_MODE_DISABLED => !$this->isLocalEnvironment() && !$this->isShopDeactivated(),
             self::CACHE_ENABLED => !$this->isCacheDisabled(),


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | safe_mode was deprecated in PHP 5.3 and removed in PHP 5.4 (https://www.mediawiki.org/wiki/PHP_5_safe_mode)
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | https://www.openservis.cz/
| How to test?      | 
