### PR TITLE
[FIX] performs the deletion step before modifying the DB during restore

### DIFF
--- a/classes/Task/Restore/RestoreDatabase.php
+++ b/classes/Task/Restore/RestoreDatabase.php
@@ -152,6 +152,8 @@ class RestoreDatabase extends AbstractTask
 
                 if (!empty($tablesToRemove)) {
                     $this->container->getFileStorage()->save($tablesToRemove, UpgradeFileNames::DB_TABLES_TO_CLEAN_LIST);
+                    // TODO: This is a temporary workaround and does not properly handle.
+                    $databaseTools->cleanTablesAfterBackup($this->container->getFileStorage()->load(UpgradeFileNames::DB_TABLES_TO_CLEAN_LIST));
                 }
             }
             $backlog = new Backlog(array_reverse($listQuery), count($listQuery));
@@ -233,8 +235,6 @@ class RestoreDatabase extends AbstractTask
             $this->status = 'ok';
             $this->next = TaskName::TASK_RESTORE_COMPLETE;
             $this->logger->info($this->translator->trans('Database restoration done.'));
-
-            $databaseTools->cleanTablesAfterBackup($this->container->getFileStorage()->load(UpgradeFileNames::DB_TABLES_TO_CLEAN_LIST));
         }
 
         return ExitCode::SUCCESS;

--- a/classes/Task/Restore/RestoreDatabase.php
+++ b/classes/Task/Restore/RestoreDatabase.php
@@ -152,7 +152,7 @@ class RestoreDatabase extends AbstractTask
 
                 if (!empty($tablesToRemove)) {
                     $this->container->getFileStorage()->save($tablesToRemove, UpgradeFileNames::DB_TABLES_TO_CLEAN_LIST);
-                    // TODO: This is a temporary workaround and does not properly handle.
+                    // TODO: This is a temporary workaround and does not properly handle multiple files.
                     $databaseTools->cleanTablesAfterBackup($this->container->getFileStorage()->load(UpgradeFileNames::DB_TABLES_TO_CLEAN_LIST));
                 }
             }


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Temporary workaround :warning:  Performs the deletion step before modifying the DB during restore
| Type?             | bug fix / improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | @PrestaShopCorp
| How to test?      | see internal ticket