### PR TITLE
Fix enabling of the next button with some PHP versions

### DIFF
--- a/views/templates/components/radio-card.html.twig
+++ b/views/templates/components/radio-card.html.twig
@@ -35,7 +35,7 @@
       {% if disabled %} disabled {% endif %}
       {% if checked and not disabled %} checked {% endif %}
       {% if required %} required {% endif %}
-      {% if requirements and requirements.requirements_ok %}data-requirements-are-ok="1"{% endif %}
+      {% if requirements and requirements.requirements_ok %} data-requirements-are-ok="1" {% endif %}
     />
   </div>
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | In some cases, the attributes of an input were concatenated without space. This prevented the user to click on the Next button on the Version selection page.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/38222
| Sponsor company   | @PrestaShopCorp
| How to test?      | With PHP 7.4 and PrestaShop 1.7.6.9, you should be able to reach the next step of the update selection.