### PR TITLE
[FIX] error 500 on backup choice

### DIFF
--- a/controllers/admin/self-managed/RestorePageBackupSelectionController.php
+++ b/controllers/admin/self-managed/RestorePageBackupSelectionController.php
@@ -152,6 +152,15 @@ class RestorePageBackupSelectionController extends AbstractPageWithStepControlle
      */
     public function submitRestore(): JsonResponse
     {
+        $errors = $this->saveBackupConfiguration();
+
+        if (!empty($errors)) {
+            return $this->getRefreshOfForm(array_merge(
+                $this->getParams(),
+                ['errors' => ValidatorToFormFormater::format($errors)]
+            ));
+        }
+
         $backupName = $this->request->request->get(RestoreConfiguration::BACKUP_NAME);
         $backupVersion = $this->upgradeContainer->getBackupFinder()->parseBackupMetadata($backupName)['version'];
 


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix issue then we don't change choice of backup and the choice is not valid. No error are displayed and we got an error 500 page.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/38363
| Sponsor company   | @PrestaShopCorp
| How to test?      | See the issue