### PR TITLE
Remove use of uneeded GLOB_BRACE constant

### DIFF
--- a/classes/UpgradeTools/Module/ModuleMigration.php
+++ b/classes/UpgradeTools/Module/ModuleMigration.php
@@ -74,7 +74,7 @@ class ModuleMigration
             $this->logger->notice($this->translator->trans('No version present in database for module %s, all files for update will be applied.', [$moduleMigrationContext->getModuleName()]));
         }
 
-        $files = glob($moduleMigrationContext->getUpgradeFilesRootPath() . '/*.php', GLOB_BRACE);
+        $files = glob($moduleMigrationContext->getUpgradeFilesRootPath() . '/*.php');
 
         $upgradeFiles = [];
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | GLOB_BRACE is a constant that can be undefined on some environments (i.e Alpine). It is useful when the glob you use to find files contains brackets, which is not the case here, we only look for all PHP files. In consequence, it only removed from the call, whithout bringing any regression.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/38241
| Sponsor company   | @PrestaShopCorp
| How to test?      | Running an upgrade from Mac OS (M1+ processor) running a docker container of the image PrestaShop-flashlight must work, espacially on the module update step.