### PR TITLE
Handle manually the creation of symlinks while creating a ZIP archive

### DIFF
--- a/classes/Parameters/UpgradeFileNames.php
+++ b/classes/Parameters/UpgradeFileNames.php
@@ -58,15 +58,6 @@ class UpgradeFileNames
     const FILES_TO_UPGRADE_LIST = 'filesToUpgrade.list';
 
     /**
-     * during upgradeFiles process,
-     * this files contains the list of symbolic links left to upgrade in a serialized array.
-     * (this file is deleted in init() method if you reload the page).
-     *
-     * @var string
-     */
-    const SYMLINKS_TO_UPGRADE_LIST = 'symLinksToUpgrade.list';
-
-    /**
      * during updateDatabase process,
      * this files contains the list of queries left to execute in a serialized array.
      * (this file is deleted in init() method if you reload the page).
@@ -156,7 +147,6 @@ class UpgradeFileNames
     public static $update_tmp_files = [
         'STATE_FILENAME' => self::STATE_UPDATE_FILENAME,
         'FILES_TO_UPGRADE_LIST' => self::FILES_TO_UPGRADE_LIST,
-        'SYMLINKS_TO_UPGRADE_LIST' => self::SYMLINKS_TO_UPGRADE_LIST,
         'FILES_TO_REMOVE_LIST' => self::FILES_TO_REMOVE_LIST,
         'MODULES_TO_UPGRADE_LIST' => self::MODULES_TO_UPGRADE_LIST,
         'MODULE_SOURCE_PROVIDER_CACHE_LOCAL' => self::MODULE_SOURCE_PROVIDER_CACHE_LOCAL,

--- a/classes/Task/Update/UpdateFiles.php
+++ b/classes/Task/Update/UpdateFiles.php
@@ -120,7 +120,11 @@ class UpdateFiles extends AbstractTask
         }
 
         if (is_link($orig)) {
-            $symLinkTarget = readlink($orig);
+            $rawSymlink = readlink($orig);
+            // Windows resolves the symlink target to an absolute path. We restore the original path.
+            $symLinkTarget = $this->container->getFileSystem()->isAbsolutePath($rawSymlink)
+                ? $this->container->getFileSystem()->makePathRelative(readlink($orig), pathinfo($orig, PATHINFO_DIRNAME))
+                : $rawSymlink;
 
             if ($this->container->getFileSystem()->exists($dest)) {
                 $this->container->getFileSystem()->remove($dest);

--- a/classes/Task/Update/UpdateFiles.php
+++ b/classes/Task/Update/UpdateFiles.php
@@ -73,7 +73,6 @@ class UpdateFiles extends AbstractTask
 
             // Note - upgrade this file means do whatever is needed for that file to be in the final state, delete included.
             if (!$this->upgradeThisFile($file)) {
-                // put the file back to the begin of the list
                 $this->next = TaskName::TASK_ERROR;
                 $this->logger->error($this->translator->trans('Error when trying to update file %s.', [$file]));
                 break;
@@ -100,7 +99,7 @@ class UpdateFiles extends AbstractTask
      *
      * @throws Exception
      */
-    public function upgradeThisFile($orig): bool
+    protected function upgradeThisFile($orig): bool
     {
         // translations_custom and mails_custom list are currently not used
         // later, we could handle customization with some kind of diff functions
@@ -123,14 +122,14 @@ class UpdateFiles extends AbstractTask
             $rawSymlink = readlink($orig);
             // Windows resolves the symlink target to an absolute path. We restore the original path.
             $symLinkTarget = $this->container->getFileSystem()->isAbsolutePath($rawSymlink)
-                ? $this->container->getFileSystem()->makePathRelative(readlink($orig), pathinfo($orig, PATHINFO_DIRNAME))
+                ? $this->container->getFileSystem()->makePathRelative($rawSymlink, pathinfo($orig, PATHINFO_DIRNAME))
                 : $rawSymlink;
 
-            if ($this->container->getFileSystem()->exists($dest)) {
-                $this->container->getFileSystem()->remove($dest);
-            }
-
             try {
+                if ($this->container->getFileSystem()->exists($dest)) {
+                    $this->container->getFileSystem()->remove($dest);
+                }
+
                 $this->container->getFileSystem()->symlink($symLinkTarget, $dest);
                 $this->logger->debug($this->translator->trans('Created link %s to %s.', [$file, $symLinkTarget]));
 

--- a/classes/Task/Update/UpdateFiles.php
+++ b/classes/Task/Update/UpdateFiles.php
@@ -267,7 +267,7 @@ class UpdateFiles extends AbstractTask
             return ExitCode::FAIL;
         }
         // $diffFileList now contains an array with a list of changed and deleted files.
-        // We only keep list of files to delete. The modified files will be listed in list_files_to_upgrade below.
+        // We only keep list of files to delete. The modified files will be listed in listFilesToUpgrade below.
         $diffFileList = $diffFileList['deleted'];
 
         // Admin folder name in this deleted files list is standard /admin/.
@@ -285,26 +285,26 @@ class UpdateFiles extends AbstractTask
         }
 
         // Now, we get the list of files that are either new or must be modified
-        $list_files_to_upgrade = $this->container->getFilesystemAdapter()->listFilesInDir(
+        $listFilesToUpgrade = $this->container->getFilesystemAdapter()->listFilesInDir(
             $newReleasePath, 'upgrade', true
         );
 
         // Add our previously created list of deleted files
-        $list_files_to_upgrade = array_reverse(array_merge($diffFileList, $list_files_to_upgrade));
+        $listFilesToUpgrade = array_reverse(array_merge($diffFileList, $listFilesToUpgrade));
 
-        $total_files_to_upgrade = count($list_files_to_upgrade);
+        $totalFilesToUpgrade = count($listFilesToUpgrade);
         $this->container->getFileStorage()->save(
-            (new Backlog($list_files_to_upgrade, $total_files_to_upgrade))->dump(),
+            (new Backlog($listFilesToUpgrade, $totalFilesToUpgrade))->dump(),
             UpgradeFileNames::FILES_TO_UPGRADE_LIST
         );
 
-        if ($total_files_to_upgrade === 0) {
+        if ($totalFilesToUpgrade === 0) {
             $this->logger->error($this->translator->trans('Unable to find files to update.'));
             $this->next = TaskName::TASK_ERROR;
 
             return ExitCode::FAIL;
         }
-        $this->logger->info($this->translator->trans('%s files will be updated.', [$total_files_to_upgrade]));
+        $this->logger->info($this->translator->trans('%s files will be updated.', [$totalFilesToUpgrade]));
         $this->next = TaskName::TASK_UPDATE_FILES;
         $this->stepDone = false;
 

--- a/classes/Task/Update/UpdateFiles.php
+++ b/classes/Task/Update/UpdateFiles.php
@@ -118,7 +118,26 @@ class UpdateFiles extends AbstractTask
 
             return true;
         }
-        if (is_dir($orig)) {
+
+        if (is_link($orig)) {
+            $symLinkTarget = readlink($orig);
+
+            if ($this->container->getFileSystem()->exists($dest)) {
+                $this->container->getFileSystem()->remove($dest);
+            }
+
+            try {
+                $this->container->getFileSystem()->symlink($symLinkTarget, $dest);
+                $this->logger->debug($this->translator->trans('Created link %s to %s.', [$file, $symLinkTarget]));
+
+                return true;
+            } catch (IOException $e) {
+                $this->next = TaskName::TASK_ERROR;
+                $this->logger->error($this->translator->trans('Error while creating link %s: %s', [$file, $e->getMessage()]));
+
+                return false;
+            }
+        } elseif (is_dir($orig)) {
             // if $dest is not a directory (that can happen), just remove that file
             if (!is_dir($dest) && $this->container->getFileSystem()->exists($dest)) {
                 $this->container->getFileSystem()->remove($dest);

--- a/classes/Task/Update/UpdateFiles.php
+++ b/classes/Task/Update/UpdateFiles.php
@@ -59,39 +59,24 @@ class UpdateFiles extends AbstractTask
         $filesToUpgrade = Backlog::fromContents(
             $this->container->getFileStorage()->load(UpgradeFileNames::FILES_TO_UPGRADE_LIST)
         );
-        $symlinksToUpdate = Backlog::fromContents(
-            $this->container->getFileStorage()->load(UpgradeFileNames::SYMLINKS_TO_UPGRADE_LIST)
-        );
 
         // @TODO : does not upgrade files in modules, translations if they have not a correct md5 (or crc32, or whatever) from previous version
         for ($i = 0; $i < $this->container->getUpdateConfiguration()->getNumberOfFilesPerCall(); ++$i) {
-            $hasAtLeastOneFileToUpdate = $filesToUpgrade->getRemainingTotal();
-
-            if (!$hasAtLeastOneFileToUpdate && !$symlinksToUpdate->getRemainingTotal()) {
+            if (!$filesToUpgrade->getRemainingTotal()) {
                 $this->next = TaskName::TASK_UPDATE_DATABASE;
                 $this->logger->info($this->translator->trans('All files updated. Now updating database...'));
                 $this->stepDone = true;
                 break;
             }
 
-            if ($hasAtLeastOneFileToUpdate) {
-                $file = $filesToUpgrade->getNext();
+            $file = $filesToUpgrade->getNext();
 
-                // Note - upgrade this file means do whatever is needed for that file to be in the final state, delete included.
-                if (!$this->upgradeThisFile($file)) {
-                    $this->next = TaskName::TASK_ERROR;
-                    $this->logger->error($this->translator->trans('Error when trying to update file %s.', [$file]));
-                    break;
-                }
-            } else {
-                // If there was no file to update, reaching this part of the code means we have symbolic links to update
-                /** @var array{'name':string,'target':string} */
-                $symlink = $symlinksToUpdate->getNext();
-                if (!$this->updateThisSymbolicLink($symlink['name'], $symlink['target'])) {
-                    $this->next = TaskName::TASK_ERROR;
-                    $this->logger->error($this->translator->trans('Error when trying to update link %s.', [$symlink['name']]));
-                    break;
-                }
+            // Note - upgrade this file means do whatever is needed for that file to be in the final state, delete included.
+            if (!$this->upgradeThisFile($file)) {
+                // put the file back to the begin of the list
+                $this->next = TaskName::TASK_ERROR;
+                $this->logger->error($this->translator->trans('Error when trying to update file %s.', [$file]));
+                break;
             }
         }
         $this->container->getUpdateState()->setProgressPercentage(
@@ -115,11 +100,12 @@ class UpdateFiles extends AbstractTask
      *
      * @throws Exception
      */
-    protected function upgradeThisFile($orig): bool
+    public function upgradeThisFile($orig): bool
     {
         // translations_custom and mails_custom list are currently not used
         // later, we could handle customization with some kind of diff functions
         // for now, just copy $file in str_replace($this->latestRootDir,_PS_ROOT_DIR_)
+
         $file = str_replace($this->container->getProperty(UpgradeContainer::TMP_FILES_PATH), '', $orig);
 
         // The path to the file in our prestashop directory
@@ -132,12 +118,6 @@ class UpdateFiles extends AbstractTask
 
             return true;
         }
-
-        /*
-         * Note about symlinks: This is the place where we expected to handle symbolic links.
-         * Unfortunately, PHP does not extract them properly from the archive (see https://bugs.php.net/bug.php?id=46013).
-         * They will be handled in a dedicated backlog by relying on the XML files instead.
-         */
         if (is_dir($orig)) {
             // if $dest is not a directory (that can happen), just remove that file
             if (!is_dir($dest) && $this->container->getFileSystem()->exists($dest)) {
@@ -215,21 +195,6 @@ class UpdateFiles extends AbstractTask
         }
     }
 
-    protected function updateThisSymbolicLink(string $symLinkFile, string $symLinkTarget): bool
-    {
-        $file = $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH) . DIRECTORY_SEPARATOR . $symLinkFile;
-
-        // Remove the file/folder, it already exists from $this->upgradeThisFile(...)
-        if ($this->container->getFileSystem()->exists($file)) {
-            $this->container->getFileSystem()->remove($file);
-        }
-
-        $this->container->getFileSystem()->symlink($symLinkTarget, $file);
-        $this->logger->debug($this->translator->trans('Created link %s to %s.', [$symLinkFile, $symLinkTarget]));
-
-        return true;
-    }
-
     /**
      * First call of this task needs a warmup, where we load the files list to be upgraded.
      *
@@ -283,7 +248,7 @@ class UpdateFiles extends AbstractTask
             return ExitCode::FAIL;
         }
         // $diffFileList now contains an array with a list of changed and deleted files.
-        // We only keep list of files to delete. The modified files will be listed in listFilesToUpgrade below.
+        // We only keep list of files to delete. The modified files will be listed in list_files_to_upgrade below.
         $diffFileList = $diffFileList['deleted'];
 
         // Admin folder name in this deleted files list is standard /admin/.
@@ -293,53 +258,34 @@ class UpdateFiles extends AbstractTask
             if (preg_match('#autoupgrade#', $path)) {
                 unset($diffFileList[$k]);
             } elseif (substr($path, 0, 6) === '/admin') {
-                // Please make sure that the condition to check if the string starts with /admin stays here,
-                // because it was replacing "admin" even in the middle of a path, not deleting some files as a result.
+                // Please make sure that the condition to check if the string starts with /admin stays here, because it was replacing
+                // admin even in the middle of a path, not deleting some files as a result.
                 // Also, do not use DIRECTORY_SEPARATOR, keep forward slash, because the path come from the XML standardized.
                 $diffFileList[$k] = '/' . $admin_dir . substr($path, 6);
             }
         }
 
-        // Prepare symbolic links list
-        $symbolicLinks = $this->container->getChecksumCompare()->getSymbolicLinks($state->getDestinationVersion());
-
-        /** @var array{'name':string,'target':string} $symlink */
-        foreach ($symbolicLinks as &$symlink) {
-            if (substr($symlink['name'], 0, 6) === 'admin/') {
-                // Please make sure that the condition to check if the string starts with /admin stays here,
-                // because it was replacing "admin" even in the middle of a path, not deleting some files as a result.
-                // Also, do not use DIRECTORY_SEPARATOR, keep forward slash, because the path come from the XML standardized.
-                $symlink['name'] = $admin_dir . '/' . substr($symlink['name'], 6);
-            }
-        }
-
-        $totalSymbolicLinks = count($symbolicLinks);
-        $this->container->getFileStorage()->save(
-            (new Backlog($symbolicLinks, $totalSymbolicLinks))->dump(),
-            UpgradeFileNames::SYMLINKS_TO_UPGRADE_LIST
-        );
-
         // Now, we get the list of files that are either new or must be modified
-        $listFilesToUpgrade = $this->container->getFilesystemAdapter()->listFilesInDir(
+        $list_files_to_upgrade = $this->container->getFilesystemAdapter()->listFilesInDir(
             $newReleasePath, 'upgrade', true
         );
 
         // Add our previously created list of deleted files
-        $listFilesToUpgrade = array_reverse(array_merge($diffFileList, $listFilesToUpgrade));
+        $list_files_to_upgrade = array_reverse(array_merge($diffFileList, $list_files_to_upgrade));
 
-        $totalFilesToUpgrade = count($listFilesToUpgrade);
+        $total_files_to_upgrade = count($list_files_to_upgrade);
         $this->container->getFileStorage()->save(
-            (new Backlog($listFilesToUpgrade, $totalFilesToUpgrade))->dump(),
+            (new Backlog($list_files_to_upgrade, $total_files_to_upgrade))->dump(),
             UpgradeFileNames::FILES_TO_UPGRADE_LIST
         );
 
-        if ($totalFilesToUpgrade === 0 && $totalSymbolicLinks === 0) {
+        if ($total_files_to_upgrade === 0) {
             $this->logger->error($this->translator->trans('Unable to find files to update.'));
             $this->next = TaskName::TASK_ERROR;
 
             return ExitCode::FAIL;
         }
-        $this->logger->info($this->translator->trans('%s files will be updated.', [$totalFilesToUpgrade + $totalSymbolicLinks]));
+        $this->logger->info($this->translator->trans('%s files will be updated.', [$total_files_to_upgrade]));
         $this->next = TaskName::TASK_UPDATE_FILES;
         $this->stepDone = false;
 

--- a/classes/Xml/ChecksumCompare.php
+++ b/classes/Xml/ChecksumCompare.php
@@ -144,18 +144,6 @@ class ChecksumCompare
         return $this->fileDifferences;
     }
 
-    /**
-     * @param string $version
-     *
-     * @return string[] Indexed by relative path from root folder, value is the symbolic link target
-     */
-    public function getSymbolicLinks(string $version): array
-    {
-        $checksum = $this->fileLoader->getXmlMd5File($version);
-
-        return $this->symbolicLinksAsArray($checksum->ps_root_dir[0]);
-    }
-
     public function isAuthenticPrestashopVersion(string $version): bool
     {
         return !$this->getTamperedFilesOnShop($version);
@@ -269,27 +257,6 @@ class ChecksumCompare
         }
 
         return $array;
-    }
-
-    /**
-     * @return array<string, string>
-     */
-    protected function symbolicLinksAsArray(SimpleXMLElement $node, string $dir = ''): array
-    {
-        $links = [];
-        foreach ($node as $child) {
-            if (is_object($child) && $child->getName() == 'dir') {
-                $subDir = $dir ? $dir . DIRECTORY_SEPARATOR : '';
-                $subDir .= (string) $child['name'];
-                $subDirLinks = $this->symbolicLinksAsArray($child, $subDir);
-                $links = $links + $subDirLinks;
-            } elseif (is_object($child) && $child->getName() == 'link') {
-                $linkName = (string) $child['name'];
-                $links[] = ['name' => $dir . DIRECTORY_SEPARATOR . $linkName, 'target' => (string) $child];
-            }
-        }
-
-        return $links;
     }
 
     /** populate $this->$this->file_differences with $path

--- a/classes/ZipAction.php
+++ b/classes/ZipAction.php
@@ -91,7 +91,13 @@ class ZipAction
                 continue;
             }
 
-            if (!$zip->addFile($file, $archiveFilename)) {
+            if (is_link($file)) {
+                $result = $this->addSymlink($file, $archiveFilename, $zip);
+            } else {
+                $result = $zip->addFile($file, $archiveFilename);
+            }
+
+            if (!$result) {
                 $error = $zip->getStatusString();
                 // if an error occur, it's more safe to delete the corrupted backup
                 $zip->close();
@@ -132,6 +138,18 @@ class ZipAction
         }
 
         return true;
+    }
+
+    private function addSymlink(string $file, string $archiveFilename, ZipArchive $zip): bool
+    {
+        $targetPath = readlink($file);
+        $stat = lstat($file);
+
+        return $zip->addFromString($archiveFilename, $targetPath)
+            && $zip->setExternalAttributesName($archiveFilename,
+                ZipArchive::OPSYS_UNIX,
+                $stat['mode'] << 16
+            );
     }
 
     /**

--- a/classes/ZipAction.php
+++ b/classes/ZipAction.php
@@ -184,7 +184,31 @@ class ZipAction
 
         for ($i = 0; $i < $zip->numFiles; ++$i) {
             $nameIndex = $zip->getNameIndex($i);
-            if (!$zip->extractTo($to_dir, [$nameIndex])) {
+            $zip->getExternalAttributesName($nameIndex, $opsys, $stat);
+
+            /*
+             * Symlink case. Matches octal value 12000 and does not end with a separator
+             * @see https://discuss.python.org/t/how-info-zip-represents-symlinks/4104/2
+             * @see https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT - 4.5.7 -UNIX Extra Field (0x000d):
+             */
+            if ($opsys === ZipArchive::OPSYS_UNIX && $this->isCompressedFileASymLink($stat, $nameIndex)) {
+                try {
+                    $this->filesystem->symlink($zip->getFromIndex($i), $to_dir . DIRECTORY_SEPARATOR . $nameIndex);
+                } catch (IOException $e) {
+                    $this->logger->error(
+                        $this->translator->trans(
+                            'Could not extract symbolic link %file% from archive: %error%',
+                            [
+                                '%file%' => $nameIndex,
+                                '%error%' => $e->getMessage(),
+                            ]
+                        )
+                    );
+                    $zip->close();
+
+                    return false;
+                }
+            } elseif (!$zip->extractTo($to_dir, [$nameIndex])) {
                 $issue = $zip->getStatusString() ?: $this->translator->trans('Unknown extraction error (possible permission issue or filesystem error)');
 
                 $fullDiskPath = rtrim($to_dir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $nameIndex;
@@ -339,5 +363,10 @@ class ZipAction
         }
 
         return $pass;
+    }
+
+    public function isCompressedFileASymLink(int $stat, string $file): bool
+    {
+        return (($stat >> 16) & 0120000) === 0120000 && !in_array(substr($file, -1), ['/', '\\']);
     }
 }

--- a/classes/ZipAction.php
+++ b/classes/ZipAction.php
@@ -186,18 +186,13 @@ class ZipAction
             $nameIndex = $zip->getNameIndex($i);
             $zip->getExternalAttributesName($nameIndex, $opsys, $stat);
 
-            /*
-             * Symlink case. Matches octal value 12000 and does not end with a separator
-             * @see https://discuss.python.org/t/how-info-zip-represents-symlinks/4104/2
-             * @see https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT - 4.5.7 -UNIX Extra Field (0x000d):
-             */
             if ($opsys === ZipArchive::OPSYS_UNIX && $this->isCompressedFileASymLink($stat, $nameIndex)) {
                 try {
                     $this->filesystem->symlink($zip->getFromIndex($i), $to_dir . DIRECTORY_SEPARATOR . $nameIndex);
                 } catch (IOException $e) {
-                    $this->logger->error(
+                    $this->logger->warning(
                         $this->translator->trans(
-                            'Could not extract symbolic link %file% from archive: %error%',
+                            'Could not extract link %file% from archive: %error%',
                             [
                                 '%file%' => $nameIndex,
                                 '%error%' => $e->getMessage(),
@@ -365,6 +360,11 @@ class ZipAction
         return $pass;
     }
 
+    /*
+     * Detect files stored as symlinks. Matches octal value 12000 and does not end with a separator
+     * @see https://discuss.python.org/t/how-info-zip-represents-symlinks/4104/2
+     * @see https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT - 4.5.7 -UNIX Extra Field (0x000d):
+     */
     public function isCompressedFileASymLink(int $stat, string $file): bool
     {
         return (($stat >> 16) & 0120000) === 0120000 && !in_array(substr($file, -1), ['/', '\\']);

--- a/tests/fixtures/checksum-compare/8.1.0.xml
+++ b/tests/fixtures/checksum-compare/8.1.0.xml
@@ -4,6 +4,9 @@
 		<dir name="admin">
 			<md5file name=".htaccess">f9801a6607a14db3eebab2da3a649716</md5file>
 			<md5file name="init.php">dc55d3ee8cd557eacc4e191643207698</md5file>
+			<dir name="bundles">
+				<link name="apiplatform">../../vendor/api-platform/core/src/Symfony/Bundle/Resources/public/</link>
+			</dir>
 		</dir>
 		<dir name="app">
 			<md5file name="AppKernel.php">37d3976fc4877231fa652567e4e02cd4</md5file>

--- a/tests/fixtures/checksum-compare/8.1.0.xml
+++ b/tests/fixtures/checksum-compare/8.1.0.xml
@@ -4,9 +4,6 @@
 		<dir name="admin">
 			<md5file name=".htaccess">f9801a6607a14db3eebab2da3a649716</md5file>
 			<md5file name="init.php">dc55d3ee8cd557eacc4e191643207698</md5file>
-			<dir name="bundles">
-				<link name="apiplatform">../../vendor/api-platform/core/src/Symfony/Bundle/Resources/public/</link>
-			</dir>
 		</dir>
 		<dir name="app">
 			<md5file name="AppKernel.php">37d3976fc4877231fa652567e4e02cd4</md5file>

--- a/tests/unit/Xml/ChecksumCompareTest.php
+++ b/tests/unit/Xml/ChecksumCompareTest.php
@@ -102,32 +102,4 @@ class ChecksumCompareTest extends TestCase
 
         $this->assertEquals($expected, $tamperedFiles);
     }
-
-    public function testGetSymbolicLinks()
-    {
-        $fileSystemAdapter = $this->getMockBuilder(FilesystemAdapter::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $fileLoader = $this->getMockBuilder(FileLoader::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getXmlMd5File'])
-            ->getMock();
-
-        $xmlFile = @simplexml_load_file(__DIR__ . '/../../fixtures/checksum-compare/8.1.0.xml');
-
-        $fileLoader->method('getXmlMd5File')
-            ->willReturn($xmlFile);
-
-        $checksumCompare = new ChecksumCompare($fileLoader, $fileSystemAdapter, __DIR__ . '/../../fixtures/checksum-compare/8.1.0', __DIR__ . '/../../fixtures/checksum-compare/8.1.0/adminTest');
-        $actual = $checksumCompare->getSymbolicLinks('8.1.0');
-        $expected = [
-            [
-                'name' => 'admin/bundles/apiplatform',
-                'target' => '../../vendor/api-platform/core/src/Symfony/Bundle/Resources/public/',
-            ],
-        ];
-
-        $this->assertEquals($expected, $actual);
-    }
 }

--- a/tests/unit/ZipActionTest.php
+++ b/tests/unit/ZipActionTest.php
@@ -20,6 +20,7 @@
 use PHPUnit\Framework\TestCase;
 use PrestaShop\Module\AutoUpgrade\Progress\Backlog;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
+use Symfony\Component\Filesystem\Filesystem;
 
 class ZipActionTest extends TestCase
 {
@@ -27,6 +28,7 @@ class ZipActionTest extends TestCase
     const IDENTICAL_CONTENT_FILE_PATH = __DIR__ . '/../fixtures/ArchiveExample/dummyFolder/AppKernelExample.php.txt';
     const NOT_IDENTICAL_CONTENT_FILE_PATH = __DIR__ . '/../fixtures/AppKernelExample.php.txt';
 
+    /** @var UpgradeContainer */
     private $container;
     private $contentExcepted;
 
@@ -37,7 +39,8 @@ class ZipActionTest extends TestCase
             'dummyFolder/AppKernelExample.php.txt',
         ];
 
-        $this->container = new UpgradeContainer(__DIR__, __DIR__ . '/..');
+        $rootDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid();
+        $this->container = new UpgradeContainer($rootDir, $rootDir . DIRECTORY_SEPARATOR . 'admin');
     }
 
     public function testArchiveContentWithZipArchive()
@@ -85,5 +88,61 @@ class ZipActionTest extends TestCase
 
         $this->assertTrue($zipAction->isFileUnchanged(self::IDENTICAL_CONTENT_FILE_PATH, 'dummyFolder/AppKernelExample.php.txt', $zip));
         $this->assertFalse($zipAction->isFileUnchanged(self::NOT_IDENTICAL_CONTENT_FILE_PATH, 'dummyFolder/AppKernelExample.php.txt', $zip));
+    }
+
+    public function testCompleteCompressionAndExtractionOfFiles()
+    {
+        $filesystem = new Filesystem();
+
+        // Create contents to be zipped and unzipped
+        $sourceFolder = $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH);
+        $destinationFolder = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid();
+        $temporaryZipFile = tempnam(sys_get_temp_dir(), 'mod');
+
+        $filesystem->mkdir([
+            $sourceFolder,
+            $sourceFolder . DIRECTORY_SEPARATOR . 'folder/folder2',
+            $destinationFolder,
+        ]);
+        $filesystem->touch([
+            $sourceFolder . DIRECTORY_SEPARATOR . 'file1.txt',
+            $sourceFolder . DIRECTORY_SEPARATOR . 'file2.txt',
+            $sourceFolder . DIRECTORY_SEPARATOR . 'folder/file3.txt',
+        ]);
+        $filesystem->symlink(
+            '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'file2.txt',
+            $sourceFolder . DIRECTORY_SEPARATOR . 'folder/folder2/file4.txt'
+        );
+
+        $backlog = new Backlog([
+            $sourceFolder . DIRECTORY_SEPARATOR . 'file1.txt',
+            $sourceFolder . DIRECTORY_SEPARATOR . 'file2.txt',
+            $sourceFolder . DIRECTORY_SEPARATOR . 'folder/file3.txt',
+            $sourceFolder . DIRECTORY_SEPARATOR . 'folder/folder2/file4.txt',
+        ], 4);
+
+        // Run
+        $zipAction = $this->container->getZipAction();
+        $resultOfCompress = $zipAction->compress($backlog, $temporaryZipFile);
+        $resultOfExtract = $zipAction->extract($temporaryZipFile, $destinationFolder);
+
+        // Check
+        $this->assertTrue($resultOfCompress);
+        $this->assertTrue($resultOfExtract);
+
+        echo $destinationFolder;
+
+        $this->assertTrue(is_dir($destinationFolder . DIRECTORY_SEPARATOR . 'folder'));
+        $this->assertTrue(is_dir($destinationFolder . DIRECTORY_SEPARATOR . 'folder/folder2'));
+
+        $this->assertTrue(is_file($destinationFolder . DIRECTORY_SEPARATOR . 'file1.txt'));
+        $this->assertTrue(is_file($destinationFolder . DIRECTORY_SEPARATOR . 'file2.txt'));
+        $this->assertTrue(is_file($destinationFolder . DIRECTORY_SEPARATOR . 'folder/file3.txt'));
+
+        $this->assertTrue(is_link($destinationFolder . DIRECTORY_SEPARATOR . 'folder/folder2/file4.txt'));
+        $this->assertSame(
+            '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'file2.txt',
+            readlink($destinationFolder . DIRECTORY_SEPARATOR . 'folder/folder2/file4.txt')
+        );
     }
 }

--- a/tests/unit/ZipActionTest.php
+++ b/tests/unit/ZipActionTest.php
@@ -130,8 +130,6 @@ class ZipActionTest extends TestCase
         $this->assertTrue($resultOfCompress);
         $this->assertTrue($resultOfExtract);
 
-        echo $destinationFolder;
-
         $this->assertTrue(is_dir($destinationFolder . DIRECTORY_SEPARATOR . 'folder'));
         $this->assertTrue(is_dir($destinationFolder . DIRECTORY_SEPARATOR . 'folder/folder2'));
 
@@ -144,5 +142,14 @@ class ZipActionTest extends TestCase
             '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'file2.txt',
             readlink($destinationFolder . DIRECTORY_SEPARATOR . 'folder/folder2/file4.txt')
         );
+    }
+
+    public function testCompressedFilesAreSimlinks()
+    {
+        $zipAction = $this->container->getZipAction();
+
+        $this->assertFalse($zipAction->isCompressedFileASymLink(2179792896, 'file.txt'));
+        $this->assertFalse($zipAction->isCompressedFileASymLink(2180841472, 'file.txt'));
+        $this->assertTrue($zipAction->isCompressedFileASymLink(2717843456, 'file.txt'));
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Now that we have handled symlinks while upgrading PrestaShop, it appears we now have to handle them on backup and restore.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/38493
| Sponsor company   | @PrestaShopCorp
| How to test?      | Making a backup and restoring a store with symlinks does not fail, and the extraction of a new release of PrestaShop with symlinks (i.e 9.0.0) still works.<ul><li>Update to PrestaShop v9 (from any version of PrestaShop). The update must succeed and a symbolic link `admin-dev/bundles/apiplatform` must exist.</li><li>Make a backup of a store running v9, try updating to a fake PrestaShop v.9.1. The process must succeed.</li><li>Restore to PrestaShop v9, The process must succeed.</li><li>Delete the symbolic link created by PrestaShop (`admin-dev/bundles/apiplatform`), then restore again to PrestaShop v9. It must be restored by the process.</li></ul>

## Roadmap:

- [x] Create a test suite to completely test the management of symlinks in ZIP archives
- [x] Handle symlinks on backup
- [x] Handle symlinks on restore
- [x] Improve previously merged https://github.com/PrestaShop/autoupgrade/pull/1187 with management of symlinks on update.