### PR TITLE
[NEW UI] Update dialog theming

### DIFF
--- a/_dev/src/scss/_variables.scss
+++ b/_dev/src/scss/_variables.scss
@@ -60,7 +60,10 @@ $cdk-prefix: "cdk-";
     --#{$cdk-prefix}box-shadow-pop-modal,
     0 12px 24px rgb(0 0 0 / 0.1)
   );
-  --#{$ua-prefix}box-shadow-md: var(--#{$cdk-prefix}box-shadow-md, 0 4px 6px -1px rgba(29, 29, 27, 0.2));
+  --#{$ua-prefix}box-shadow-md: var(
+    --#{$cdk-prefix}box-shadow-md,
+    0 4px 6px -1px rgb(29 29 27 / 0.2)
+  );
   --#{$ua-prefix}required-color: var(--#{$ua-prefix}red-500);
   --#{$ua-prefix}primary: var(--#{$ua-prefix}primary-800);
   --#{$ua-prefix}primary-hover: var(--#{$ua-prefix}primary-700);

--- a/_dev/src/scss/_variables.scss
+++ b/_dev/src/scss/_variables.scss
@@ -60,6 +60,7 @@ $cdk-prefix: "cdk-";
     --#{$cdk-prefix}box-shadow-pop-modal,
     0 12px 24px rgb(0 0 0 / 0.1)
   );
+  --#{$ua-prefix}box-shadow-md: var(--#{$cdk-prefix}box-shadow-md, 0 4px 6px -1px rgba(29, 29, 27, 0.2));
   --#{$ua-prefix}required-color: var(--#{$ua-prefix}red-500);
   --#{$ua-prefix}primary: var(--#{$ua-prefix}primary-800);
   --#{$ua-prefix}primary-hover: var(--#{$ua-prefix}primary-700);

--- a/_dev/src/scss/appUpdateNotification/components/_dialog.scss
+++ b/_dev/src/scss/appUpdateNotification/components/_dialog.scss
@@ -155,10 +155,28 @@ $media-query-mobile: 992px;
     }
   }
 
-  &.v1-7-8-0,
-  &.v1-7-3-0 {
+  &.v1-7-8-0 {
     #{$e} {
       --#{$ua-prefix}dialog-badge-background-color: var(--#{$ua-prefix}primary);
+    }
+  }
+
+  &.v1-7-3-0 {
+    #{$e} {
+      --#{$ua-prefix}dialog-badge-background-color: #25b9d7;
+
+      @at-root {
+        // CSS class to identify legacy BO themes
+        .ps_back-office {
+          #{$notification-id} {
+            &.v1-7-3-0 {
+              #{$e} {
+                --#{$ua-prefix}dialog-badge-background-color: var(--#{$ua-prefix}primary);
+              }
+            }
+          }
+        }
+      }
     }
   }
 

--- a/_dev/src/scss/appUpdateNotification/components/_dialog.scss
+++ b/_dev/src/scss/appUpdateNotification/components/_dialog.scss
@@ -164,6 +164,7 @@ $media-query-mobile: 992px;
   &.v1-7-3-0 {
     #{$e} {
       --#{$ua-prefix}dialog-badge-background-color: #25b9d7;
+      border-radius: 0;
 
       @at-root {
         // CSS class to identify legacy BO themes
@@ -172,6 +173,7 @@ $media-query-mobile: 992px;
             &.v1-7-3-0 {
               #{$e} {
                 --#{$ua-prefix}dialog-badge-background-color: var(--#{$ua-prefix}primary);
+                border-radius: var(--#{$ua-prefix}border-radius);
               }
             }
           }

--- a/_dev/src/scss/appUpdateNotification/components/_dialog.scss
+++ b/_dev/src/scss/appUpdateNotification/components/_dialog.scss
@@ -143,12 +143,14 @@ $media-query-mobile: 992px;
 
     &__buttons {
       display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
+      grid-template-columns: repeat(2, minmax(0, auto));
+      align-items: stretch;
       gap: 1rem;
     }
 
     &__button {
       width: 100%;
+      height: 100%;
       text-transform: none;
     }
   }

--- a/_dev/src/scss/appUpdateNotification/components/_dialog.scss
+++ b/_dev/src/scss/appUpdateNotification/components/_dialog.scss
@@ -144,8 +144,8 @@ $media-query-mobile: 992px;
     &__buttons {
       display: grid;
       grid-template-columns: repeat(2, minmax(0, auto));
-      align-items: stretch;
       gap: 1rem;
+      align-items: stretch;
     }
 
     &__button {

--- a/_dev/src/scss/appUpdateNotification/components/_dropdown.scss
+++ b/_dev/src/scss/appUpdateNotification/components/_dropdown.scss
@@ -37,21 +37,20 @@ $e: ".dropdown";
         }
       }
     }
-      
+
     &-menu {
-      margin-block-start: 0;
-      margin-block-end: 0.125rem;
       min-width: 100%;
+      margin-block: 0 0.125rem;
       border: var(--#{$ua-prefix}dropdown-menu-border-color);
       box-shadow: var(--#{$ua-prefix}dropdown-menu-box-shadow);
     }
 
     &-toggle {
       display: inline-flex;
-      padding-inline: 1rem;
       gap: 0.5rem;
       align-items: center;
       justify-content: space-between;
+      padding-inline: 1rem;
       text-align: left;
 
       &::after {
@@ -67,23 +66,23 @@ $e: ".dropdown";
 
     &-item {
       display: block;
-      cursor: pointer;
       width: 100%;
       padding: 0.375rem 1rem;
       clear: both;
-      font-weight: 400;
+      background-color: transparent;
+      border: 0;
       font-size: 0.875rem;
+      font-weight: 400;
       line-height: 1.25rem;
       color: var(--#{$ua-prefix}dropdown-menu-item-color);
       text-align: inherit;
       text-decoration: none;
       white-space: nowrap;
-      background-color: transparent;
-      border: 0;
+      cursor: pointer;
 
       &:hover {
-        color: var(--#{$ua-prefix}dropdown-menu-item-color-hover);
         background-color: var(--#{$ua-prefix}dropdown-menu-item-background-color-hover);
+        color: var(--#{$ua-prefix}dropdown-menu-item-color-hover);
       }
     }
   }
@@ -92,7 +91,7 @@ $e: ".dropdown";
   &.v1-7-8-0 {
     #{$e} {
       --#{$ua-prefix}dropdown-menu-border-color: 1px solid #b3c7cd;
-      --#{$ua-prefix}dropdown-menu-box-shadow: 1px 1px 2px 0 rgba(0, 0, 0, 0.3);
+      --#{$ua-prefix}dropdown-menu-box-shadow: 1px 1px 2px 0 rgb(0 0 0 / 0.3);
       --#{$ua-prefix}dropdown-menu-item-color: #576c72;
       --#{$ua-prefix}dropdown-menu-item-color-hover: var(--#{$ua-prefix}primary);
       --#{$ua-prefix}dropdown-menu-item-background-color-hover: #f4fcfd;
@@ -137,24 +136,10 @@ $e: ".dropdown";
   &.v1-7-3-0 {
     #{$e} {
       --#{$ua-prefix}dropdown-menu-border-color: 1px solid #bbcdd2;
-      --#{$ua-prefix}dropdown-menu-box-shadow: 1px 1px 2px 0 rgba(0, 0, 0, 0.3);
+      --#{$ua-prefix}dropdown-menu-box-shadow: 1px 1px 2px 0 rgb(0 0 0 / 0.3);
       --#{$ua-prefix}dropdown-menu-item-color: #576c72;
       --#{$ua-prefix}dropdown-menu-item-color-hover: var(--#{$ua-prefix}white);
       --#{$ua-prefix}dropdown-menu-item-background-color-hover: #25b9d7;
-
-      @at-root {
-        // CSS class to identify legacy BO themes
-        .ps_back-office {
-          #{$notification-id} {
-            &.v1-7-3-0 {
-              #{$e} {
-                --#{$ua-prefix}dropdown-menu-box-shadow: 0 6px 12px rgba(0,0,0,.175);
-                --#{$ua-prefix}dropdown-menu-item-background-color-hover: var(--#{$ua-prefix}primary);
-              }
-            }
-          }
-        }
-      }
 
       &-menu {
         padding: 0.3125rem 0;
@@ -162,6 +147,22 @@ $e: ".dropdown";
 
       &-item {
         line-height: inherit;
+      }
+
+      @at-root {
+        // CSS class to identify legacy BO themes
+        .ps_back-office {
+          #{$notification-id} {
+            &.v1-7-3-0 {
+              #{$e} {
+                --#{$ua-prefix}dropdown-menu-box-shadow: 0 6px 12px rgb(0 0 0 / 0.175);
+                --#{$ua-prefix}dropdown-menu-item-background-color-hover: var(
+                  --#{$ua-prefix}primary
+                );
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/_dev/src/scss/appUpdateNotification/components/_dropdown.scss
+++ b/_dev/src/scss/appUpdateNotification/components/_dropdown.scss
@@ -1,0 +1,118 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+@use "../../variables" as *;
+
+$notification-id: "#update_assistant_notification";
+$e: ".dropdown";
+
+#{$notification-id} {
+  #{$e} {
+    
+  }
+
+  // Unified UI accross versions and BO themes
+  &.v1-7-8-0 {
+    #{$e} {
+      --#{$ua-prefix}dropdown-menu-background-color: #b3c7cd;
+      --#{$ua-prefix}dropdown-menu-box-shadow: 1px 1px 2px 0 rgba(0, 0, 0, 0.3);
+      --#{$ua-prefix}dropdown-menu-item-color: #576c72;
+      --#{$ua-prefix}dropdown-menu-item-color-hover: var(--#{$ua-prefix}primary);
+      --#{$ua-prefix}dropdown-menu-item-background-color-hover: #f4fcfd;
+
+      &.open,
+      &.show {
+        #{$e}-toggle {
+          &:focus {
+            color: var(--#{$ua-prefix}white);
+          }
+
+          &::after {
+            transform: rotate(0.5turn);
+          }
+        }
+      }
+
+      &.show {
+        #{$e}-toggle {
+          color: var(--#{$ua-prefix}white);
+        }
+      }
+
+      &-toggle {
+        display: inline-flex;
+        padding-inline: 1rem;
+        gap: 0.5rem;
+        align-items: center;
+        justify-content: space-between;
+        text-align: left;
+
+        &::after {
+          content: "expand_less";
+          margin: 0;
+          font-family: var(--#{$ua-prefix}font-family-material-icons);
+          font-size: 1.25rem;
+          line-height: 0;
+          transition: transform var(--#{$ua-prefix}default-transition-duration);
+        }
+      }
+
+      &-menu {
+        margin-block-end: 0.125rem;
+        padding: 1px 0;
+        border: 1px solid var(--#{$ua-prefix}dropdown-menu-background-color);
+        border-radius: 0.25rem;
+        box-shadow: var(--#{$ua-prefix}dropdown-menu-box-shadow);
+      }
+
+      &-item {
+        display: block;
+        width: 100%;
+        padding: 0.438rem 1rem 0.438rem 0.938rem;
+        clear: both;
+        font-weight: 400;
+        font-size: 0.875rem;
+        color: var(--#{$ua-prefix}dropdown-menu-item-color);
+        text-align: inherit;
+        text-decoration: none;
+        white-space: nowrap;
+        background-color: transparent;
+        border: 0;
+
+        &:hover {
+          color: var(--#{$ua-prefix}dropdown-menu-item-color-hover);
+          background-color: var(--#{$ua-prefix}dropdown-menu-item-background-color-hover);
+        }
+
+        &:first-child {
+          border-start-start-radius: 0.1875rem;
+          border-start-end-radius: 0.1875rem;
+        }
+
+        &:last-child {
+          border-end-start-radius: 0.1875rem;
+          border-end-end-radius: 0.1875rem;
+        }
+      }
+    }
+  }
+
+  &.v1-7-3-0 {
+
+  }
+}

--- a/_dev/src/scss/appUpdateNotification/components/_dropdown.scss
+++ b/_dev/src/scss/appUpdateNotification/components/_dropdown.scss
@@ -23,7 +23,9 @@ $e: ".dropdown";
 
 #{$notification-id} {
   #{$e} {
-    
+    &-menu {
+      min-width: 100%;
+    }
   }
 
   // Unified UI accross versions and BO themes
@@ -113,6 +115,82 @@ $e: ".dropdown";
   }
 
   &.v1-7-3-0 {
+    #{$e} {
+      --#{$ua-prefix}dropdown-menu-background-color: #bbcdd2;
+      --#{$ua-prefix}dropdown-menu-box-shadow: 1px 1px 2px 0 rgba(0, 0, 0, 0.3);
+      --#{$ua-prefix}dropdown-menu-item-color: #576c72;
+      --#{$ua-prefix}dropdown-menu-item-color-hover: var(--#{$ua-prefix}white);
+      --#{$ua-prefix}dropdown-menu-item-background-color-hover: #25b9d7;
 
+      @at-root {
+        // CSS class to identify legacy BO themes
+        .ps_back-office {
+          #{$notification-id} {
+            &.v1-7-3-0 {
+              #{$e} {
+                --#{$ua-prefix}dropdown-menu-item-background-color-hover: var(--#{$ua-prefix}primary);
+                --#{$ua-prefix}dropdown-menu-box-shadow: 0 6px 12px rgba(0,0,0,.175);
+              }
+            }
+          }
+        }
+      }
+
+      &.open,
+      &.show {
+        #{$e}-toggle {
+          &::after {
+            transform: rotate(0.5turn);
+          }
+        }
+      }
+
+      &-toggle {
+        display: inline-flex;
+        padding-inline: 1rem;
+        gap: 0.5rem;
+        align-items: center;
+        justify-content: space-between;
+        text-align: left;
+        white-space: initial;
+
+        &::after {
+          content: "expand_less";
+          margin: 0;
+          font-family: var(--#{$ua-prefix}font-family-material-icons);
+          font-size: 1.25rem;
+          line-height: 0;
+          transition: transform var(--#{$ua-prefix}default-transition-duration);
+        }
+      }
+
+      &-menu {
+        margin-block-end: 0.125rem;
+        padding: 0.3125rem 0;
+        border: 1px solid var(--#{$ua-prefix}dropdown-menu-background-color);
+        box-shadow: var(--#{$ua-prefix}dropdown-menu-box-shadow);
+      }
+
+      &-item {
+        display: block;
+        cursor: pointer;
+        width: 100%;
+        padding: 0.375rem 1rem;
+        clear: both;
+        font-weight: 400;
+        font-size: 0.875rem;
+        color: var(--#{$ua-prefix}dropdown-menu-item-color);
+        text-align: inherit;
+        text-decoration: none;
+        white-space: nowrap;
+        background-color: transparent;
+        border: 0;
+
+        &:hover {
+          color: var(--#{$ua-prefix}dropdown-menu-item-color-hover);
+          background-color: var(--#{$ua-prefix}dropdown-menu-item-background-color-hover);
+        }
+      }
+    }
   }
 }

--- a/_dev/src/scss/appUpdateNotification/components/_dropdown.scss
+++ b/_dev/src/scss/appUpdateNotification/components/_dropdown.scss
@@ -23,15 +23,75 @@ $e: ".dropdown";
 
 #{$notification-id} {
   #{$e} {
+    --#{$ua-prefix}dropdown-menu-border-color: 0;
+    --#{$ua-prefix}dropdown-menu-box-shadow: var(--#{$ua-prefix}box-shadow-md);
+    --#{$ua-prefix}dropdown-menu-item-color: var(--#{$ua-prefix}primary-800);
+    --#{$ua-prefix}dropdown-menu-item-color-hover: var(--#{$ua-prefix}primary);
+    --#{$ua-prefix}dropdown-menu-item-background-color-hover: var(--#{$ua-prefix}primary-200);
+
+    &.open,
+    &.show {
+      #{$e}-toggle {
+        &::after {
+          transform: rotate(0.5turn);
+        }
+      }
+    }
+      
     &-menu {
+      margin-block-start: 0;
+      margin-block-end: 0.125rem;
       min-width: 100%;
+      border: var(--#{$ua-prefix}dropdown-menu-border-color);
+      box-shadow: var(--#{$ua-prefix}dropdown-menu-box-shadow);
+    }
+
+    &-toggle {
+      display: inline-flex;
+      padding-inline: 1rem;
+      gap: 0.5rem;
+      align-items: center;
+      justify-content: space-between;
+      text-align: left;
+
+      &::after {
+        content: "\e5ce";
+        margin: 0;
+        font-family: var(--#{$ua-prefix}font-family-material-icons);
+        font-size: 1.25rem;
+        font-weight: 400;
+        line-height: 0;
+        transition: transform var(--#{$ua-prefix}default-transition-duration);
+      }
+    }
+
+    &-item {
+      display: block;
+      cursor: pointer;
+      width: 100%;
+      padding: 0.375rem 1rem;
+      clear: both;
+      font-weight: 400;
+      font-size: 0.875rem;
+      line-height: 1.25rem;
+      color: var(--#{$ua-prefix}dropdown-menu-item-color);
+      text-align: inherit;
+      text-decoration: none;
+      white-space: nowrap;
+      background-color: transparent;
+      border: 0;
+
+      &:hover {
+        color: var(--#{$ua-prefix}dropdown-menu-item-color-hover);
+        background-color: var(--#{$ua-prefix}dropdown-menu-item-background-color-hover);
+      }
     }
   }
 
   // Unified UI accross versions and BO themes
   &.v1-7-8-0 {
     #{$e} {
-      --#{$ua-prefix}dropdown-menu-background-color: #b3c7cd;
+      --#{$ua-prefix}dropdown-menu-border-color: 1px solid #b3c7cd;
       --#{$ua-prefix}dropdown-menu-box-shadow: 1px 1px 2px 0 rgba(0, 0, 0, 0.3);
       --#{$ua-prefix}dropdown-menu-item-color: #576c72;
       --#{$ua-prefix}dropdown-menu-item-color-hover: var(--#{$ua-prefix}primary);
@@ -43,10 +103,6 @@ $e: ".dropdown";
           &:focus {
             color: var(--#{$ua-prefix}white);
           }
-
-          &::after {
-            transform: rotate(0.5turn);
-          }
         }
       }
 
@@ -56,50 +112,14 @@ $e: ".dropdown";
         }
       }
 
-      &-toggle {
-        display: inline-flex;
-        padding-inline: 1rem;
-        gap: 0.5rem;
-        align-items: center;
-        justify-content: space-between;
-        text-align: left;
-
-        &::after {
-          content: "expand_less";
-          margin: 0;
-          font-family: var(--#{$ua-prefix}font-family-material-icons);
-          font-size: 1.25rem;
-          line-height: 0;
-          transition: transform var(--#{$ua-prefix}default-transition-duration);
-        }
-      }
-
       &-menu {
-        margin-block-end: 0.125rem;
         padding: 1px 0;
-        border: 1px solid var(--#{$ua-prefix}dropdown-menu-background-color);
         border-radius: 0.25rem;
-        box-shadow: var(--#{$ua-prefix}dropdown-menu-box-shadow);
       }
 
       &-item {
-        display: block;
-        width: 100%;
         padding: 0.438rem 1rem 0.438rem 0.938rem;
-        clear: both;
-        font-weight: 400;
-        font-size: 0.875rem;
-        color: var(--#{$ua-prefix}dropdown-menu-item-color);
-        text-align: inherit;
-        text-decoration: none;
-        white-space: nowrap;
-        background-color: transparent;
-        border: 0;
-
-        &:hover {
-          color: var(--#{$ua-prefix}dropdown-menu-item-color-hover);
-          background-color: var(--#{$ua-prefix}dropdown-menu-item-background-color-hover);
-        }
+        line-height: inherit;
 
         &:first-child {
           border-start-start-radius: 0.1875rem;
@@ -116,7 +136,7 @@ $e: ".dropdown";
 
   &.v1-7-3-0 {
     #{$e} {
-      --#{$ua-prefix}dropdown-menu-background-color: #bbcdd2;
+      --#{$ua-prefix}dropdown-menu-border-color: 1px solid #bbcdd2;
       --#{$ua-prefix}dropdown-menu-box-shadow: 1px 1px 2px 0 rgba(0, 0, 0, 0.3);
       --#{$ua-prefix}dropdown-menu-item-color: #576c72;
       --#{$ua-prefix}dropdown-menu-item-color-hover: var(--#{$ua-prefix}white);
@@ -128,68 +148,20 @@ $e: ".dropdown";
           #{$notification-id} {
             &.v1-7-3-0 {
               #{$e} {
-                --#{$ua-prefix}dropdown-menu-item-background-color-hover: var(--#{$ua-prefix}primary);
                 --#{$ua-prefix}dropdown-menu-box-shadow: 0 6px 12px rgba(0,0,0,.175);
+                --#{$ua-prefix}dropdown-menu-item-background-color-hover: var(--#{$ua-prefix}primary);
               }
             }
           }
         }
       }
 
-      &.open,
-      &.show {
-        #{$e}-toggle {
-          &::after {
-            transform: rotate(0.5turn);
-          }
-        }
-      }
-
-      &-toggle {
-        display: inline-flex;
-        padding-inline: 1rem;
-        gap: 0.5rem;
-        align-items: center;
-        justify-content: space-between;
-        text-align: left;
-        white-space: initial;
-
-        &::after {
-          content: "expand_less";
-          margin: 0;
-          font-family: var(--#{$ua-prefix}font-family-material-icons);
-          font-size: 1.25rem;
-          line-height: 0;
-          transition: transform var(--#{$ua-prefix}default-transition-duration);
-        }
-      }
-
       &-menu {
-        margin-block-end: 0.125rem;
         padding: 0.3125rem 0;
-        border: 1px solid var(--#{$ua-prefix}dropdown-menu-background-color);
-        box-shadow: var(--#{$ua-prefix}dropdown-menu-box-shadow);
       }
 
       &-item {
-        display: block;
-        cursor: pointer;
-        width: 100%;
-        padding: 0.375rem 1rem;
-        clear: both;
-        font-weight: 400;
-        font-size: 0.875rem;
-        color: var(--#{$ua-prefix}dropdown-menu-item-color);
-        text-align: inherit;
-        text-decoration: none;
-        white-space: nowrap;
-        background-color: transparent;
-        border: 0;
-
-        &:hover {
-          color: var(--#{$ua-prefix}dropdown-menu-item-color-hover);
-          background-color: var(--#{$ua-prefix}dropdown-menu-item-background-color-hover);
-        }
+        line-height: inherit;
       }
     }
   }

--- a/_dev/src/scss/appUpdateNotification/components/_index.scss
+++ b/_dev/src/scss/appUpdateNotification/components/_index.scss
@@ -17,3 +17,4 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */
 @use "dialog";
+@use "dropdown";


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR handles the theming of the update notification, more specifically, the "Remind me later" option by adapting styles according to the Back Office version and the theme (either default or new-theme) used on specific PrestaShop pages.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | --
| Sponsor company   | @PrestaShopCorp
| How to test?      | --

**INFO:** Refer to the matrix below to test all cases.
- Install the module on PrestaShop
- Check how the modal is displayed on the "Dashboard" page (which uses the "default" theme)
- Check how the modal is displayed on the "Products" page (which uses the "new-theme")

**Must be tested on:**
- PrestaShop < 1.7.8.0
- PrestaShop >= 1.7.8.0 and < 9.0.0
- PrestaShop 9.0.0

**Note:** Some elements may slightly differ depending on the Back Office version and the theme used, as certain components of the dialog rely on existing theme-embedded elements.