### PR TITLE
[NEW UI] Add next step info + confirmation dialog

### DIFF
--- a/_dev/src/ts/appUI/pages/UpdatePagePostUpdate.ts
+++ b/_dev/src/ts/appUI/pages/UpdatePagePostUpdate.ts
@@ -17,11 +17,43 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */
 import StepPage from './StepPage';
+import api from '../api/RequestHandler';
 
 export default class UpdatePagePostUpdate extends StepPage {
   protected stepCode = 'post-update';
 
   public mount() {
     this.initStepper();
+    this.#handleHydrate();
   }
+
+  #handleHydrate = () => {
+    this.#addListenerToDialogConfirmModuleManagerLink();
+  };
+
+  #onClickDialogLink = async (event: MouseEvent) => {
+    const target = event.target as HTMLAnchorElement;
+
+    // Checks if the clicked element is an <a> tag pointing towards an ID
+    if (!target || target.tagName !== 'A' || !target.hash) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const hashRoute = target.hash.substring(1);
+    await api.post(hashRoute);
+  };
+
+  #addListenerToDialogConfirmModuleManagerLink = () => {
+    this.#dialogConfirmModuleManagerLink.addEventListener('click', this.#onClickDialogLink);
+  };
+
+  get #dialogConfirmModuleManagerLink(): HTMLAnchorElement {
+    const link = document.getElementById('dialog-confirm-module-manager-link');
+    if (!link) {
+      throw new Error('Dialog trigger link not found');
+    }
+    return link as HTMLAnchorElement;
+  }  
 }

--- a/_dev/src/ts/appUI/pages/UpdatePagePostUpdate.ts
+++ b/_dev/src/ts/appUI/pages/UpdatePagePostUpdate.ts
@@ -52,7 +52,7 @@ export default class UpdatePagePostUpdate extends StepPage {
   get #dialogConfirmModuleManagerLink(): HTMLAnchorElement {
     const link = document.getElementById('dialog-confirm-module-manager-link');
     if (!link) {
-      throw new Error('Dialog trigger link not found');
+      throw new Error('Dialog trigger link ID was not found');
     }
     return link as HTMLAnchorElement;
   }  

--- a/_dev/src/ts/appUI/pages/UpdatePagePostUpdate.ts
+++ b/_dev/src/ts/appUI/pages/UpdatePagePostUpdate.ts
@@ -24,12 +24,12 @@ export default class UpdatePagePostUpdate extends StepPage {
 
   public mount() {
     this.initStepper();
-    this.#handleHydrate();
+    this.#addListenerToDialogConfirmModuleManagerLink();
   }
 
-  #handleHydrate = () => {
-    this.#addListenerToDialogConfirmModuleManagerLink();
-  };
+  public beforeDestroy() {
+    this.#removeListenerToDialogConfirmModuleManagerLink();
+  }
 
   #onClickDialogLink = async (event: MouseEvent) => {
     const target = event.target as HTMLAnchorElement;
@@ -47,6 +47,10 @@ export default class UpdatePagePostUpdate extends StepPage {
 
   #addListenerToDialogConfirmModuleManagerLink = () => {
     this.#dialogConfirmModuleManagerLink.addEventListener('click', this.#onClickDialogLink);
+  };
+
+  #removeListenerToDialogConfirmModuleManagerLink = () => {
+    this.#dialogConfirmModuleManagerLink.removeEventListener('click', this.#onClickDialogLink);
   };
 
   get #dialogConfirmModuleManagerLink(): HTMLAnchorElement {

--- a/_dev/src/ts/appUI/pages/UpdatePagePostUpdate.ts
+++ b/_dev/src/ts/appUI/pages/UpdatePagePostUpdate.ts
@@ -24,11 +24,11 @@ export default class UpdatePagePostUpdate extends StepPage {
 
   public mount() {
     this.initStepper();
-    this.#addListenerToDialogConfirmModuleManagerLink();
+    this.#dialogConfirmModuleManagerLink.addEventListener('click', this.#onClickDialogLink);
   }
 
   public beforeDestroy() {
-    this.#removeListenerToDialogConfirmModuleManagerLink();
+    this.#dialogConfirmModuleManagerLink.removeEventListener('click', this.#onClickDialogLink);
   }
 
   #onClickDialogLink = async (event: MouseEvent) => {
@@ -43,14 +43,6 @@ export default class UpdatePagePostUpdate extends StepPage {
 
     const hashRoute = target.hash.substring(1);
     await api.post(hashRoute);
-  };
-
-  #addListenerToDialogConfirmModuleManagerLink = () => {
-    this.#dialogConfirmModuleManagerLink.addEventListener('click', this.#onClickDialogLink);
-  };
-
-  #removeListenerToDialogConfirmModuleManagerLink = () => {
-    this.#dialogConfirmModuleManagerLink.removeEventListener('click', this.#onClickDialogLink);
   };
 
   get #dialogConfirmModuleManagerLink(): HTMLAnchorElement {

--- a/_dev/src/ts/appUI/pages/UpdatePagePostUpdate.ts
+++ b/_dev/src/ts/appUI/pages/UpdatePagePostUpdate.ts
@@ -55,5 +55,5 @@ export default class UpdatePagePostUpdate extends StepPage {
       throw new Error('Dialog trigger link ID was not found');
     }
     return link as HTMLAnchorElement;
-  }  
+  }
 }

--- a/classes/Router/Routes.php
+++ b/classes/Router/Routes.php
@@ -60,6 +60,7 @@ class Routes
     /* step: post update */
     const UPDATE_PAGE_POST_UPDATE = 'update-page-post-update';
     const UPDATE_STEP_POST_UPDATE = 'update-step-post-update';
+    const UPDATE_STEP_POST_UPDATE_CONFIRM_MODULE_MANAGER_DIALOG = 'update-step-post-update-confirm-module-manager-dialog';
 
     /* RESTORE PAGE */
     /* step: backup selection */

--- a/classes/Router/RoutesConfig.php
+++ b/classes/Router/RoutesConfig.php
@@ -169,6 +169,10 @@ class RoutesConfig
                 'controller' => UpdatePagePostUpdateController::class,
                 'method' => 'step',
             ],
+            Routes::UPDATE_STEP_POST_UPDATE_CONFIRM_MODULE_MANAGER_DIALOG => [
+                'controller' => UpdatePagePostUpdateController::class,
+                'method' => 'confirmModuleManagerDialog',
+            ],
             /* RESTORE PAGE */
             /* step: backup selection */
             Routes::RESTORE_PAGE_BACKUP_SELECTION => [

--- a/controllers/admin/self-managed/UpdatePagePostUpdateController.php
+++ b/controllers/admin/self-managed/UpdatePagePostUpdateController.php
@@ -21,13 +21,17 @@
 
 namespace PrestaShop\Module\AutoUpgrade\Controller;
 
+use Context;
+use PrestaShop\Module\AutoUpgrade\AjaxResponseBuilder;
 use PrestaShop\Module\AutoUpgrade\DocumentationLinks;
 use PrestaShop\Module\AutoUpgrade\Router\Routes;
 use PrestaShop\Module\AutoUpgrade\Task\TaskType;
+use PrestaShop\Module\AutoUpgrade\Twig\PageSelectors;
 use PrestaShop\Module\AutoUpgrade\Twig\Steps\Stepper;
 use PrestaShop\Module\AutoUpgrade\Twig\Steps\UpdateSteps;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 use PrestaShop\Module\AutoUpgrade\VersionUtils;
+use Symfony\Component\HttpFoundation\JsonResponse;
 
 class UpdatePagePostUpdateController extends AbstractPageWithStepController
 {
@@ -66,7 +70,24 @@ class UpdatePagePostUpdateController extends AbstractPageWithStepController
                 'dev_doc_link' => DocumentationLinks::getDevDocUpdateAssistantPostUpdateUrl($currentMajorVersion),
                 'download_logs' => $this->upgradeContainer->getLogsService()->getDownloadLogsData(TaskType::TASK_TYPE_UPDATE),
                 'ps_version' => $this->upgradeContainer->getCurrentPrestaShopVersion(),
+                'form_route_to_confirm_module_manager_dialog' => Routes::UPDATE_STEP_POST_UPDATE_CONFIRM_MODULE_MANAGER_DIALOG,
             ]
+        );
+    }
+
+    public function confirmModuleManagerDialog(): JsonResponse
+    {
+        $adminPath = $this->upgradeContainer->getUrlGenerator()->getShopAdminAbsolutePathFromRequest($this->request);
+        $moduleManagerLink = $adminPath . '/index.php?controller=AdminLogin&redirect=AdminModules';
+
+        return AjaxResponseBuilder::hydrationResponse(
+            PageSelectors::DIALOG_PARENT_ID,
+            $this->getTwig()->render(
+                '@ModuleAutoUpgrade/dialogs/dialog-confirm-module-manager.html.twig',
+                [
+                    'module_manager_link' => $moduleManagerLink,
+                ]
+            )
         );
     }
 }

--- a/controllers/admin/self-managed/UpdatePagePostUpdateController.php
+++ b/controllers/admin/self-managed/UpdatePagePostUpdateController.php
@@ -77,8 +77,8 @@ class UpdatePagePostUpdateController extends AbstractPageWithStepController
 
     public function confirmModuleManagerDialog(): JsonResponse
     {
-        $adminPath = $this->upgradeContainer->getUrlGenerator()->getShopAdminAbsolutePathFromRequest($this->request);
-        $moduleManagerLink = $adminPath . '/index.php?controller=AdminLogin&redirect=AdminModules';
+        $this->upgradeContainer->initPrestaShopCore();
+        $moduleManagerLink = Context::getContext()->link->getAdminLink('AdminModules');
 
         return AjaxResponseBuilder::hydrationResponse(
             PageSelectors::DIALOG_PARENT_ID,

--- a/storybook/stories/components/DialogConfirmModuleManager.stories.js
+++ b/storybook/stories/components/DialogConfirmModuleManager.stories.js
@@ -17,31 +17,20 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */
 
-import PostUpdatePage from "../../../views/templates/pages/update.html.twig";
-import { PostUpdate as Stepper } from "../components/Stepper.stories";
+import DialogConfirmModuleManager from "../../../views/templates/dialogs/dialog-confirm-module-manager.html.twig";
 
 export default {
-  component: PostUpdatePage,
-  id: "35",
-  title: "Pages/Update",
+  title: "Components/Dialog",
+  component: DialogConfirmModuleManager,
 };
 
-export const PostUpdate = {
+export const ConfirmModuleManager = {
   args: {
-    // Step
-    step: {
-      code: "post-update",
-      title: "Post-update checklist",
-    },
-    step_parent_id: "ua_container",
-    exit_link: "#",
-    dev_doc_link: "#",
-    data_transparency_link:
-      "https://www.prestashop-project.org/data-transparency",
-    admin_url: "#",
-    ps_version: "9.0.0",
-    form_route_to_confirm_module_manager_dialog: "#",
-    // Stepper
-    ...Stepper.args,
+    form_route_to_confirm_module_manager_dialog: "/",
+    module_manager_link: "/",
+  },
+  play: async () => {
+    const dialog = document.querySelector(".dialog");
+    dialog.showModal();
   },
 };

--- a/views/templates/dialogs/dialog-confirm-module-manager.html.twig
+++ b/views/templates/dialogs/dialog-confirm-module-manager.html.twig
@@ -1,4 +1,4 @@
-/**
+{#**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -15,33 +15,26 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
- */
+ *#}
+{% extends "@ModuleAutoUpgrade/components/dialog.html.twig" %}
 
-import PostUpdatePage from "../../../views/templates/pages/update.html.twig";
-import { PostUpdate as Stepper } from "../components/Stepper.stories";
+{% set title = 'Access the Module Manager?'|trans({}) %}
+{% set dialogSize = 'sm' %}
+{% set message = 'To reach the module manager, you will be logged out of your session and will have to log in again. Do you want to continue?'|trans({}) %}
 
-export default {
-  component: PostUpdatePage,
-  id: "35",
-  title: "Pages/Update",
-};
+{% block dialog_content %}
+  {{ parent() }}
+{% endblock %}
 
-export const PostUpdate = {
-  args: {
-    // Step
-    step: {
-      code: "post-update",
-      title: "Post-update checklist",
-    },
-    step_parent_id: "ua_container",
-    exit_link: "#",
-    dev_doc_link: "#",
-    data_transparency_link:
-      "https://www.prestashop-project.org/data-transparency",
-    admin_url: "#",
-    ps_version: "9.0.0",
-    form_route_to_confirm_module_manager_dialog: "#",
-    // Stepper
-    ...Stepper.args,
-  },
-};
+{% block dialog_extra_content %}{% endblock %}
+
+{% block dialog_footer_inner %}
+  <button type="button" class="btn btn-link" data-dismiss="dialog">
+    {{ 'Cancel'|trans({}) }}
+  </button>
+
+  <a class="btn btn-primary" href="{{ module_manager_link }}">
+    <i class="material-icons">exit_to_app</i>
+    {{ 'Go to Module Manager'|trans({}) }}
+  </a>
+{% endblock %}

--- a/views/templates/steps/post-update.html.twig
+++ b/views/templates/steps/post-update.html.twig
@@ -62,6 +62,14 @@
             '%endbold%': '</b>'
           })|raw }}
         </li>
+        <li>
+          {{ '%startbold%Check the %startlink%Module Manager%endlink%%endbold% to discover and install the modules extracted on your server during the update process.'|trans({
+            '%startbold%': '<b>',
+            '%endbold%': '</b>',
+            '%startlink%': '<a id="dialog-confirm-module-manager-link" class="link" href="#' ~ form_route_to_confirm_module_manager_dialog ~ '">',
+            '%endlink%': '</a>'
+          })|raw }}
+        </li>
       </ul>
     </div>
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add new line in next step info on the post update page with a confirmation dialog
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | --
| Sponsor company   | @PrestaShopCorp
| How to test?      | --

- Run a successful update. On the post-update page, you should see a new line in the Next Step section that says:
"Check the Module Manager to discover and install the modules extracted on your server during the update process."
- When you click on the "Module Manager" link, a dialog should open.
- Inside the dialog, if you click the "Go to Module Manager" link, you'll be redirected to the login page.
- After logging in, you should be redirected to the Module Manager page.
