### PR TITLE
Removed core call when retrieving timezone for restore process

### DIFF
--- a/classes/Task/Runner/ChainedTasks.php
+++ b/classes/Task/Runner/ChainedTasks.php
@@ -117,16 +117,10 @@ abstract class ChainedTasks extends AbstractTask
 
         if (in_array($this->step, $initializationSteps)) {
             if (php_sapi_name() !== 'cli') {
-                try {
-                    $this->container->initPrestaShopCore();
-                    $timeZone = DbWrapper::getValue('SELECT `value` FROM `' . _DB_PREFIX_ . 'configuration` WHERE `name` = \'PS_TIMEZONE\'');
-                } catch (Throwable $t) {
-                    $timeZone = date_default_timezone_get();
-                }
+                $timeZone = $this->getCoreTimezone();
                 $logsState->setTimeZone($timeZone);
                 date_default_timezone_set($timeZone);
             }
-
             $timestamp = date('Y-m-d-His');
             switch ($this->step) {
                 case TaskName::TASK_BACKUP_INITIALIZATION:
@@ -145,5 +139,21 @@ abstract class ChainedTasks extends AbstractTask
                 date_default_timezone_set($timeZone);
             }
         }
+    }
+
+    private function getCoreTimezone(): string
+    {
+        if ($this->step === TaskName::TASK_RESTORE_INITIALIZATION) {
+            $timeZone = date_default_timezone_get();
+        } else {
+            try {
+                $this->container->initPrestaShopCore();
+                $timeZone = DbWrapper::getValue('SELECT `value` FROM `' . _DB_PREFIX_ . 'configuration` WHERE `name` = \'PS_TIMEZONE\'');
+            } catch (Throwable $t) {
+                $timeZone = date_default_timezone_get();
+            }
+        }
+
+        return $timeZone;
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Removed core call when retrieving timezone for restore process
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     |no
| Fixed ticket?     | -
| Sponsor company   | -
| How to test?      | make the core unstable before the restore process and start restore. 
