### PR TITLE
Update error message when openssl_pkey_new() fails

### DIFF
--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -325,7 +325,7 @@ class UpgradeSelfCheck
 
             case self::KEY_GENERATION_INVALID:
                 return [
-                    'message' => $this->translator->trans('Unable to generate private keys using openssl_pkey_new. Check your OpenSSL configuration, especially the path to openssl.cafile.'),
+                    'message' => $this->translator->trans('Failed to generate private keys using openssl_pkey_new(). Please check your PHP configuration, especially the openssl.cafile setting, and ensure that the specified file exists and is accessible.'),
                 ];
 
             case self::NOT_WRITING_DIRECTORY_LIST_NOT_EMPTY:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Update the error message when openssl_pkey_new() fails during the requirement checks. When I got the issue for the first time, I did not understand it was related to my php.ini file.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/33615 partially
| Sponsor company   | @PrestaShopCorp
| How to test?      | Make OpenSSL fail on your environment (with a bad PHP configuration, by removing the OpenSSL one etc). The message must be updated in the list of requirements.