### PR TITLE
Add error code and type in error page dataset

### DIFF
--- a/_dev/src/ts/components/ErrorPageBuilder.ts
+++ b/_dev/src/ts/components/ErrorPageBuilder.ts
@@ -27,10 +27,13 @@ export default class ErrorPageBuilder {
   /**
    * Replace the id of the cloned element
    */
-  public updateId(type: ApiError['type']): void {
+  public updateId(errorDetails: Pick<ApiError, 'code' | 'type'>): void {
     const errorChild = this.errorElement.getElementById('ua_error_placeholder');
     if (errorChild) {
-      errorChild.id = `ua_error_${type}`;
+      errorChild.id = `ua_error_${isHttpErrorCode(errorDetails.code) ? errorDetails.code : errorDetails.type}`;
+
+      errorChild.dataset.error_code = errorDetails.code?.toString();
+      errorChild.dataset.error_type = errorDetails.type;
     }
   }
 

--- a/_dev/src/ts/pages/ErrorPage.ts
+++ b/_dev/src/ts/pages/ErrorPage.ts
@@ -80,7 +80,7 @@ export default class ErrorPage extends PageAbstract {
     const errorElement = this.#errorTemplateElement.content.cloneNode(true) as DocumentFragment;
 
     const pageBuilder = new ErrorPageBuilder(errorElement);
-    pageBuilder.updateId(event.detail.type);
+    pageBuilder.updateId(event.detail);
     pageBuilder.updateLeftColumn(event.detail.code);
     pageBuilder.updateDescriptionBlock(event.detail);
     pageBuilder.updateResponseBlock(event.detail.additionalContents);

--- a/_dev/tests/components/ErrorPageBuilder.test.ts
+++ b/_dev/tests/components/ErrorPageBuilder.test.ts
@@ -121,8 +121,10 @@ describe('ErrorPageBuilder', () => {
 
   test('updateId should update the id of the error placeholder', () => {
     const referenceToDiv = errorElement.getElementById('ua_error_placeholder');
-    errorPageBuilder.updateId('404');
+    errorPageBuilder.updateId({ code: 404, type: 'ERR_BAD_RESPONSE' });
     expect(referenceToDiv!.id).toBe('ua_error_404');
+    expect(referenceToDiv!.dataset.error_code).toBe('404');
+    expect(referenceToDiv!.dataset.error_type).toBe('ERR_BAD_RESPONSE');
   });
 
   test('updateLeftColumn should update error code display with HTTP 404', () => {

--- a/views/templates/layouts/error.html.twig
+++ b/views/templates/layouts/error.html.twig
@@ -19,7 +19,7 @@
 {% extends "@ModuleAutoUpgrade/layouts/page.html.twig" %}
 
 {% block update_assistant %}
-  <div id="ua_error_{{ error_code }}" class="error-page">
+  <div id="ua_error_{{ error_code }}" class="error-page" {% if error_code %}data-error_code="{{ error_code }}"{% endif %}>
     <div class="error-page__container">
       {% block error_code %}
         <div class="error-page__code">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Required by the incoming analytics on the error page, this PR add the basic code and type of the error in the page dataset when available. They will be then picked up by Segment. This PR also fixes the block ID, where the code is supposed to be displayed instead of the type when > 300.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Code and type now appear on the `.error-page` block when possible. ![image](https://github.com/user-attachments/assets/14f4ca60-ce32-4738-b81d-57bf645f647a)
