### PR TITLE
[NEW UI] change message to add version on post update

### DIFF
--- a/controllers/admin/self-managed/UpdatePagePostUpdateController.php
+++ b/controllers/admin/self-managed/UpdatePagePostUpdateController.php
@@ -65,6 +65,7 @@ class UpdatePagePostUpdateController extends AbstractPageWithStepController
                 'exit_link' => $this->upgradeContainer->getUrlGenerator()->getShopAdminAbsolutePathFromRequest($this->request),
                 'dev_doc_link' => DocumentationLinks::getDevDocUpdateAssistantPostUpdateUrl($currentMajorVersion),
                 'download_logs' => $this->upgradeContainer->getLogsService()->getDownloadLogsData(TaskType::TASK_TYPE_UPDATE),
+                'ps_version' => $this->upgradeContainer->getCurrentPrestaShopVersion(),
             ]
         );
     }

--- a/views/templates/steps/post-update.html.twig
+++ b/views/templates/steps/post-update.html.twig
@@ -27,7 +27,7 @@
 {% block content %}
   <div class="content__container">
     {% include '@ModuleAutoUpgrade/components/alert.html.twig' with {
-      title: 'Your store is up to date'|trans({}),
+      title: 'Your store has been updated to PrestaShop version %version%'|trans({ '%version%': ps_version }),
       message: 'Before continuing with your tasks, please review the following checklist to ensure smooth operation after recent updates.'|trans({}),
       alertStatus: 'success',
     } %}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Currently, after a successful update via the Update Assistant (autoupgrade) module, a success message is displayed on the "Post-update" page: "Your store is up to date." This message is generic and does not specify the exact version to which the store was updated. To improve user clarity, we would like to explicitly display the installed version after the update, for example: "Your store has been updated to PrestaShop version 8.1.2." This message must be translatable and dynamically integrate the installed PrestaShop version.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | @PrestaShopCorp
| How to test?      | See internal ticket

![image](https://github.com/user-attachments/assets/ed8d1f33-2577-4fbc-9c06-e81222e4c919)
