### PR TITLE
Pick up & display details if possible when an error occurs during a process

### DIFF
--- a/_dev/src/ts/api/axiosError.ts
+++ b/_dev/src/ts/api/axiosError.ts
@@ -36,7 +36,8 @@ export const toApiResponseAction = (error: AxiosError): ApiResponseAction => ({
   nextParams: {
     progressPercentage: 0
   },
-  nextQuickInfo: [],
+  // Pick up & display details from the PHP ErrorHandler if provided
+  nextQuickInfo: (<ApiResponseAction>error.response?.data)?.nextQuickInfo || [],
   apiError: toApiError(error)
 });
 


### PR DESCRIPTION


<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When a error is caught by the PHP Error handler, a proper response is built to allow the process to stop gracefully. With the new interface, all the details of these errors were not completely displayed on the screen. This PR shows the error details on the logs when possible.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Thow an exception during any process (backup, restore or update). It should now appears on the logs before the generic message.

### With the PR

![Capture d’écran du 2025-03-06 12-05-03](https://github.com/user-attachments/assets/c82ee39d-52f5-43e9-8d7b-a288518470a2)

### Original behavior

![Capture d’écran du 2025-03-06 11-59-46](https://github.com/user-attachments/assets/7dfa48c0-1c6f-4bc9-9577-e8150c1843a3)
