### PR TITLE
Move deletion of files BEFORE unzipping backup

### DIFF
--- a/classes/Task/Restore/RestoreFiles.php
+++ b/classes/Task/Restore/RestoreFiles.php
@@ -96,6 +96,12 @@ class RestoreFiles extends AbstractTask
             $filepath = $this->container->getProperty(UpgradeContainer::BACKUP_PATH) . DIRECTORY_SEPARATOR . $state->getRestoreFilesFilename();
             $destExtract = $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH);
 
+            if (!empty($toRemoveOnly)) {
+                foreach ($toRemoveOnly as $fileToRemove) {
+                    $this->container->getFileSystem()->remove($this->container->getProperty(UpgradeContainer::PS_ROOT_PATH) . $fileToRemove);
+                }
+            }
+
             $res = $this->container->getZipAction()->extract($filepath, $destExtract);
             if (!$res) {
                 $this->next = TaskName::TASK_ERROR;
@@ -109,12 +115,6 @@ class RestoreFiles extends AbstractTask
                 ));
 
                 return ExitCode::FAIL;
-            }
-
-            if (!empty($toRemoveOnly)) {
-                foreach ($toRemoveOnly as $fileToRemove) {
-                    $this->container->getFileSystem()->remove($this->container->getProperty(UpgradeContainer::PS_ROOT_PATH) . $fileToRemove);
-                }
             }
 
             $this->next = TaskName::TASK_RESTORE_DATABASE;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix the the code to match to match what is announced by the log "XX file(s) will be removed before restoring the backup files." by moving the code deleting the files BEFORE the backup extraction.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | On UNIX environments, there is no regression. On Windows environments, the shop was deleted by this cleanup done after the restore.
