### PR TITLE
[FIX] segment update dialog async call

### DIFF
--- a/_dev/src/ts/api/SegmentApi.ts
+++ b/_dev/src/ts/api/SegmentApi.ts
@@ -40,8 +40,8 @@ class Analytics {
    * @param {object} [properties] - Optional properties to include with the event.
    * @description Tracks an event with optional properties.
    */
-  public track = (event: string, properties?: object) => {
-    this.analytics.track(
+  public track = async (event: string, properties?: object) => {
+    await this.analytics.track(
       event,
       {
         module: 'autoupgrade',

--- a/_dev/src/ts/appUpdateNotification/dialogs/UpdateNotificationDialog.ts
+++ b/_dev/src/ts/appUpdateNotification/dialogs/UpdateNotificationDialog.ts
@@ -95,11 +95,11 @@ export default class UpdateNotificationDialog implements DomLifecycle {
 
       if (submitButton.value) {
         Object.assign(params, { value: submitButton.value });
-        analytics.track('[SUE] Update modal snoozed', {
+        await analytics.track('[SUE] Update modal snoozed', {
           representation_delay: submitButton.value
         });
       } else {
-        analytics.track('[SUE] Update module opened following modal display');
+        await analytics.track('[SUE] Update module opened following modal display');
       }
 
       const response = await api.post('', null, {


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Actually then you click on "udate" from update dialog if your shop redirect you too fast you can't send the event from segment. This PR fix this with async/await.
| Type?             | bug fix
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | @PrestaShopCorp
| How to test?      | try "update" button on modal and check if something is send to segment/mixpanel