### PR TITLE
[FIX] issue then multiple employee snoozed modal

### DIFF
--- a/classes/Hooks/DisplayBackOfficeHeader.php
+++ b/classes/Hooks/DisplayBackOfficeHeader.php
@@ -133,9 +133,9 @@ class DisplayBackOfficeHeader
 
         $employees = $this->updateNotificationConfiguration->getEmployeesReminderChoice();
 
-        $employeeExists = array_filter($employees, function ($employee) {
+        $employeeExists = array_values(array_filter($employees, function ($employee) {
             return $employee['employeeID'] === $this->employee->id;
-        });
+        }));
 
         if ($this->updateIsAvailable()) {
             if (


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The modal is displayed continuously if we are not the first user. After investigation this is due to the array_filter which will keep the original key of the user which will therefore not be 0 afterwards.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     |  no
| Fixed ticket?     | N/A
| Sponsor company   | @PrestaShopCorp
| How to test?      | See internal ticket