### PR TITLE
Remove intl from the PHP requirements in Composer as it is checked on runtime

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
     "require": {
         "php": ">=7.1",
         "ext-zip": "*",
-        "ext-intl": "*",
         "symfony/filesystem": "^3.0",
         "doctrine/collections": "^1.8",
         "segmentio/analytics-php": "^1.8",


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Remove a requirements in the composer.json file, as it is checked at the runtime before use.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | On a shop that does not have `intl` enabled, the list of backups must be working
