### PR TITLE
[NEW UI] Add release notes in employee menu

### DIFF
--- a/autoupgrade.php
+++ b/autoupgrade.php
@@ -248,7 +248,7 @@ class Autoupgrade extends Module
             new \PrestaShop\PrestaShop\Core\Action\ActionsBarButton(
                 __CLASS__,
                 [
-                    'link' => \PrestaShop\Module\AutoUpgrade\DocumentationLinks::PRESTASHOP_RELEASES,
+                    'link' => \PrestaShop\Module\AutoUpgrade\DocumentationLinks::getPrestashopReleasesUrl(),
                     'icon' => 'history',
                     'isExternalLink' => true,
                 ],

--- a/autoupgrade.php
+++ b/autoupgrade.php
@@ -110,7 +110,7 @@ class Autoupgrade extends Module
             }
         }
 
-        return parent::install() && $this->registerHook('displayBackOfficeHeader');
+        return parent::install() && $this->registerHook('displayBackOfficeHeader') && $this->registerHook('displayBackOfficeEmployeeMenu');
     }
 
     /**
@@ -224,6 +224,37 @@ class Autoupgrade extends Module
         }
 
         return (new \PrestaShop\Module\AutoUpgrade\Hooks\DisplayBackOfficeHeader($this->getUpgradeContainer()))->renderUpdateNotification();
+    }
+
+    /**
+     * Only available from PS8.
+     *
+     * @param array{links: \PrestaShop\PrestaShop\Core\Action\ActionsBarButtonsCollection} $params
+     *
+     * @return void
+     */
+    public function hookDisplayBackOfficeEmployeeMenu(array $params)
+    {
+        if (
+            !$this->initAutoloaderIfCompliant()
+            || !class_exists(\PrestaShop\PrestaShop\Core\Action\ActionsBarButtonsCollection::class)
+            || !class_exists(\PrestaShop\PrestaShop\Core\Action\ActionsBarButton::class)
+            || !($params['links'] instanceof \PrestaShop\PrestaShop\Core\Action\ActionsBarButtonsCollection)
+        ) {
+            return;
+        }
+
+        $params['links']->add(
+            new \PrestaShop\PrestaShop\Core\Action\ActionsBarButton(
+                __CLASS__,
+                [
+                    'link' => \PrestaShop\Module\AutoUpgrade\DocumentationLinks::PRESTASHOP_RELEASES,
+                    'icon' => 'history',
+                    'isExternalLink' => true,
+                ],
+                $this->trans('Discover the latest releases')
+            )
+        );
     }
 
     /**

--- a/classes/DocumentationLinks.php
+++ b/classes/DocumentationLinks.php
@@ -83,4 +83,9 @@ class DocumentationLinks
     {
         return 'https://experts.prestashop.com/english/experts/';
     }
+
+    public static function getPrestashopReleasesUrl()
+    {
+        return 'https://build.prestashop-project.org/tag/releases/';
+    }
 }

--- a/classes/DocumentationLinks.php
+++ b/classes/DocumentationLinks.php
@@ -84,6 +84,7 @@ class DocumentationLinks
         return 'https://experts.prestashop.com/english/experts/';
     }
 
+    /** @return string */
     public static function getPrestashopReleasesUrl()
     {
         return 'https://build.prestashop-project.org/tag/releases/';

--- a/tests/phpstan/phpstan-1.7.2.5.neon
+++ b/tests/phpstan/phpstan-1.7.2.5.neon
@@ -24,6 +24,7 @@ parameters:
 		- "#^Property PrestaShop\\\\Module\\\\AutoUpgrade\\\\UpgradeTools\\\\Module\\\\ModuleAdapter\\:\\:\\$commandBus has unknown class PrestaShop\\\\PrestaShop\\\\Core\\\\CommandBus\\\\CommandBusInterface as its type\\.$#"
 		- '#Instantiated class AdminKernel not found\.#'
 		- "#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(int\\)\\: mixed\\)\\|null, 'add_quotes' given\\.$#"
+		- '#Parameter \$params of method Autoupgrade::hookDisplayBackOfficeEmployeeMenu\(\) has invalid type PrestaShop\\PrestaShop\\Core\\Action\\ActionsBarButtonsCollection.#'
 		-
 			identifier: booleanAnd.rightAlwaysTrue
 			path: ./../../classes/UpgradeSelfCheck.php

--- a/tests/phpstan/phpstan-1.7.3.4.neon
+++ b/tests/phpstan/phpstan-1.7.3.4.neon
@@ -25,6 +25,7 @@ parameters:
 		- '#Call to method getContainer\(\) on an unknown class AdminKernel.#'
 		- '#Instantiated class AdminKernel not found\.#'
 		- "#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(int\\)\\: mixed\\)\\|null, 'add_quotes' given\\.$#"
+		- '#Parameter \$params of method Autoupgrade::hookDisplayBackOfficeEmployeeMenu\(\) has invalid type PrestaShop\\PrestaShop\\Core\\Action\\ActionsBarButtonsCollection.#'
 		-
 			identifier: booleanAnd.rightAlwaysTrue
 			path: ./../../classes/UpgradeSelfCheck.php

--- a/tests/phpstan/phpstan-1.7.4.4.neon
+++ b/tests/phpstan/phpstan-1.7.4.4.neon
@@ -20,6 +20,7 @@ parameters:
 		- "#^Property PrestaShop\\\\Module\\\\AutoUpgrade\\\\UpgradeTools\\\\Module\\\\ModuleAdapter\\:\\:\\$commandBus has unknown class PrestaShop\\\\PrestaShop\\\\Core\\\\CommandBus\\\\CommandBusInterface as its type\\.$#"
 		- '#Instantiated class AdminKernel not found\.#'
 		- "#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(int\\)\\: mixed\\)\\|null, 'add_quotes' given\\.$#"
+		- '#Parameter \$params of method Autoupgrade::hookDisplayBackOfficeEmployeeMenu\(\) has invalid type PrestaShop\\PrestaShop\\Core\\Action\\ActionsBarButtonsCollection.#'
 		-
 			identifier: booleanAnd.rightAlwaysTrue
 			path: ./../../classes/UpgradeSelfCheck.php

--- a/tests/phpstan/phpstan-1.7.5.1.neon
+++ b/tests/phpstan/phpstan-1.7.5.1.neon
@@ -14,6 +14,7 @@ parameters:
 		- "#^Class PrestaShop\\\\Module\\\\AutoUpgrade\\\\Parameters\\\\LanguageConfiguration @extends tag contains incompatible type Doctrine\\\\Common\\\\Collections\\\\ArrayCollection&iterable\\<string, mixed\\>\\.$#"
 		- '#Instantiated class AdminKernel not found\.#'
 		- "#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(int\\)\\: mixed\\)\\|null, 'add_quotes' given\\.$#"
+		- '#Parameter \$params of method Autoupgrade::hookDisplayBackOfficeEmployeeMenu\(\) has invalid type PrestaShop\\PrestaShop\\Core\\Action\\ActionsBarButtonsCollection.#'
 		-
 			identifier: booleanAnd.rightAlwaysTrue
 			path: ./../../classes/UpgradeSelfCheck.php

--- a/tests/phpstan/phpstan-1.7.6.neon
+++ b/tests/phpstan/phpstan-1.7.6.neon
@@ -15,6 +15,7 @@ parameters:
 		- "#^Class PrestaShop\\\\Module\\\\AutoUpgrade\\\\Parameters\\\\LanguageConfiguration @extends tag contains incompatible type Doctrine\\\\Common\\\\Collections\\\\ArrayCollection&iterable\\<string, mixed\\>\\.$#"
 		- '#Instantiated class AdminKernel not found\.#'
 		- "#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(int\\)\\: mixed\\)\\|null, 'add_quotes' given\\.$#"
+		- '#Parameter \$params of method Autoupgrade::hookDisplayBackOfficeEmployeeMenu\(\) has invalid type PrestaShop\\PrestaShop\\Core\\Action\\ActionsBarButtonsCollection.#'
 		-
 			identifier: booleanAnd.rightAlwaysTrue
 			path: ./../../classes/UpgradeSelfCheck.php

--- a/tests/phpstan/phpstan-1.7.7.neon
+++ b/tests/phpstan/phpstan-1.7.7.neon
@@ -12,6 +12,7 @@ parameters:
 		- "#^Parameter \\$moduleRepository of method PrestaShop\\\\Module\\\\AutoUpgrade\\\\UpgradeTools\\\\Module\\\\ModuleAdapter\\:\\:disableNonNativeModules80\\(\\) has invalid type PrestaShop\\\\PrestaShop\\\\Adapter\\\\Module\\\\Repository\\\\ModuleRepository\\.$#"
 		- '#Instantiated class AdminKernel not found\.#'
 		- "#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(int\\)\\: mixed\\)\\|null, 'add_quotes' given\\.$#"
+		- '#Parameter \$params of method Autoupgrade::hookDisplayBackOfficeEmployeeMenu\(\) has invalid type PrestaShop\\PrestaShop\\Core\\Action\\ActionsBarButtonsCollection.#'
 		-
 			identifier: booleanAnd.rightAlwaysTrue
 			path: ./../../classes/UpgradeSelfCheck.php

--- a/tests/phpstan/phpstan-1.7.8.neon
+++ b/tests/phpstan/phpstan-1.7.8.neon
@@ -11,6 +11,7 @@ parameters:
 		- '#Method PrestaShop\\Module\\AutoUpgrade\\UpgradeTools\\SymfonyAdapter::initKernel\(\) has invalid return type AdminKernel.#'
 		- '#Instantiated class AdminKernel not found\.#'
 		- "#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(int\\)\\: mixed\\)\\|null, 'add_quotes' given\\.$#"
+		- '#Parameter \$params of method Autoupgrade::hookDisplayBackOfficeEmployeeMenu\(\) has invalid type PrestaShop\\PrestaShop\\Core\\Action\\ActionsBarButtonsCollection.#'
 		-
 			identifier: booleanAnd.rightAlwaysTrue
 			path: ./../../classes/UpgradeSelfCheck.php

--- a/upgrade/upgrade-7.1.0.php
+++ b/upgrade/upgrade-7.1.0.php
@@ -42,6 +42,7 @@ function upgrade_module_7_1_0($module)
     }
 
     $module->registerHook('displayBackOfficeHeader');
+    $module->registerHook('displayBackOfficeEmployeeMenu');
 
     return true;
 }


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add link to employee menu to access release notes. I used `hookDisplayBackOfficeEmployeeMenu` only available from version 8 of PrestaShop
| Type?             |  new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | @PrestaShopCorp
| How to test?      | Install module on V8 or more and check the employee menu on top right in BO, you need to have a new link targeting release notes.