### PR TITLE
Add index on shop_tax for query to select most used tax rule (PS 8.2.x)

### DIFF
--- a/upgrade/sql/8.2.2.sql
+++ b/upgrade/sql/8.2.2.sql
@@ -4,3 +4,5 @@ SET NAMES 'utf8mb4';
 INSERT INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES
   (NULL, 'actionDuplicateCartData','Cart Duplication','This hook is triggered after all the cart related data has been duplicated', '1')
 ON DUPLICATE KEY UPDATE `title` = VALUES(`title`), `description` = VALUES(`description`);
+
+ALTER TABLE `PREFIX_product_shop` ADD INDEX `shop_tax` (`id_shop`, `id_tax_rules_group`);


### PR DESCRIPTION
Added the "shop_tax" index to the "product_shop" table for PS version 8.2.2.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The query in the Product::getIdTaxRulesGroupMostUsed() method, in the case of a database with many products, makes the insertion of a new product very slow
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #38095
| Sponsor company   | @codencode
| How to test?      | See https://github.com/PrestaShop/PrestaShop/issues/38095 and see: https://github.com/PrestaShop/PrestaShop/pull/38251#issuecomment-2747196930
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/38251