### PR TITLE
Fix redirection after the last backup deletion

### DIFF
--- a/classes/Router/Router.php
+++ b/classes/Router/Router.php
@@ -73,7 +73,7 @@ class Router
     {
         $newUrl = $this->upgradeContainer->getUrlGenerator()->getUrlToRoute($request, $route, ['_redirected' => '1']);
 
-        header('Location: ' . $newUrl, true, 302);
+        header('Location: ' . $newUrl, true, 307);
         exit;
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Use the HTTP 307 instead of the HTTP 302 to make sure we keep the same method and data after a redirection. Otherwise we lose some mandatory details such as the admin directory. This PR fixes the redirection after the last backup is deleted.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Delete the last backup of a shop. You should be redirected on the home page.