### PR TITLE
Fetch the stepper on each update

### DIFF
--- a/_dev/src/ts/appUI/utils/Stepper.ts
+++ b/_dev/src/ts/appUI/utils/Stepper.ts
@@ -19,51 +19,11 @@
 import type { Step } from '../types/Stepper';
 
 export default class Stepper {
-  #stepper: HTMLDivElement | null = null;
-  #steps: Step[] = [];
-
   #baseClass = 'stepper__step';
   #currentClass = `${this.#baseClass}--current`;
   #doneClass = `${this.#baseClass}--done`;
   #normalClass = `${this.#baseClass}--normal`;
   #stepperHydrationClass = 'stepper--hydration';
-
-  constructor() {
-    this.#initStepper();
-  }
-
-  /**
-   * @private
-   * @throws Error Will throw an error if the stepper or its steps are not found in the DOM.
-   * @description Initializes the Stepper by finding the parent element in the DOM and setting up the steps.
-   */
-  #initStepper = (): void => {
-    this.#stepper = document.getElementById(
-      window.AutoUpgradeVariables.stepper_parent_id
-    ) as HTMLDivElement | null;
-    if (!this.#stepper) {
-      throw new Error("The stepper wasn't found inside DOM. stepper can't be initiated properly");
-    }
-
-    const domSteps = Array.from(this.#stepper.children) as HTMLElement[];
-
-    if (!domSteps.length) {
-      throw new Error("The stepper hasn't steps inside DOM. stepper can't be initiated properly");
-    }
-
-    this.#steps = domSteps.map((step) => {
-      const stepCode = step.dataset.stepCode;
-      if (!stepCode) {
-        throw new Error(
-          "Step code is missing in one of the steps. stepper can't be initiated properly"
-        );
-      }
-      return {
-        code: stepCode,
-        element: step
-      };
-    });
-  };
 
   /**
    * @public
@@ -71,10 +31,6 @@ export default class Stepper {
    * @description Sets the current step in the stepper and updates the classes for each step accordingly.
    */
   public setCurrentStep = (currentStep: string) => {
-    if (this.#getStepIndex(currentStep) === -1) {
-      this.#initStepper();
-    }
-
     const stepIndex = this.#getStepIndex(currentStep);
 
     if (stepIndex === -1) {
@@ -110,5 +66,36 @@ export default class Stepper {
     }
 
     return this.#normalClass;
+  }
+
+  get #stepper(): HTMLDivElement {
+    const stepper = document.getElementById(
+      window.AutoUpgradeVariables.stepper_parent_id
+    ) as HTMLDivElement | null;
+    if (!stepper) {
+      throw new Error("The stepper wasn't found inside DOM. stepper can't be initiated properly");
+    }
+    return stepper;
+  }
+
+  get #steps(): Step[] {
+    const domSteps = Array.from(this.#stepper.children) as HTMLElement[];
+
+    if (!domSteps.length) {
+      throw new Error("The stepper hasn't steps inside DOM. stepper can't be initiated properly");
+    }
+
+    return domSteps.map((step) => {
+      const stepCode = step.dataset.stepCode;
+      if (!stepCode) {
+        throw new Error(
+          "Step code is missing in one of the steps. stepper can't be initiated properly"
+        );
+      }
+      return {
+        code: stepCode,
+        element: step
+      };
+    });
   }
 }

--- a/_dev/tests/utils/Stepper.test.ts
+++ b/_dev/tests/utils/Stepper.test.ts
@@ -47,7 +47,7 @@ describe('Stepper', () => {
   it('should throw an error if the stepper is not found in the DOM', () => {
     document.body.innerHTML = '';
 
-    expect(() => new Stepper()).toThrow(
+    expect(() => new Stepper().setCurrentStep('backup')).toThrow(
       "The stepper wasn't found inside DOM. stepper can't be initiated properly"
     );
   });
@@ -55,7 +55,7 @@ describe('Stepper', () => {
   it('should throw an error if the stepper contains no steps', () => {
     document.body.innerHTML = '<div class="stepper" id="stepper_content"></div>';
 
-    expect(() => new Stepper()).toThrow(
+    expect(() => new Stepper().setCurrentStep('backup')).toThrow(
       "The stepper hasn't steps inside DOM. stepper can't be initiated properly"
     );
   });
@@ -63,7 +63,7 @@ describe('Stepper', () => {
   it('should throw an error if a step is missing the step code', () => {
     document.querySelector('[data-step-code="backup"]')?.removeAttribute('data-step-code');
 
-    expect(() => new Stepper()).toThrow(
+    expect(() => new Stepper().setCurrentStep('backup')).toThrow(
       "Step code is missing in one of the steps. stepper can't be initiated properly"
     );
   });


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR fixes an issue where the stepper is not updated anymore after using the "Previous" button of the browser. This was caused by a cached value of `getElementById` that was removed from the DOM.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/38314
| Sponsor company   | @PrestaShopCorp
| How to test?      | Use the previous button of the browser, then reach the next step again by using the "Next step" button.