### PR TITLE
Avoid images to be deleted during a restore

### DIFF
--- a/classes/UpgradeTools/FileFilter.php
+++ b/classes/UpgradeTools/FileFilter.php
@@ -111,11 +111,10 @@ class FileFilter
             '..',
         ];
 
-        if (!$this->updateConfiguration->shouldBackupImages()) {
-            $restoreIgnoreAbsoluteFiles[] = '/img';
-        } else {
-            $restoreIgnoreAbsoluteFiles[] = '/img/tmp';
-        }
+        // TODO: Let the images being overwritten by the backup if they exist.
+        // For the images created after the backup, they will remain of the filesystem until
+        // we find a condition based on the presence of the images in the backup.
+        $restoreIgnoreAbsoluteFiles[] = '/img';
 
         return $restoreIgnoreAbsoluteFiles;
     }

--- a/tests/unit/UpgradeContainer/FilesystemAdapterTest.php
+++ b/tests/unit/UpgradeContainer/FilesystemAdapterTest.php
@@ -112,34 +112,8 @@ class FilesystemAdapterTest extends TestCase
         $this->assertEquals([], array_diff($actual, $expected), "There are more files in the actual array than in the expected list: \n" . implode("\n", array_diff($actual, $expected)));
     }
 
-    public function testListFilesInDirForRestoreWithImages()
+    public function testListFilesInDirForRestore()
     {
-        $configurationStorage = $this->container->getConfigurationStorage();
-        $configuration = $this->container->getUpdateConfiguration();
-        $configuration->merge([UpgradeConfiguration::PS_AUTOUP_KEEP_IMAGES => true]);
-        $configurationStorage->save($configuration);
-
-        $expected = $this->loadFixtureAndAddPrefixToFilePaths(
-            __DIR__ . '/../../fixtures/listOfFiles-restore-with-images.json',
-            self::$pathToFakeShop
-        );
-
-        $actual = $this->filesystemAdapter->listFilesInDir(
-            self::$pathToFakeShop,
-            'restore'
-        );
-        // TODO: Should try using assertEqualsCanonicalizing after upgrade of PHPUnit
-        $this->assertEquals([], array_diff($expected, $actual), "There are more files in the expected array than in the actual list: \n" . implode("\n", array_diff($expected, $actual)));
-        $this->assertEquals([], array_diff($actual, $expected), "There are more files in the actual array than in the expected list: \n" . implode("\n", array_diff($actual, $expected)));
-    }
-
-    public function testListFilesInDirForRestoreWithoutImages()
-    {
-        $configurationStorage = $this->container->getConfigurationStorage();
-        $configuration = $this->container->getUpdateConfiguration();
-        $configuration->merge([UpgradeConfiguration::PS_AUTOUP_KEEP_IMAGES => false]);
-        $configurationStorage->save($configuration);
-
         $expected = $this->loadFixtureAndAddPrefixToFilePaths(
             __DIR__ . '/../../fixtures/listOfFiles-restore-without-images.json',
             self::$pathToFakeShop


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | With https://github.com/PrestaShop/autoupgrade/pull/1117, configuration files are deleted after a process is completed, or restarted. This makes the configuration cleaned while another process relies on it. We discovered that in some cases, all the images can be deleted from a store when a backup is restored :exploding_head: 
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | <ul><li>Start a shop</li><li>Backup WITHOUT images</li><li>Complete a backup</li><li>Complete an update</li><li>Refresh the page or reach the Update Assistant homepage by clicking on the entry in the BO side menu</li><li>Restore the freshly created backup</li><li>The images should remain, but without this PR, they are missing.</li></ul>
