### PR TITLE
Catch all potential issues of core init during a process startup

### DIFF
--- a/classes/Task/Runner/ChainedTasks.php
+++ b/classes/Task/Runner/ChainedTasks.php
@@ -24,7 +24,6 @@ namespace PrestaShop\Module\AutoUpgrade\Task\Runner;
 use Exception;
 use PrestaShop\Module\AutoUpgrade\AjaxResponse;
 use PrestaShop\Module\AutoUpgrade\Database\DbWrapper;
-use PrestaShop\Module\AutoUpgrade\Exceptions\UpdateDatabaseException;
 use PrestaShop\Module\AutoUpgrade\Task\AbstractTask;
 use PrestaShop\Module\AutoUpgrade\Task\TaskName;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\TaskRepository;
@@ -118,10 +117,10 @@ abstract class ChainedTasks extends AbstractTask
 
         if (in_array($this->step, $initializationSteps)) {
             if (php_sapi_name() !== 'cli') {
-                $this->container->initPrestaShopCore();
                 try {
+                    $this->container->initPrestaShopCore();
                     $timeZone = DbWrapper::getValue('SELECT `value` FROM `' . _DB_PREFIX_ . 'configuration` WHERE `name` = \'PS_TIMEZONE\'');
-                } catch (UpdateDatabaseException $e) {
+                } catch (Throwable $t) {
                     $timeZone = date_default_timezone_get();
                 }
                 $logsState->setTimeZone($timeZone);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When restoring my shop after a critical failure, I was unable to start the restoration because my PrestaShop was impossible to init. This was caused during the retrieval of the current timezone, which was temporarily unavailable.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | /
| How to test?      | Crash an update, remove the critical files of a PrestaShop (i.e the configuration files), then try a restore. Without the PR, starting the process will fail, with the PR the module should manage to start.