### PR TITLE
Allow use of flexible directory separator

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -44,10 +44,10 @@ if (!is_dir(dirname(__DIR__).'/vendor')) {
 require_once dirname(__DIR__).'/vendor/autoload.php';
 
 if (!defined('_PS_ROOT_DIR_')) {
-    define('_PS_ROOT_DIR_', __DIR__ . '/../../..');
+    define('_PS_ROOT_DIR_', __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..');
 }
 
-$moduleConfig = @simplexml_load_file(dirname(__DIR__).'/config.xml');
+$moduleConfig = @simplexml_load_file(dirname(__DIR__). DIRECTORY_SEPARATOR . 'config.xml');
 
 $application = new Application();
 

--- a/classes/UpgradeTools/FilesystemAdapter.php
+++ b/classes/UpgradeTools/FilesystemAdapter.php
@@ -86,7 +86,7 @@ class FilesystemAdapter
         $files = [];
         $directory = new RecursiveDirectoryIterator(
             $dir,
-            FilesystemIterator::SKIP_DOTS | FilesystemIterator::KEY_AS_FILENAME | FilesystemIterator::CURRENT_AS_PATHNAME | FilesystemIterator::UNIX_PATHS
+            FilesystemIterator::SKIP_DOTS | FilesystemIterator::KEY_AS_FILENAME | FilesystemIterator::CURRENT_AS_PATHNAME
         );
         $filter = new RecursiveCallbackFilterIterator($directory, function ($current, $key, $iterator) use ($way, $dir) {
             return !$this->isFileSkipped($key, $current, $way, $dir);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The `DIRECTORY_SEPARATOR` is used all around the project to allow it to be used on many OSes. Unfortunately, the listing of files to backup was forces to use UNIX separators, which prevented some comparison of string to succeed. 
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Attempt a backup on a server running an OS using `\` as separator, such as Windows. The generated backup of files must be valid and the shop should be able to restore from it..