### PR TITLE
Remove old check preventing PrestaShop 8.2.1+ to be installed

### DIFF
--- a/autoupgrade.php
+++ b/autoupgrade.php
@@ -39,14 +39,6 @@ class Autoupgrade extends Module
 
         $this->multishop_context = Shop::CONTEXT_ALL;
 
-        if (!defined('_PS_ADMIN_DIR_')) {
-            if (defined('PS_ADMIN_DIR')) {
-                define('_PS_ADMIN_DIR_', PS_ADMIN_DIR);
-            } else {
-                $this->_errors[] = $this->trans('This version of PrestaShop cannot be upgraded: the PS_ADMIN_DIR constant is missing.');
-            }
-        }
-
         $this->displayName = $this->trans('Update assistant');
         $this->description = $this->trans('Upgrade to the latest version of PrestaShop in a few clicks, thanks to this automated method.');
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | From PrestaShop 8.2.1 (Especially https://github.com/PrestaShop/PrestaShop/pull/36612), the installation of a module will fail with the array of errors is filled. This conflicts with one very old condition present in the module constructor, supposed to prevent the use of the module where the admin folder constant did not exist yet. Because we're currently compliant with PS 1.7+, this is unnecessary to check it. This will also will the installation outside the admin context (i.e during the installation of PS)
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes the UI tests: https://github.com/PrestaShop/autoupgrade/actions/runs/13688079359/job/38275964871
| Sponsor company   | @PrestaShopCorp
| How to test?      | In the folder `tests/UI/`, the command `PS_DOCKER=8.2.1-8.1 PS_VERSION=8.2.1-8.1 CAMPAIGN=autoupgrade docker compose -f "docker-compose.yml" up` must work
