### PR TITLE
Improve generation of basepath for URLs

### DIFF
--- a/classes/Router/UrlGenerator.php
+++ b/classes/Router/UrlGenerator.php
@@ -26,37 +26,19 @@ use Symfony\Component\HttpFoundation\Request;
 class UrlGenerator
 {
     /** @var string */
-    private $shopBasePath;
-    /** @var string */
     private $adminFolder;
 
-    public function __construct(string $shopBasePath, string $adminFolder)
+    public function __construct(string $adminFolder)
     {
-        $this->shopBasePath = $shopBasePath;
         $this->adminFolder = $adminFolder;
     }
 
     public function getShopAbsolutePathFromRequest(Request $request): string
     {
-        // Determine the subdirectories of the PHP entry point (the script being executed)
-        // relative to the shop root folder.
-        // This calculation helps generate a base path that correctly accounts for any subfolder in which
-        // the shop might be installed.
-        $subDirs = explode(
-            DIRECTORY_SEPARATOR,
-            trim(
-                str_replace(
-                    $this->shopBasePath,
-                    '',
-                    dirname($request->server->get('SCRIPT_FILENAME', '')
-                )
-            ), DIRECTORY_SEPARATOR)
-        );
-        $numberOfSubDirs = count($subDirs);
-
         $path = explode('/', $request->getBasePath());
+        $keyOfAdminInPath = array_search($this->adminFolder, $path);
 
-        $path = array_splice($path, 0, -$numberOfSubDirs);
+        array_splice($path, $keyOfAdminInPath);
 
         return implode('/', $path) ?: '/';
     }

--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -1021,7 +1021,6 @@ class UpgradeContainer
     {
         if (null === $this->urlGenerator) {
             $this->urlGenerator = new UrlGenerator(
-                $this->getProperty(self::PS_ROOT_PATH),
                 $this->getProperty(self::PS_ADMIN_SUBDIR)
             );
         }

--- a/tests/unit/Controller/AbstractGlobalControllerTest.php
+++ b/tests/unit/Controller/AbstractGlobalControllerTest.php
@@ -51,7 +51,7 @@ class AbstractGlobalControllerTest extends TestCase
             ->getMock();
 
         $upgradeContainer->method('getUrlGenerator')
-            ->willReturn(new UrlGenerator('/yo/doge', 'admin-wololo'));
+            ->willReturn(new UrlGenerator('admin-wololo'));
 
         $server = [
             'HTTP_HOST' => 'localhost',

--- a/tests/unit/Router/UrlGeneratorTest.php
+++ b/tests/unit/Router/UrlGeneratorTest.php
@@ -28,9 +28,8 @@ class UrlGeneratorTest extends TestCase
 
     protected function setUp()
     {
-        $shopBasePath = '/yo/doge';
-        $adminPath = 'wololo';
-        $this->urlGenerator = new UrlGenerator($shopBasePath, $adminPath);
+        $adminPath = 'admin-wololo';
+        $this->urlGenerator = new UrlGenerator($adminPath);
     }
 
     public function testGetShopUrlReturnsUrl()
@@ -47,12 +46,12 @@ class UrlGeneratorTest extends TestCase
         $request = new Request([], [], [], [], [], $server);
 
         $expectedAbsoluteUrlPathToShop = '/';
-        $expectedAbsoluteUrlPathToAdmin = '/wololo';
+        $expectedAbsoluteUrlPathToAdmin = '/admin-wololo';
         $this->assertSame($expectedAbsoluteUrlPathToShop, $this->urlGenerator->getShopAbsolutePathFromRequest($request));
         $this->assertSame($expectedAbsoluteUrlPathToAdmin, $this->urlGenerator->getShopAdminAbsolutePathFromRequest($request));
     }
 
-    public function testGetShopUrlReturnsUrlWithShopInSubFolder()
+    public function testUrlWithShopInSubFolder()
     {
         $server = [
             'HTTP_HOST' => 'localhost',
@@ -66,12 +65,32 @@ class UrlGeneratorTest extends TestCase
         $request = new Request([], [], [], [], [], $server);
 
         $expectedAbsoluteUrlPathToShop = '/hello-world';
-        $expectedAbsoluteUrlPathToAdmin = '/hello-world/wololo';
+        $expectedAbsoluteUrlPathToAdmin = '/hello-world/admin-wololo';
         $this->assertSame($expectedAbsoluteUrlPathToShop, $this->urlGenerator->getShopAbsolutePathFromRequest($request));
         $this->assertSame($expectedAbsoluteUrlPathToAdmin, $this->urlGenerator->getShopAdminAbsolutePathFromRequest($request));
     }
 
-    public function testGetShopUrlReturnsUrlWithCustomEntrypoint()
+    public function testUrlWithShopInSubFolderBehindSymbolicLink()
+    {
+        $server = [
+            'HTTP_HOST' => 'localhost',
+            'SERVER_PORT' => '80',
+            'QUERY_STRING' => 'controller=AdminSelfUpgrade&token=0fbeae3341a7e5f5f3fdc901f783271d',
+            'PHP_SELF' => '/PrestaShop-zip/admin-wololo/index.php',
+            // Script filepath could be different if the root shop is behind a symlink
+            'SCRIPT_FILENAME' => '/var/www/html/PrestaShop-zip/admin-wololo/index.php',
+            'REQUEST_URI' => '/PrestaShop-zip/admin-wololo/index.php?controller=AdminSelfUpgrade&token=0fbeae3341a7e5f5f3fdc901f783271d',
+        ];
+
+        $request = new Request([], [], [], [], [], $server);
+
+        $expectedAbsoluteUrlPathToShop = '/PrestaShop-zip';
+        $expectedAbsoluteUrlPathToAdmin = '/PrestaShop-zip/admin-wololo';
+        $this->assertSame($expectedAbsoluteUrlPathToShop, $this->urlGenerator->getShopAbsolutePathFromRequest($request));
+        $this->assertSame($expectedAbsoluteUrlPathToAdmin, $this->urlGenerator->getShopAdminAbsolutePathFromRequest($request));
+    }
+
+    public function testUrlWithCustomEntrypoint()
     {
         $server = [
             'HTTP_HOST' => 'localhost',
@@ -85,12 +104,12 @@ class UrlGeneratorTest extends TestCase
         $request = new Request([], [], [], [], [], $server);
 
         $expectedAbsoluteUrlPathToShop = '/';
-        $expectedAbsoluteUrlPathToAdmin = '/wololo';
+        $expectedAbsoluteUrlPathToAdmin = '/admin-wololo';
         $this->assertSame($expectedAbsoluteUrlPathToShop, $this->urlGenerator->getShopAbsolutePathFromRequest($request));
         $this->assertSame($expectedAbsoluteUrlPathToAdmin, $this->urlGenerator->getShopAdminAbsolutePathFromRequest($request));
     }
 
-    public function testGetShopUrlReturnsUrlWithShopInSubFolderAndParams()
+    public function testUrlWithShopInSubFolderAndParams()
     {
         $server = [
             'HTTP_HOST' => 'localhost',
@@ -104,7 +123,7 @@ class UrlGeneratorTest extends TestCase
         $request = new Request([], [], [], [], [], $server);
 
         $expectedAbsoluteUrlPathToShop = '/hello-world';
-        $expectedAbsoluteUrlPathToAdmin = '/hello-world/wololo';
+        $expectedAbsoluteUrlPathToAdmin = '/hello-world/admin-wololo';
         $this->assertSame($expectedAbsoluteUrlPathToShop, $this->urlGenerator->getShopAbsolutePathFromRequest($request));
         $this->assertSame($expectedAbsoluteUrlPathToAdmin, $this->urlGenerator->getShopAdminAbsolutePathFromRequest($request));
     }

--- a/tests/unit/Twig/AssetsEnvironmentTest.php
+++ b/tests/unit/Twig/AssetsEnvironmentTest.php
@@ -28,9 +28,8 @@ class AssetsEnvironmentTest extends TestCase
 
     protected function setUp()
     {
-        $shopBasePath = '/yo/doge';
-        $adminPath = 'wololo';
-        $this->assetsEnvironment = new AssetsEnvironment(new UrlGenerator($shopBasePath, $adminPath));
+        $adminPath = 'admin-wololo';
+        $this->assetsEnvironment = new AssetsEnvironment(new UrlGenerator($adminPath));
     }
 
     protected function tearDown()


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | In some environments, the URLs to load the JS and CSS files is incorrect. This PRs adds the case I met in the tests.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Run Update Assistant on all kinds of shops with the assets built in production mode. The UI must always work (you can at least navigate between pages). Try with a shop running on Docker, in a subfolder, on Windows if possible...
