### PR TITLE
Add string size limit for logs

### DIFF
--- a/_dev/src/ts/appUI/utils/logsUtils.ts
+++ b/_dev/src/ts/appUI/utils/logsUtils.ts
@@ -109,5 +109,8 @@ export function debounce<T extends Procedure>(
  * @description
  */
 export function formatLogsMessages(logs: Log[]): string {
-  return logs.map((log) => log.message).join('\n');
+  const formattedLogs = logs.map((log) => log.message).join('\n');
+  // We limit to 5 million characters so that each log file is approximately 5MB in size.
+  // Since we send 4 files, this ensures the total size does not exceed Sentry's 20MB limit.
+  return formattedLogs.slice(-5_000_000); // Limit due to Sentry attachment constraints
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add string size limit for logs
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     |no
| Fixed ticket?     | -
| Sponsor company   | -
| How to test?      | make an update with an error report that has an error code 413 (payload too large) before this PR. The error code is no longer present, the request works correctly
