### PR TITLE
[NEW UI] Add update notification dialog

### DIFF
--- a/_dev/src/scss/appUpdateNotification/components/_dialog.scss
+++ b/_dev/src/scss/appUpdateNotification/components/_dialog.scss
@@ -36,8 +36,8 @@ $media-query-mobile: 992px;
     border-radius: var(--#{$ua-prefix}border-radius);
     box-shadow: var(--#{$ua-prefix}box-shadow-dialog);
     transition:
-            display var(--#{$ua-prefix}dialog-animation-duration) ease-out allow-discrete,
-            overlay var(--#{$ua-prefix}dialog-animation-duration) ease-out allow-discrete;
+      display var(--#{$ua-prefix}dialog-animation-duration) ease-out allow-discrete,
+      overlay var(--#{$ua-prefix}dialog-animation-duration) ease-out allow-discrete;
     animation: dialog-hide var(--#{$ua-prefix}dialog-animation-duration) ease-out forwards;
 
     &::backdrop {

--- a/_dev/src/scss/appUpdateNotification/components/_dialog.scss
+++ b/_dev/src/scss/appUpdateNotification/components/_dialog.scss
@@ -1,0 +1,192 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+@use "../../variables" as *;
+@use "../../mixins" as *;
+@use "../../fonts" as *;
+
+$notification-id: "#update_assistant_notification";
+$e: ".dialog-notification";
+$media-query-mobile: 992px;
+
+#{$notification-id} {
+  #{$e} {
+    --#{$ua-prefix}dialog-animation-duration: 0.25s;
+    --#{$ua-prefix}dialog-badge-background-color: var(--#{$ua-prefix}purple-500);
+    width: 30rem;
+    max-width: calc(100% - 2rem);
+    max-height: calc(100% - 2rem);
+    padding: 0;
+    border: none;
+    border-radius: var(--#{$ua-prefix}border-radius);
+    box-shadow: var(--#{$ua-prefix}box-shadow-dialog);
+    transition:
+            display var(--#{$ua-prefix}dialog-animation-duration) ease-out allow-discrete,
+            overlay var(--#{$ua-prefix}dialog-animation-duration) ease-out allow-discrete;
+    animation: dialog-hide var(--#{$ua-prefix}dialog-animation-duration) ease-out forwards;
+
+    &::backdrop {
+      background-color: rgb(0 0 0 / 0.6);
+      animation: backdrop-hide var(--#{$ua-prefix}dialog-animation-duration) ease-out forwards;
+    }
+
+    &[open] {
+      display: grid;
+      animation: dialog-show var(--#{$ua-prefix}dialog-animation-duration) ease-out forwards;
+
+      &::backdrop {
+        animation: backdrop-show var(--#{$ua-prefix}dialog-animation-duration) ease-out forwards;
+      }
+    }
+
+    &__content {
+      display: grid;
+      grid-template-columns: 1fr;
+      height: 100%;
+    }
+
+    &__left {
+      display: grid;
+      gap: 1rem;
+      align-content: center;
+      justify-items: start;
+      padding: 1.5rem 1.25rem;
+      background-color: var(--#{$ua-prefix}black);
+    }
+
+    &__right {
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+      align-content: center;
+      padding: 1rem;
+    }
+
+    &__badge {
+      padding: 0.1875rem 0.5rem;
+      background-color: var(--#{$ua-prefix}dialog-badge-background-color);
+      border-radius: 0.5rem;
+      font-size: 0.875rem;
+      font-weight: 600;
+      line-height: 1.25;
+    }
+
+    &__title {
+      font-family: var(--#{$ua-prefix}font-family-prestafont);
+      font-size: clamp(2rem, 1.75vw + 1.5rem, 2.875rem);
+      font-weight: 400;
+      line-height: 1.125;
+      color: var(--#{$ua-prefix}white);
+      text-wrap: balance;
+      word-break: break-word;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    &__informations {
+      display: flex;
+      flex-direction: column;
+      flex-grow: 1;
+      gap: 1rem;
+      justify-content: center;
+    }
+
+    &__section {
+      display: grid;
+      gap: 0.25rem;
+
+      &-title {
+        font-size: 0.75rem;
+        line-height: 1.5;
+        color: var(--#{$ua-prefix}primary-600);
+      }
+
+      &-content {
+        margin: 0;
+        font-size: 0.875rem;
+        line-height: 1.5;
+        color: var(--#{$ua-prefix}primary-700);
+      }
+    }
+
+    &__link {
+      color: var(--#{$ua-prefix}primary-700);
+      text-decoration: underline;
+      text-underline-offset: 0.125rem;
+      white-space: nowrap;
+      transition: text-underline-offset 0.15s;
+
+      &:hover {
+        color: var(--#{$ua-prefix}primary-800);
+        text-underline-offset: 0.25rem;
+      }
+
+      &:focus,
+      &:focus-visible {
+        outline-offset: 2px;
+      }
+    }
+
+    &__buttons {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 1rem;
+    }
+
+    &__button {
+      width: 100%;
+      text-transform: none;
+    }
+  }
+
+  &.v1-7-8-0,
+  &.v1-7-3-0 {
+    #{$e} {
+      --#{$ua-prefix}dialog-badge-background-color: var(--#{$ua-prefix}primary);
+    }
+  }
+
+  @media screen and (min-width: $media-query-mobile) {
+    #{$e} {
+      width: 58rem;
+      min-height: 33rem;
+
+      &__content {
+        grid-template-columns: 33rem 1fr;
+        height: 100%;
+      }
+
+      &__left {
+        padding: 1.25rem;
+      }
+
+      &__right {
+        gap: 1rem;
+        padding: 1.5rem;
+      }
+
+      &__title {
+        font-size: 3.375rem;
+      }
+
+      &__badge {
+        padding: 0.1875rem 1rem;
+        font-size: 1.125rem;
+      }
+    }
+  }
+}

--- a/_dev/src/scss/appUpdateNotification/components/_index.scss
+++ b/_dev/src/scss/appUpdateNotification/components/_index.scss
@@ -1,0 +1,19 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+@use "dialog";

--- a/_dev/src/scss/appUpdateNotification/main.scss
+++ b/_dev/src/scss/appUpdateNotification/main.scss
@@ -1,0 +1,19 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+@use "components";

--- a/_dev/src/ts/appUpdateNotification/api/baseApi.ts
+++ b/_dev/src/ts/appUpdateNotification/api/baseApi.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+import axios from 'axios';
+
+const baseApi = axios.create({
+  baseURL: `${window.AutoUpgradeVariables.admin_url}/index.php?controller=AdminAutoupgradeAjax`,
+  headers: {
+    'X-Requested-With': 'XMLHttpRequest'
+  },
+  params: {
+    ajax: 1,
+    token: window.AutoUpgradeVariables.token
+  }
+});
+
+export default baseApi;

--- a/_dev/src/ts/appUpdateNotification/dialogs/UpdateNotificationDialog.ts
+++ b/_dev/src/ts/appUpdateNotification/dialogs/UpdateNotificationDialog.ts
@@ -24,7 +24,7 @@ export default class UpdateNotificationDialog implements DomLifecycle {
   readonly #formDismissId = 'dismiss-update';
   readonly #formSubmitId = 'submit-update';
 
-  public mount() {
+  public mount(): void {
     this.#dialog.showModal();
 
     this.#dialog.addEventListener('close', this.#preventClose);

--- a/_dev/src/ts/appUpdateNotification/dialogs/UpdateNotificationDialog.ts
+++ b/_dev/src/ts/appUpdateNotification/dialogs/UpdateNotificationDialog.ts
@@ -47,13 +47,14 @@ export default class UpdateNotificationDialog implements DomLifecycle {
     return dialog;
   }
 
-  get #dismissForm(): HTMLFormElement {
-    const form = document.forms.namedItem(this.#formDismissId);
+  #getFormById(formId: string, requireDataset: string[] = ['action']): HTMLFormElement {
+    const form = document.forms.namedItem(formId);
+
     if (!form) {
       throw new Error('Form not found');
     }
 
-    ['action'].forEach((data) => {
+    requireDataset.forEach((data) => {
       if (!form.dataset[data]) {
         throw new Error(`Missing data ${data} from form dataset.`);
       }
@@ -62,19 +63,12 @@ export default class UpdateNotificationDialog implements DomLifecycle {
     return form;
   }
 
+  get #dismissForm(): HTMLFormElement {
+    return this.#getFormById(this.#formDismissId);
+  }
+
   get #submitForm(): HTMLFormElement {
-    const form = document.forms.namedItem(this.#formSubmitId);
-    if (!form) {
-      throw new Error('Form not found');
-    }
-
-    ['action'].forEach((data) => {
-      if (!form.dataset[data]) {
-        throw new Error(`Missing data ${data} from form dataset.`);
-      }
-    });
-
-    return form;
+    return this.#getFormById(this.#formSubmitId);
   }
 
   #sendForm = async (event: SubmitEvent): Promise<void> => {

--- a/_dev/src/ts/appUpdateNotification/dialogs/UpdateNotificationDialog.ts
+++ b/_dev/src/ts/appUpdateNotification/dialogs/UpdateNotificationDialog.ts
@@ -1,0 +1,108 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+import api from '../api/baseApi';
+import DomLifecycle from '../../types/DomLifecycle';
+
+export default class UpdateNotificationDialog implements DomLifecycle {
+  readonly #dialogId = 'dialog-update-notification';
+  readonly #formDismissId = 'dismiss-update';
+  readonly #formSubmitId = 'submit-update';
+
+  public mount() {
+    this.#dialog.showModal();
+
+    this.#dialog.addEventListener('close', this.#preventClose);
+    this.#dismissForm.addEventListener('submit', this.#sendForm);
+    this.#submitForm.addEventListener('submit', this.#sendForm);
+  }
+
+  public beforeDestroy(): void {
+    this.#dialog.removeEventListener('close', this.#preventClose);
+    this.#dismissForm.removeEventListener('submit', this.#sendForm);
+    this.#submitForm.removeEventListener('submit', this.#sendForm);
+  }
+
+  get #dialog(): HTMLDialogElement {
+    const dialog = document.getElementById(this.#dialogId);
+    if (!dialog || !(dialog instanceof HTMLDialogElement)) {
+      throw new Error('Dialog not found');
+    }
+
+    return dialog;
+  }
+
+  get #dismissForm(): HTMLFormElement {
+    const form = document.forms.namedItem(this.#formDismissId);
+    if (!form) {
+      throw new Error('Form not found');
+    }
+
+    ['action'].forEach((data) => {
+      if (!form.dataset[data]) {
+        throw new Error(`Missing data ${data} from form dataset.`);
+      }
+    });
+
+    return form;
+  }
+
+  get #submitForm(): HTMLFormElement {
+    const form = document.forms.namedItem(this.#formSubmitId);
+    if (!form) {
+      throw new Error('Form not found');
+    }
+
+    ['action'].forEach((data) => {
+      if (!form.dataset[data]) {
+        throw new Error(`Missing data ${data} from form dataset.`);
+      }
+    });
+
+    return form;
+  }
+
+  #sendForm = async (event: SubmitEvent): Promise<void> => {
+    event.preventDefault();
+
+    const form = event.target as HTMLFormElement;
+    const submitButton = event.submitter as HTMLElement;
+
+    if (submitButton.dataset.dismiss === 'dialog') {
+      this.#dialog.close();
+    }
+
+    try {
+      const response = await api.post('', null, {
+        params: { action: form.dataset.action }
+      });
+
+      if (response.data.url_to_redirect) {
+        window.location = response.data.url_to_redirect;
+      }
+
+      this.beforeDestroy();
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  #preventClose = (event: Event): void => {
+    event.preventDefault();
+  };
+}

--- a/_dev/src/ts/appUpdateNotification/main.ts
+++ b/_dev/src/ts/appUpdateNotification/main.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+import UpdateNotificationDialog from './dialogs/UpdateNotificationDialog';
+
+const updateNotificationDialog = new UpdateNotificationDialog();
+updateNotificationDialog.mount();

--- a/_dev/vite.config.ts
+++ b/_dev/vite.config.ts
@@ -67,14 +67,19 @@ export default defineConfig({
     rollupOptions: {
       input: {
         app_ui_script: './src/ts/appUI/main.ts',
-        app_ui_theme: './src/scss/appUI/main.scss'
+        app_update_notification_script: './src/ts/appUpdateNotification/main.ts',
+        app_ui_theme: './src/scss/appUI/main.scss',
+        app_update_notification_theme: './src/scss/appUpdateNotification/main.scss'
       },
       output: {
         dir: resolve(__dirname, '../views/'),
         entryFileNames: (chunkInfo) => {
           if (chunkInfo.name === 'app_ui_script') {
             return `js/autoupgrade.js`;
+          } else if (chunkInfo.name === 'app_update_notification_script') {
+            return 'js/autoupgrade-notification.js';
           }
+
           return 'js/[name].js';
         },
         manualChunks: segmentIdsToChunks,
@@ -83,9 +88,14 @@ export default defineConfig({
 
           if (assetName === 'app_ui_theme.css') {
             return 'css/autoupgrade.css';
-          } else if (/\.(webp|png|jpe?g|gif|svg)$/.test(assetName)) {
+          } else if (assetName === 'app_update_notification_theme.css') {
+            return 'css/autoupgrade-notification.css';
+          }
+
+          if (/\.(webp|png|jpe?g|gif|svg)$/.test(assetName)) {
             return 'img/[name].[extname]';
           }
+
           return 'assets/[name].[extname]';
         }
       }

--- a/autoupgrade.php
+++ b/autoupgrade.php
@@ -77,9 +77,10 @@ class Autoupgrade extends Module
         }
 
         // If the "AdminSelfUpgrade" tab does not exist yet, create it
-        if (!Tab::getIdFromClassName('AdminSelfUpgrade')) {
+        $moduleTabName = 'AdminSelfUpgrade';
+        if (!Tab::getIdFromClassName($moduleTabName)) {
             $tab = new Tab();
-            $tab->class_name = 'AdminSelfUpgrade';
+            $tab->class_name = $moduleTabName;
             $tab->icon = 'arrow_upward';
             $tab->module = 'autoupgrade';
 
@@ -90,13 +91,14 @@ class Autoupgrade extends Module
                 $tab->name[(int) $lang['id_lang']] = 'Update assistant';
             }
             if (!$tab->save()) {
-                return $this->_abortInstall($this->trans('Unable to create the "AdminSelfUpgrade" tab'));
+                return $this->_abortInstall($this->trans('Unable to create the %s tab', [$moduleTabName]));
             }
         }
 
-        if (!Tab::getIdFromClassName('AdminAutoupgradeAjax')) {
+        $ajaxTabName = 'AdminAutoupgradeAjax';
+        if (!Tab::getIdFromClassName($ajaxTabName)) {
             $ajaxTab = new Tab();
-            $ajaxTab->class_name = 'AdminAutoupgradeAjax';
+            $ajaxTab->class_name = $ajaxTabName;
             $ajaxTab->module = 'autoupgrade';
             $ajaxTab->id_parent = -1;
 
@@ -104,7 +106,7 @@ class Autoupgrade extends Module
                 $ajaxTab->name[(int) $lang['id_lang']] = 'Update assistant';
             }
             if (!$ajaxTab->save()) {
-                return $this->_abortInstall($this->trans('Unable to create the "AdminAutoupgradeAjax" tab'));
+                return $this->_abortInstall($this->trans('Unable to create the %s tab', [$ajaxTabName]));
             }
         }
 
@@ -229,12 +231,12 @@ class Autoupgrade extends Module
      */
     public function initAutoloaderIfCompliant()
     {
-        require_once _PS_ROOT_DIR_ . '/modules/autoupgrade/classes/VersionUtils.php';
+        require_once _PS_ROOT_DIR_ . DIRECTORY_SEPARATOR.  'modules'  . DIRECTORY_SEPARATOR .  'autoupgrade' . DIRECTORY_SEPARATOR . 'classes'  . DIRECTORY_SEPARATOR . 'VersionUtils.php';
         if (!\PrestaShop\Module\AutoUpgrade\VersionUtils::isActualPHPVersionCompatible()) {
             return false;
         }
 
-        $autoloadPath = __DIR__ . '/vendor/autoload.php';
+        $autoloadPath = __DIR__ . DIRECTORY_SEPARATOR .'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
         if (file_exists($autoloadPath)) {
             require_once $autoloadPath;
         }

--- a/autoupgrade.php
+++ b/autoupgrade.php
@@ -25,6 +25,11 @@ class Autoupgrade extends Module
      */
     public $multishop_context;
 
+    /**
+     * @var \PrestaShop\Module\AutoUpgrade\UpgradeContainer
+     */
+    protected $container;
+
     public function __construct()
     {
         $this->name = 'autoupgrade';
@@ -89,7 +94,21 @@ class Autoupgrade extends Module
             }
         }
 
-        return parent::install();
+        if (!Tab::getIdFromClassName('AdminAutoupgradeAjax')) {
+            $ajaxTab = new Tab();
+            $ajaxTab->class_name = 'AdminAutoupgradeAjax';
+            $ajaxTab->module = 'autoupgrade';
+            $ajaxTab->id_parent = -1;
+
+            foreach (Language::getLanguages(false) as $lang) {
+                $ajaxTab->name[(int) $lang['id_lang']] = 'Update assistant';
+            }
+            if (!$ajaxTab->save()) {
+                return $this->_abortInstall($this->trans('Unable to create the "AdminAutoupgradeAjax" tab'));
+            }
+        }
+
+        return parent::install() && $this->registerHook('displayBackOfficeHeader');
     }
 
     /**
@@ -97,11 +116,17 @@ class Autoupgrade extends Module
      */
     public function uninstall()
     {
-        // Delete the 1-click upgrade Back-office tab
+        // Delete the module Back-office tab
         $id_tab = Tab::getIdFromClassName('AdminSelfUpgrade');
         if ($id_tab) {
             $tab = new Tab((int) $id_tab);
             $tab->delete();
+        }
+
+        $id_ajax_tab = Tab::getIdFromClassName('AdminAutoupgradeAjax');
+        if ($id_ajax_tab) {
+            $ajaxTab = new Tab((int) $id_ajax_tab);
+            $ajaxTab->delete();
         }
 
         // Remove the 1-click upgrade working directory
@@ -176,5 +201,56 @@ class Autoupgrade extends Module
         );
 
         return $translator->trans($id, $parameters);
+    }
+
+    /**
+     * Hook called after the backoffice content is rendered.
+     * Used to display the update notification dialog.
+     *
+     * @return string
+     *
+     * @throws \PrestaShop\Module\AutoUpgrade\Exceptions\DistributionApiException
+     * @throws \PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException
+     * @throws \Twig\Error\LoaderError
+     * @throws \Twig\Error\RuntimeError
+     * @throws \Twig\Error\SyntaxError
+     */
+    public function hookDisplayBackOfficeHeader()
+    {
+        if (!$this->initAutoloaderIfCompliant()) {
+            return '';
+        }
+
+        return (new \PrestaShop\Module\AutoUpgrade\Hooks\DisplayBackOfficeHeader($this->getUpgradeContainer()))->renderUpdateNotification();
+    }
+
+    /**
+     * @return bool
+     */
+    public function initAutoloaderIfCompliant()
+    {
+        require_once _PS_ROOT_DIR_ . '/modules/autoupgrade/classes/VersionUtils.php';
+        if (!\PrestaShop\Module\AutoUpgrade\VersionUtils::isActualPHPVersionCompatible()) {
+            return false;
+        }
+
+        $autoloadPath = __DIR__ . '/vendor/autoload.php';
+        if (file_exists($autoloadPath)) {
+            require_once $autoloadPath;
+        }
+
+        return true;
+    }
+
+    /**
+     * @return \PrestaShop\Module\AutoUpgrade\UpgradeContainer
+     */
+    public function getUpgradeContainer()
+    {
+        if (null === $this->container) {
+            $this->container = new \PrestaShop\Module\AutoUpgrade\UpgradeContainer(_PS_ROOT_DIR_, realpath(_PS_ADMIN_DIR_));
+        }
+
+        return $this->container;
     }
 }

--- a/autoupgrade.php
+++ b/autoupgrade.php
@@ -231,12 +231,12 @@ class Autoupgrade extends Module
      */
     public function initAutoloaderIfCompliant()
     {
-        require_once _PS_ROOT_DIR_ . DIRECTORY_SEPARATOR.  'modules'  . DIRECTORY_SEPARATOR .  'autoupgrade' . DIRECTORY_SEPARATOR . 'classes'  . DIRECTORY_SEPARATOR . 'VersionUtils.php';
+        require_once _PS_ROOT_DIR_ . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR . 'autoupgrade' . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR . 'VersionUtils.php';
         if (!\PrestaShop\Module\AutoUpgrade\VersionUtils::isActualPHPVersionCompatible()) {
             return false;
         }
 
-        $autoloadPath = __DIR__ . DIRECTORY_SEPARATOR .'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
+        $autoloadPath = __DIR__ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
         if (file_exists($autoloadPath)) {
             require_once $autoloadPath;
         }

--- a/classes/DocumentationLinks.php
+++ b/classes/DocumentationLinks.php
@@ -31,4 +31,5 @@ class DocumentationLinks
     public const DEV_DOC_UPGRADE_POST_RESTORE_URL = self:: DEV_DOC_UPGRADE_URL . '/post-restore-checklist';
     public const PRESTASHOP_PROJECT_URL = 'https://www.prestashop-project.org';
     public const PRESTASHOP_PROJECT_DATA_TRANSPARENCY_URL = self::PRESTASHOP_PROJECT_URL . '/data-transparency';
+    public const PRESTASHOP_EXPERTS = 'https://experts.prestashop.com/english/experts/';
 }

--- a/classes/Hooks/DisplayBackOfficeHeader.php
+++ b/classes/Hooks/DisplayBackOfficeHeader.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\AutoUpgrade\Hooks;
+
+use Context;
+use Employee;
+use Exception;
+use PrestaShop\Module\AutoUpgrade\DocumentationLinks;
+use PrestaShop\Module\AutoUpgrade\Exceptions\DistributionApiException;
+use PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException;
+use PrestaShop\Module\AutoUpgrade\Models\UpdateNotificationConfiguration;
+use PrestaShop\Module\AutoUpgrade\Services\UpdateNotificationService;
+use PrestaShop\Module\AutoUpgrade\Twig\PageSelectors;
+use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
+use PrestaShop\Module\AutoUpgrade\Upgrader;
+use PrestaShop\Module\AutoUpgrade\VersionUtils;
+use Symfony\Component\HttpFoundation\Request;
+use Tab;
+use Tools;
+use Twig\Error\LoaderError;
+use Twig\Error\RuntimeError;
+use Twig\Error\SyntaxError;
+
+class DisplayBackOfficeHeader
+{
+    const INTERVAL_CHECK_TIME_IN_SECONDS = 2592000; // 30 days
+
+    /**
+     * @var UpgradeContainer
+     */
+    private $container;
+
+    /**
+     * @var Upgrader
+     */
+    private $upgrader;
+
+    /**
+     * @var UpdateNotificationService
+     */
+    private $updateNotificationService;
+
+    /**
+     * @var UpdateNotificationConfiguration
+     */
+    private $updateNotificationConfiguration;
+
+    /**
+     * @var string
+     */
+    private $content = '';
+
+    /**
+     * @var string
+     */
+    private $psVersion;
+
+    /**
+     * @var Context
+     */
+    private $context;
+
+    /**
+     * @var int
+     */
+    private $employeeId;
+
+    /**
+     * @throws Exception
+     */
+    public function __construct(UpgradeContainer $container)
+    {
+        $this->container = $container;
+        $this->upgrader = $this->container->getUpgrader();
+        $this->updateNotificationService = $this->container->getUpdateNotificationService();
+        $this->updateNotificationConfiguration = $this->updateNotificationService->getUpdateNotificationConfiguration();
+        $this->psVersion = $this->container->getProperty(UpgradeContainer::PS_VERSION);
+        $this->context = Context::getContext();
+        $this->employeeId = $this->context->employee->id;
+    }
+
+    /**
+     * @return string
+     *
+     * @throws DistributionApiException
+     * @throws UpgradeException
+     * @throws LoaderError
+     * @throws RuntimeError
+     * @throws SyntaxError
+     */
+    public function renderUpdateNotification(): string
+    {
+        if (
+            !$this->updateNotificationConfiguration->getTimestamp()
+            || (time() - $this->updateNotificationConfiguration->getTimestamp()) > self::INTERVAL_CHECK_TIME_IN_SECONDS
+        ) {
+            $this->checkNewerVersion();
+        }
+
+        $this->addScriptsVariables();
+
+        $request = Request::createFromGlobals();
+        $this->addUIAssets($request);
+
+        if (!$this->isEmployeeDefaultController()) {
+            return $this->content;
+        }
+
+        $employees = $this->updateNotificationConfiguration->getEmployees();
+
+        $employeeExists = array_filter($employees, function ($employee) {
+            return $employee['employeeID'] === $this->employeeId;
+        });
+
+        if ((empty($employeeExists) || time() > $employeeExists[0]['timestamp']) && $this->updateIsAvailable()) {
+            $this->content .= $this->container->getTwig()->render('@ModuleAutoUpgrade/hooks/external-layout.html.twig', $this->getParams());
+        }
+        return $this->content;
+    }
+
+    /**
+     * @throws LoaderError
+     * @throws RuntimeError
+     * @throws SyntaxError
+     */
+    private function addScriptsVariables(): void
+    {
+        $adminDir = trim(str_replace(_PS_ROOT_DIR_, '', realpath(_PS_ADMIN_DIR_)), DIRECTORY_SEPARATOR);
+
+        $scriptsVariables = [
+            'token' => Tools::getAdminTokenLite('AdminAutoupgradeAjax'),
+            'admin_url' => __PS_BASE_URI__ . $adminDir,
+            'admin_dir' => $adminDir,
+        ];
+
+        $this->content .= $this->container->getTwig()->render('@ModuleAutoUpgrade/module-script-variables.html.twig', [
+            'autoupgrade_variables' => $scriptsVariables,
+        ]);
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @throws LoaderError
+     * @throws RuntimeError
+     * @throws SyntaxError
+     */
+    private function addUIAssets(Request $request): void
+    {
+        $assetsEnvironment = $this->container->getAssetsEnvironment();
+        $assetsBaseUrl = $assetsEnvironment->getAssetsBaseUrl($request);
+        $twig = $this->container->getTwig();
+
+        if ($assetsEnvironment->isDevMode()) {
+            $this->context->controller->addCSS($assetsBaseUrl . '/src/scss/appUpdateNotification/main.scss');
+            $this->content .= $twig->render('@ModuleAutoUpgrade/module-script-tag.html.twig', ['module_type' => true, 'src' => $assetsBaseUrl . '/src/ts/appUpdateNotification/main.ts']);
+        } else {
+            $this->context->controller->addCSS($assetsBaseUrl . '/css/autoupgrade-notification.css');
+            $this->content .= $twig->render('@ModuleAutoUpgrade/module-script-tag.html.twig', ['module_type' => true, 'src' => $assetsBaseUrl . '/js/autoupgrade-notification.js?version=' . $this->psVersion]);
+        }
+    }
+
+    private function isEmployeeDefaultController(): bool
+    {
+        $controller = Tools::getValue('controller');
+        $employee = new Employee($this->employeeId);
+        $default_tab_id = $employee->default_tab;
+
+        $tab = new Tab($default_tab_id);
+        $default_controller = $tab->class_name;
+
+        return $controller === $default_controller;
+    }
+
+    /**
+     * @throws DistributionApiException
+     * @throws UpgradeException
+     */
+    private function checkNewerVersion(): void
+    {
+        $this->updateNotificationConfiguration->setTimestamp(time());
+
+        if ($this->upgrader->isNewerVersionAvailableOnline()) {
+            $onlineDestination = $this->upgrader->getOnlineDestinationRelease();
+
+            $onlineVersion = $onlineDestination->getVersion();
+            $this->updateNotificationConfiguration->setVersion($onlineVersion);
+
+            $releaseNote = $onlineDestination->getReleaseNoteUrl();
+            $this->updateNotificationConfiguration->setReleaseNote($releaseNote);
+        }
+
+        $this->updateNotificationService->saveUpdateNotificationConfiguration($this->updateNotificationConfiguration);
+    }
+
+    private function updateIsAvailable(): bool
+    {
+        return !empty($this->updateNotificationConfiguration->getVersion()) && version_compare($this->updateNotificationConfiguration->getVersion(), $this->psVersion, '>');
+    }
+
+    /**
+     * @return array<string, mixed>
+     *
+     * @throws UpgradeException
+     */
+    private function getParams(): array
+    {
+        $psClass = '';
+
+        if (version_compare($this->psVersion, '1.7.8.0', '<')) {
+            $psClass = 'v1-7-3-0';
+        } elseif (version_compare($this->psVersion, '9.0.0', '<')) {
+            $psClass = 'v1-7-8-0';
+        }
+
+        $onlineVersion = $this->updateNotificationConfiguration->getVersion();
+
+        $updateType = VersionUtils::getUpdateType($this->psVersion, $onlineVersion);
+
+        return [
+            'external_parent_id' => PageSelectors::NOTIFICATION_PARENT_ID,
+            'component' => 'dialog-update-notification',
+            'version_class' => $psClass,
+            'version_type' => $updateType,
+            'version' => $onlineVersion,
+            'contact_expert_url' => DocumentationLinks::PRESTASHOP_EXPERTS,
+            'release_note' => $this->updateNotificationConfiguration->getReleaseNote(),
+        ];
+    }
+}

--- a/classes/Hooks/DisplayBackOfficeHeader.php
+++ b/classes/Hooks/DisplayBackOfficeHeader.php
@@ -79,9 +79,9 @@ class DisplayBackOfficeHeader
     private $context;
 
     /**
-     * @var int
+     * @var Employee
      */
-    private $employeeId;
+    private $employee;
 
     /**
      * @throws Exception
@@ -94,7 +94,7 @@ class DisplayBackOfficeHeader
         $this->updateNotificationConfiguration = $this->updateNotificationService->getUpdateNotificationConfiguration();
         $this->psVersion = $this->container->getProperty(UpgradeContainer::PS_VERSION);
         $this->context = Context::getContext();
-        $this->employeeId = $this->context->employee->id;
+        $this->employee = $this->context->employee;
     }
 
     /**
@@ -127,7 +127,7 @@ class DisplayBackOfficeHeader
         $employees = $this->updateNotificationConfiguration->getEmployees();
 
         $employeeExists = array_filter($employees, function ($employee) {
-            return $employee['employeeID'] === $this->employeeId;
+            return $employee['employeeID'] === $this->employee->id;
         });
 
         if ((empty($employeeExists) || time() > $employeeExists[0]['timestamp']) && $this->updateIsAvailable()) {
@@ -182,7 +182,7 @@ class DisplayBackOfficeHeader
     private function isEmployeeDefaultController(): bool
     {
         $controller = Tools::getValue('controller');
-        $employee = new Employee($this->employeeId);
+        $employee = $this->employee;
         $default_tab_id = $employee->default_tab;
 
         $tab = new Tab($default_tab_id);

--- a/classes/Hooks/DisplayBackOfficeHeader.php
+++ b/classes/Hooks/DisplayBackOfficeHeader.php
@@ -133,6 +133,7 @@ class DisplayBackOfficeHeader
         if ((empty($employeeExists) || time() > $employeeExists[0]['timestamp']) && $this->updateIsAvailable()) {
             $this->content .= $this->container->getTwig()->render('@ModuleAutoUpgrade/hooks/external-layout.html.twig', $this->getParams());
         }
+
         return $this->content;
     }
 

--- a/classes/Models/UpdateNotificationConfiguration.php
+++ b/classes/Models/UpdateNotificationConfiguration.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\AutoUpgrade\Models;
+
+class UpdateNotificationConfiguration
+{
+    /**
+     * @var int|null
+     */
+    private $timestamp = null;
+
+    /**
+     * @var string|null
+     */
+    private $version = null;
+
+    /**
+     * @var string|null
+     */
+    private $releaseNote = null;
+
+    /**
+     * @var array<array{employeeID: int, timestamp: int}>
+     */
+    private $employees = [];
+
+    /**
+     * @param array{lastCheck: array{timestamp: int|null, version: string|null, releaseNote: string|null}, employees: array<array{employeeID: int, timestamp: int}>}|null $configuration
+     */
+    public function __construct(array $configuration = null)
+    {
+        if ($configuration) {
+            $lastCheck = $configuration['lastCheck'];
+
+            if (isset($lastCheck['timestamp'])) {
+                $this->timestamp = $lastCheck['timestamp'];
+            }
+
+            if (isset($lastCheck['version'])) {
+                $this->version = $lastCheck['version'];
+            }
+
+            if (isset($lastCheck['releaseNote'])) {
+                $this->releaseNote = $lastCheck['releaseNote'];
+            }
+
+            $this->employees = $configuration['employees'];
+        }
+    }
+
+    public function setTimestamp(int $timestamp): void
+    {
+        $this->timestamp = $timestamp;
+    }
+
+    public function getTimestamp(): ?int
+    {
+        return $this->timestamp;
+    }
+
+    public function setVersion(string $version): void
+    {
+        $this->version = $version;
+    }
+
+    public function getVersion(): ?string
+    {
+        return $this->version;
+    }
+
+    public function setReleaseNote(string $releaseNote): void
+    {
+        $this->releaseNote = $releaseNote;
+    }
+
+    public function getReleaseNote(): ?string
+    {
+        return $this->releaseNote;
+    }
+
+    public function addEmployee(int $employeeId, int $timestamp): void
+    {
+        foreach ($this->employees as &$employee) {
+            if ($employee['employeeID'] === $employeeId) {
+                $employee['timestamp'] = $timestamp;
+
+                return;
+            }
+        }
+
+        $this->employees[] = [
+            'employeeID' => $employeeId,
+            'timestamp' => $timestamp,
+        ];
+    }
+
+    /**
+     * @return array<array{employeeID: int, timestamp: int}>
+     */
+    public function getEmployees(): array
+    {
+        return $this->employees;
+    }
+
+    public function toJson(): string
+    {
+        return json_encode([
+            'lastCheck' => [
+                'timestamp' => $this->getTimestamp(),
+                'version' => $this->getVersion(),
+                'releaseNote' => $this->getReleaseNote(),
+            ],
+            'employees' => $this->getEmployees(),
+        ]);
+    }
+}

--- a/classes/Services/UpdateNotificationService.php
+++ b/classes/Services/UpdateNotificationService.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\AutoUpgrade\Services;
+
+use Configuration;
+use PrestaShop\Module\AutoUpgrade\Models\UpdateNotificationConfiguration;
+
+class UpdateNotificationService
+{
+    const CONFIG_KEY = 'PS_AUTOUPGRADE_LAST_CHECK';
+
+    public function getUpdateNotificationConfiguration(): UpdateNotificationConfiguration
+    {
+        return new UpdateNotificationConfiguration(json_decode(Configuration::get(self::CONFIG_KEY), true));
+    }
+
+    public function saveUpdateNotificationConfiguration(UpdateNotificationConfiguration $configuration): void
+    {
+        Configuration::updateValue(self::CONFIG_KEY, $configuration->toJson());
+    }
+}

--- a/classes/Twig/PageSelectors.php
+++ b/classes/Twig/PageSelectors.php
@@ -30,6 +30,7 @@ class PageSelectors
     public const RADIO_CARD_ONLINE_PARENT_ID = 'radio_card_online';
     public const RADIO_CARD_ARCHIVE_PARENT_ID = 'radio_card_archive';
     public const DOWNLOAD_LOGS_PARENT_ID = 'download_logs';
+    public const NOTIFICATION_PARENT_ID = 'update_assistant_notification';
 
     /**
      * @return array<string, string>

--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -44,6 +44,7 @@ use PrestaShop\Module\AutoUpgrade\Services\DownloadService;
 use PrestaShop\Module\AutoUpgrade\Services\LogsService;
 use PrestaShop\Module\AutoUpgrade\Services\PhpVersionResolverService;
 use PrestaShop\Module\AutoUpgrade\Services\PrestashopVersionService;
+use PrestaShop\Module\AutoUpgrade\Services\UpdateNotificationService;
 use PrestaShop\Module\AutoUpgrade\State\AbstractState;
 use PrestaShop\Module\AutoUpgrade\State\BackupState;
 use PrestaShop\Module\AutoUpgrade\State\LogsState;
@@ -217,6 +218,9 @@ class UpgradeContainer
 
     /** @var UpgradeSelfCheck */
     private $upgradeSelfCheck;
+
+    /** @var UpdateNotificationService */
+    private $updateNotificationService;
 
     /** @var PhpVersionResolverService */
     private $phpVersionResolverService;
@@ -787,6 +791,15 @@ class UpgradeContainer
         }
 
         return $this->restoreConfiguration;
+    }
+
+    public function getUpdateNotificationService(): UpdateNotificationService
+    {
+        if (null === $this->updateNotificationService) {
+            $this->updateNotificationService = new UpdateNotificationService();
+        }
+
+        return $this->updateNotificationService;
     }
 
     public function getLanguageConfiguration(): LanguageConfiguration

--- a/controllers/admin/AdminAutoupgradeAjaxController.php
+++ b/controllers/admin/AdminAutoupgradeAjaxController.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+use PrestaShop\Module\AutoUpgrade\Hooks\DisplayBackOfficeHeader;
+use PrestaShop\Module\AutoUpgrade\Router\Routes;
+use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class AdminAutoupgradeAjaxController extends ModuleAdminController
+{
+    /** @var Autoupgrade */
+    public $module;
+
+    /** @var bool */
+    private $isActualPHPVersionCompatible = true;
+
+    /**
+     * @var UpgradeContainer
+     */
+    private $upgradeContainer;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        if (!$this->module->initAutoloaderIfCompliant()) {
+            $this->isActualPHPVersionCompatible = false;
+
+            return;
+        }
+
+        $this->upgradeContainer = $this->module->getUpgradeContainer();
+    }
+
+    public function postProcess()
+    {
+        if (!$this->isActualPHPVersionCompatible) {
+            return false;
+        }
+
+        $action = Tools::getValue('action');
+        $currentEmployeeId = \Context::getContext()->employee->id;
+
+        $updateNotificationService = $this->upgradeContainer->getUpdateNotificationService();
+        $updateNotificationConfiguration = $updateNotificationService->getUpdateNotificationConfiguration();
+        $updateNotificationConfiguration->addEmployee($currentEmployeeId, time() + DisplayBackOfficeHeader::INTERVAL_CHECK_TIME_IN_SECONDS);
+
+        $updateNotificationService->saveUpdateNotificationConfiguration($updateNotificationConfiguration);
+
+        if ($action === 'submit-update') {
+            (new JsonResponse([
+                'url_to_redirect' => $this->context->link->getAdminLink('AdminSelfUpgrade', true, [], ['route' => Routes::UPDATE_PAGE_VERSION_CHOICE]),
+            ]))->send();
+            exit;
+        }
+
+        return true;
+    }
+}

--- a/storybook/.storybook/preview.ts
+++ b/storybook/.storybook/preview.ts
@@ -27,6 +27,7 @@ import { Preview, twig } from "@sensiolabs/storybook-symfony-webpack5";
 import "../../_dev/src/scss/appUI/main.scss";
 import "../../_dev/tests/fakeWindow";
 import "../../_dev/src/ts/appUI/main";
+import '../../_dev/src/scss/appUpdateNotification/main.scss'
 
 const cssEntrypoints = {
   "9.0.0": ["/9.0.0/default/theme.css"],
@@ -41,6 +42,7 @@ const preview: Preview = {
     backgrounds: {
       disable: true,
     },
+    storyContext: 'MODULE_UI' as 'MODULE_UI' | 'STANDALONE',
     options: {
       storySort: (a, b) =>
         a.id === b.id
@@ -89,7 +91,14 @@ const preview: Preview = {
       const selectedThemeClass = `v${selectedTheme.replace(/\./g, "-")}`;
 
       const calledStory = story();
-      calledStory.template = twig(`
+      calledStory.template = context.parameters.storyContext === 'STANDALONE' ? twig(`
+        <div id="main">
+          <div id="update_assistant_notification" class="${selectedThemeClass}">
+            ${calledStory.template.getSource()}
+            ${cssContents.map((cssFile) => `<link rel="stylesheet" type="text/css" href="${cssFile}" />`)}
+          </div>
+        </div>
+      `) : twig(`
         <div id="main">
           <div id="content" class="bootstrap update-assistant">
             <div id="update_assistant" class="${selectedThemeClass}">

--- a/storybook/stories/hooks/hookDisplayBackOfficeHeader/DialogUpdateNotification.stories.js
+++ b/storybook/stories/hooks/hookDisplayBackOfficeHeader/DialogUpdateNotification.stories.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+import DialogUpdateNotification from "../../../../views/templates/hooks/dialog-update-notification.html.twig";
+
+export default {
+    component: DialogUpdateNotification,
+    title: "Hooks/hookDisplayBackOfficeHeader/Dialog update notification",
+    parameters: {
+        storyContext: 'STANDALONE',
+    },
+    argTypes: {
+        version_type: {
+            control: 'select' ,
+            options: ['major', 'minor', 'patch'],
+        },
+    },
+    args: {
+        'version_type': 'major',
+        'version': '9.0.0',
+        'contact_expert_url': 'https://experts.prestashop.com/english/experts/',
+        'update_link': '#',
+        'release_note': '#',
+    },
+    play: async () => {
+        const dialog = document.getElementById('dialog-update-notification');
+        if (dialog) {
+            dialog.showModal();
+        }
+    },
+};
+
+export const Major = {
+    args: {
+        'version_type': 'major',
+    }
+};
+
+export const Minor = {
+    args: {
+        'version_type': 'minor',
+    }
+};
+
+export const Patch = {
+    args: {
+        'version_type': 'patch',
+    }
+};

--- a/upgrade/upgrade-7.1.0.php
+++ b/upgrade/upgrade-7.1.0.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * Manually remove the dashboardZoneOne hook.
+ *
+ * @return bool
+ */
+function upgrade_module_7_1_0($module)
+{
+    // Create the 'AdminAutoupgradeAjax' tab configuration
+    if (!\Tab::getIdFromClassName('AdminAutoupgradeAjax')) {
+        $ajaxTab = new \Tab();
+        $ajaxTab->class_name = 'AdminAutoupgradeAjax';
+        $ajaxTab->module = 'autoupgrade';
+        $ajaxTab->id_parent = -1;
+
+        foreach (Language::getLanguages(false) as $lang) {
+            $ajaxTab->name[(int) $lang['id_lang']] = 'Update assistant';
+        }
+        if (!$ajaxTab->save()) {
+            return false;
+        }
+    }
+
+    $module->registerHook('displayBackOfficeHeader');
+
+    return true;
+}

--- a/upgrade/upgrade-7.1.0.php
+++ b/upgrade/upgrade-7.1.0.php
@@ -22,8 +22,6 @@ if (!defined('_PS_VERSION_')) {
 }
 
 /**
- * Manually remove the dashboardZoneOne hook.
- *
  * @return bool
  */
 function upgrade_module_7_1_0($module)

--- a/views/templates/hooks/dialog-update-notification.html.twig
+++ b/views/templates/hooks/dialog-update-notification.html.twig
@@ -1,0 +1,108 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ *#}
+<dialog class="bootstrap dialog-notification" id="dialog-update-notification" aria-label="{{ 'Update notification' }}">
+  <div class="dialog-notification__content">
+    <div class="dialog-notification__left">
+      <span class="dialog-notification__badge">
+        {% if version_type == 'patch' %}
+          {{ 'New available Patch'|trans({}) }}
+        {% elseif version_type == 'minor' %}
+          {{ 'New available Minor'|trans({}) }}
+        {% elseif version_type == 'major' %}
+          {{ 'New available Major'|trans({}) }}
+        {% endif %}
+      </span>
+
+      <span class="dialog-notification__title">
+        {{ 'New features are available'|trans({}) }}
+      </span>
+    </div>
+
+    <div class="dialog-notification__right">
+      <div class="dialog-notification__informations">
+        <div class="dialog-notification__section">
+          <span class="dialog-notification__section-title">
+            {{ 'Description'|trans({}) }}
+          </span>
+
+          <p class="dialog-notification__section-content">
+            {% if version_type == 'patch' %}
+              {{ 'Patches are fixes made between major and minor versions. They introduce security and bug fixes.'|trans({}) }}
+            {% elseif version_type == 'minor' %}
+              {{ 'The minor releases introduce new backward-compatible features, security improvements and bug fixes.'|trans({}) }}
+            {% elseif version_type == 'major' %}
+              {{ 'Major releases introduce new features that may break backward compatibility, as well as new backward-compatible features and bug fixes.'|trans({}) }}
+            {% endif %}
+            <a class="dialog-notification__link" href="{{ release_note }}" target="_blank">{{ 'See the update'|trans({}) }}</a>
+          </p>
+        </div>
+
+        <div class="dialog-notification__section">
+          <span class="dialog-notification__section-title">
+            {{ 'Version'|trans({}) }}
+          </span>
+
+          <p class="dialog-notification__section-content">
+            {{ version }}
+          </p>
+        </div>
+
+        <div class="dialog-notification__section">
+          <span class="dialog-notification__section-title">
+            {{ 'Type of improvements'|trans({}) }}
+          </span>
+
+          <p class="dialog-notification__section-content">
+            {% if version_type == 'patch' %}
+              {{ 'Bugs, security patches'|trans({}) }}
+            {% elseif version_type == 'minor' %}
+              {{ 'Bugs, security patches, new features'|trans({}) }}
+            {% elseif version_type == 'major' %}
+              {{ 'New features, Improvements to existing features, Security and bug fixes'|trans({}) }}
+            {% endif %}
+          </p>
+        </div>
+
+        <div class="dialog-notification__section">
+          <span class="dialog-notification__section-title">
+            {{ 'Need help?'|trans({}) }}
+          </span>
+
+          <p class="dialog-notification__section-content">
+            {{ 'If you\'re having trouble performing the update, our experts can help!'|trans({}) }}
+            <a class="dialog-notification__link" href="{{ contact_expert_url }}" target="_blank">{{ 'Contact an expert'|trans({}) }}</a>
+          </p>
+        </div>
+      </div>
+
+      <div class="dialog-notification__buttons">
+        <form id="dismiss-update" name="dismiss-update" action="" data-action="dismiss-update">
+          <button type="submit" class="dialog-notification__button btn btn-default"  data-dismiss="dialog">
+            {{ 'Later'|trans({}) }}
+          </button>
+        </form>
+        <form id="submit-update" name="submit-update" action="" data-action="submit-update">
+          <button type="submit" class="dialog-notification__button btn btn-primary" autofocus>
+            {{ 'Update'|trans({}) }}
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+</dialog>

--- a/views/templates/hooks/external-layout.html.twig
+++ b/views/templates/hooks/external-layout.html.twig
@@ -1,0 +1,21 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ *#}
+<div id="{{ external_parent_id }}" class="{{ version_class }}">
+  {% include "@ModuleAutoUpgrade/hooks/" ~ component ~ ".html.twig" %}
+</div>


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add update notification dialog to inform the user about the possibility of an update. The modal only appears on the user's default page. We only check for updates once every 30 days. Once the modal is closed, it does not reappear for 30 days (unless the user exits it with the Esc key)
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | @PrestaShopCorp
| How to test?      | See internal ticket