### PR TITLE
[v4] Use new API for xml md5

### DIFF
--- a/.github/action.yml
+++ b/.github/action.yml
@@ -8,7 +8,7 @@ runs:
         VERSION: ${{ matrix.from }}
       shell: bash
       run: |
-        bash -c '[[ "${VERSION}" == 1.6* ]] && docker-compose -f docker-compose-7.1.yml up -d || docker-compose -f docker-compose.yml up -d'
+        bash -c '[[ "${VERSION}" == 1.6* ]] && docker compose -f docker-compose-7.1.yml up -d || docker compose -f docker-compose.yml up -d'
         bash -c 'while [[ "$(curl -L -s -o /dev/null -w %{http_code} http://localhost:8001/index.php)" != "200" ]]; do sleep 5; done'
     - name: Copy autoupgrade module
       shell: bash

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.0.0
+        uses: actions/checkout@v4
       - name: Install composer dependencies
         run: composer install --no-dev -o
       - name: Clean-up project
@@ -19,17 +19,17 @@ jobs:
         run: |
           ~/.composer/vendor/bin/autoindex
       - name: Create & upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ github.event.repository.name }}
-          path: ../
+          path: .
   update_release_draft:
     runs-on: ubuntu-latest
     needs: [deploy]
     if: github.event_name == 'push' && github.event.ref == 'refs/heads/master'
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: ${{ github.event.repository.name }}
       - id: release_info
@@ -39,7 +39,7 @@ jobs:
       - name: Prepare for Release
         run: |
           cd ${{ github.event.repository.name }}
-          zip -r ${{ github.event.repository.name }}.zip ${{ github.event.repository.name }}
+          zip -r ${{ github.event.repository.name }}.zip ${{ github.event.repository.name }} .
       - name: Clean existing assets
         shell: bash
         run: |

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -28,16 +28,16 @@ jobs:
         presta-versions: [ '1.6.1.18', '1.7.6.9', '1.7.8.10' ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.0.0
+        uses: actions/checkout@v4
 
       - name: Cache vendor folder
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: vendor
           key: php-${{ hashFiles('composer.lock') }}
 
       - name: Cache composer folder
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache
           key: php-composer-cache

--- a/AdminSelfUpgrade.php
+++ b/AdminSelfUpgrade.php
@@ -269,9 +269,9 @@ class AdminSelfUpgrade extends AdminController
                 $upgrader->clearXmlMd5File($this->upgradeContainer->getProperty(UpgradeContainer::PS_VERSION));
                 $upgrader->clearXmlMd5File($upgrader->version_num);
                 if ($upgradeConfiguration->get('channel') == 'private' && !$upgradeConfiguration->get('private_allow_major')) {
-                    $upgrader->checkPSVersion(true, array('private', 'minor'));
+                    $upgrader->checkPSVersion(array('private', 'minor'));
                 } else {
-                    $upgrader->checkPSVersion(true, array('minor'));
+                    $upgrader->checkPSVersion(array('minor'));
                 }
                 Tools14::redirectAdmin(self::$currentIndex . '&conf=5&token=' . Tools14::getValue('token'));
             }

--- a/classes/ChannelInfo.php
+++ b/classes/ChannelInfo.php
@@ -56,9 +56,9 @@ class ChannelInfo
 
         if (in_array($channel, $publicChannels)) {
             if ($channel == 'private' && !$config->get('private_allow_major')) {
-                $upgrader->checkPSVersion(false, array('private', 'minor'));
+                $upgrader->checkPSVersion(array('private', 'minor'));
             } else {
-                $upgrader->checkPSVersion(false, array('minor'));
+                $upgrader->checkPSVersion(array('minor'));
             }
 
             $this->info = array(
@@ -77,9 +77,9 @@ class ChannelInfo
         switch ($channel) {
             case 'private':
                 if (!$config->get('private_allow_major')) {
-                    $upgrader->checkPSVersion(false, array('private', 'minor'));
+                    $upgrader->checkPSVersion(array('private', 'minor'));
                 } else {
-                    $upgrader->checkPSVersion(false, array('minor'));
+                    $upgrader->checkPSVersion(array('minor'));
                 }
 
                 $this->info = array(

--- a/classes/TaskRunner/Miscellaneous/CompareReleases.php
+++ b/classes/TaskRunner/Miscellaneous/CompareReleases.php
@@ -54,9 +54,9 @@ class CompareReleases extends AbstractTask
                 $upgrader->branch = $matches[1];
                 $upgrader->channel = $channel;
                 if ($this->container->getUpgradeConfiguration()->get('channel') == 'private' && !$this->container->getUpgradeConfiguration()->get('private_allow_major')) {
-                    $upgrader->checkPSVersion(false, array('private', 'minor'));
+                    $upgrader->checkPSVersion(array('private', 'minor'));
                 } else {
-                    $upgrader->checkPSVersion(false, array('minor'));
+                    $upgrader->checkPSVersion(array('minor'));
                 }
                 $version = $upgrader->version_num;
         }

--- a/classes/TaskRunner/Upgrade/AllUpgradeTasks.php
+++ b/classes/TaskRunner/Upgrade/AllUpgradeTasks.php
@@ -62,7 +62,7 @@ class AllUpgradeTasks extends ChainedTasks
                 'PS_AUTOUP_CHANGE_DEFAULT_THEME' => ($options['channel'] === 'major'),
             ));
             $this->container->getUpgrader()->channel = $options['channel'];
-            $this->container->getUpgrader()->checkPSVersion(true);
+            $this->container->getUpgrader()->checkPSVersion();
         }
 
         if (!empty($options['data'])) {

--- a/classes/TaskRunner/Upgrade/Download.php
+++ b/classes/TaskRunner/Upgrade/Download.php
@@ -51,9 +51,9 @@ class Download extends AbstractTask
         $upgrader->channel = $this->container->getUpgradeConfiguration()->get('channel');
         $upgrader->branch = $matches[1];
         if ($this->container->getUpgradeConfiguration()->get('channel') == 'private' && !$this->container->getUpgradeConfiguration()->get('private_allow_major')) {
-            $upgrader->checkPSVersion(false, array('private', 'minor'));
+            $upgrader->checkPSVersion(array('private', 'minor'));
         } else {
-            $upgrader->checkPSVersion(false, array('minor'));
+            $upgrader->checkPSVersion(array('minor'));
         }
 
         if ($upgrader->channel == 'private') {

--- a/classes/TaskRunner/Upgrade/UpgradeComplete.php
+++ b/classes/TaskRunner/Upgrade/UpgradeComplete.php
@@ -62,5 +62,7 @@ class UpgradeComplete extends AbstractTask
         Configuration::deleteByName('PS_AUTOUP_IGNORE_REQS');
         // removing temporary files
         $this->container->getFileConfigurationStorage()->cleanAll();
+        // Clean cache
+        $this->container->getCacheCleaner()->cleanFolders();
     }
 }

--- a/classes/TaskRunner/Upgrade/UpgradeNow.php
+++ b/classes/TaskRunner/Upgrade/UpgradeNow.php
@@ -48,9 +48,16 @@ class UpgradeNow extends AbstractTask
         $upgrader->branch = $matches[1];
         $upgrader->channel = $channel;
         if ($this->container->getUpgradeConfiguration()->get('channel') == 'private' && !$this->container->getUpgradeConfiguration()->get('private_allow_major')) {
-            $upgrader->checkPSVersion(false, array('private', 'minor'));
+            $upgrader->checkPSVersion(array('private', 'minor'));
         } else {
-            $upgrader->checkPSVersion(false, array('minor'));
+            $upgrader->checkPSVersion(array('minor'));
+        }
+
+        if (!$upgrader->isDestinationVersionCompatible()) {
+            $this->next = '';
+            $this->logger->info($this->translator->trans('This version of Update Assistant supports updates to PrestaShop 1.7. The process has been stopped to protect your store from updating to an unsupported version. Please update to PrestaShop 1.7 first, then use the latest version of Update Assistant to continue.', [], 'Modules.Autoupgrade.Admin'));
+
+            return;
         }
 
         if ($upgrader->isLastVersion()) {

--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -305,19 +305,19 @@ class UpgradeContainer
                 if (!empty($archiveXml)) {
                     $upgrader->version_md5[$upgrader->version_num] = $this->getProperty(self::DOWNLOAD_PATH) . DIRECTORY_SEPARATOR . $archiveXml;
                 }
-                $upgrader->checkPSVersion(true, array('archive'));
+                $upgrader->checkPSVersion(array('archive'));
                 break;
             case 'directory':
                 $upgrader->channel = 'directory';
                 $upgrader->version_num = $upgradeConfiguration->get('directory.version_num');
-                $upgrader->checkPSVersion(true, array('directory'));
+                $upgrader->checkPSVersion(array('directory'));
                 break;
             default:
                 $upgrader->channel = $channel;
                 if ($upgradeConfiguration->get('channel') == 'private' && !$upgradeConfiguration->get('private_allow_major')) {
-                    $upgrader->checkPSVersion(false, array('private', 'minor'));
+                    $upgrader->checkPSVersion(array('private', 'minor'));
                 } else {
-                    $upgrader->checkPSVersion(false, array('minor'));
+                    $upgrader->checkPSVersion(array('minor'));
                 }
         }
         $this->getState()->setInstallVersion($upgrader->version_num);

--- a/classes/Upgrader.php
+++ b/classes/Upgrader.php
@@ -29,6 +29,7 @@ namespace PrestaShop\Module\AutoUpgrade;
 
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Exception\IOException;
+use RuntimeException;
 use Configuration;
 
 class Upgrader
@@ -38,9 +39,8 @@ class Upgrader
     const DEFAULT_FILENAME = 'prestashop.zip';
 
     public $addons_api = 'api.addons.prestashop.com';
-    public $rss_channel_link = 'https://api.prestashop.com/xml/channel.xml';
-    public $rss_md5file_link_dir = 'https://api.prestashop.com/xml/md5/';
-
+    public $rss_md5file_link_dir = 'https://api.prestashop-project.org/assets/prestashop/%s/prestashop.xml';
+    
     /**
      * @var bool contains true if last version is not installed
      */
@@ -84,7 +84,6 @@ class Upgrader
             $this->checkPSVersion();
         }
         if (!extension_loaded('openssl')) {
-            $this->rss_channel_link = str_replace('https://', 'http://', $this->rss_channel_link);
             $this->rss_md5file_link_dir = str_replace('https://', 'http://', $this->rss_md5file_link_dir);
         }
     }
@@ -128,19 +127,25 @@ class Upgrader
         return !$this->need_upgrade;
     }
 
+    public function isDestinationVersionCompatible()
+    {
+        return version_compare($this->version_num, '8.0.0', '<');
+    }
+
     /**
      * checkPSVersion ask to prestashop.com if there is a new version. return an array if yes, false otherwise.
      *
-     * @param bool $refresh if set to true, will force to download channel.xml
      * @param array $array_no_major array of channels which will return only the immediate next version number
      *
      * @return mixed
      */
-    public function checkPSVersion($refresh = false, $array_no_major = array('minor'))
+    public function checkPSVersion($array_no_major = array('minor'))
     {
-        // if we use the autoupgrade process, we will never refresh it
-        // except if no check has been done before
-        $feed = $this->getXmlChannel($refresh);
+        Configuration::updateValue('PS_LAST_VERSION_CHECK', time());
+        $channelXml = simplexml_load_file(__DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'upgrade' . DIRECTORY_SEPARATOR . 'channel.xml');
+        if ($channelXml === false) {
+           throw new RuntimeException("Unable to retrieve channel.xml.");
+        }
         $branch_name = '';
         $channel_name = '';
 
@@ -167,12 +172,12 @@ class Upgrader
             $followed_channels[] = 'stable';
         }
 
-        if ($feed) {
-            $this->autoupgrade_module = (int) $feed->autoupgrade_module;
-            $this->autoupgrade_last_version = (string) $feed->autoupgrade->last_version;
-            $this->autoupgrade_module_link = (string) $feed->autoupgrade->download->link;
+        if ($channelXml) {
+            $this->autoupgrade_module = (int) $channelXml->autoupgrade_module;
+            $this->autoupgrade_last_version = (string) $channelXml->autoupgrade->last_version;
+            $this->autoupgrade_module_link = (string) $channelXml->autoupgrade->download->link;
 
-            foreach ($feed->channel as $channel) {
+            foreach ($channelXml->channel as $channel) {
                 $channel_available = (string) $channel['available'];
 
                 $channel_name = (string) $channel['name'];
@@ -319,22 +324,6 @@ class Upgrader
         return $xml;
     }
 
-    public function getXmlChannel($refresh = false)
-    {
-        $xml = $this->getXmlFile(
-            _PS_ROOT_DIR_ . '/config/xml/' . pathinfo($this->rss_channel_link, PATHINFO_BASENAME),
-            $this->rss_channel_link,
-            $refresh
-        );
-        if ($refresh) {
-            if (class_exists('Configuration', false)) {
-                Configuration::updateValue('PS_LAST_VERSION_CHECK', time());
-            }
-        }
-
-        return $xml;
-    }
-
     /**
      * return xml containing the list of all default PrestaShop files for version $version,
      * and their respective md5sum.
@@ -349,7 +338,7 @@ class Upgrader
             return @simplexml_load_file($this->version_md5[$version]);
         }
 
-        return $this->getXmlFile(_PS_ROOT_DIR_ . '/config/xml/' . $version . '.xml', $this->rss_md5file_link_dir . $version . '.xml', $refresh);
+        return $this->getXmlFile(_PS_ROOT_DIR_ . '/config/xml/' . $version . '.xml', sprintf($this->rss_md5file_link_dir, $version), $refresh);
     }
 
     /**

--- a/upgrade/channel.xml
+++ b/upgrade/channel.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<prestashop>
+	<channel name="stable" available="1" >
+		<branch name="1.4" available="1" >
+			<name>1.4.11 stable</name>
+			<num>1.4.11.1</num>
+			<download>
+				<link>http://www.prestashop.com/download/old/prestashop_1.4.11.1.zip</link>
+				<md5>5e98afb0b7d8d4749f2d6704c9d08dbf</md5>
+			</download>
+			<changelog>http://www.prestashop.com/download/old/changelog_1.4.11.1-stable.txt</changelog>
+		</branch>
+		<branch name="1.5" available="1" >
+			<name>1.5.6.3 stable</name>
+			<num>1.5.6.3</num>
+			<download>
+				<link>http://www.prestashop.com/download/old/prestashop_1.5.6.3.zip</link>
+				<md5>b3b70201b3e95f3b2feb0775a0cb02f6</md5>
+			</download>
+			<changelog>http://www.prestashop.com/download/old/changelog_1.5.6.3-stable.txt</changelog>
+		</branch>
+		<branch name="1.6" available="1" >
+			<name>1.6.1 stable</name>
+			<num>1.6.1.24</num>
+			<download>
+				<link>http://download.prestashop.com/download/releases/prestashop_1.6.1.24.zip</link>
+				<md5>8cd5dd3470bc42137c1018a1a8e97c0a</md5>
+			</download>
+			<changelog>http://build.prestashop.com/news/prestashop-1-7-5-2-1-6-1-24-maintenance-release/</changelog>
+		</branch>
+		<branch name="1.7" available="1" >
+			<name>1.7.8 stable</name>
+			<num>1.7.8.11</num>
+			<download>
+				<link>https://github.com/PrestaShop/PrestaShop/releases/download/1.7.8.11/prestashop_1.7.8.11.zip</link>
+				<md5>d29d55f89a2c44bef3d5c51b70e3a771</md5>
+			</download>
+			<changelog>https://build.prestashop-project.org/news/2024/prestashop-1-7-8-11-maintenance-release/</changelog>
+		</branch>
+	</channel>
+	<channel name="rc" available="1" >
+	</channel>
+	<channel name="beta" available="0" >
+	</channel>
+	<channel name="alpha" >
+		<branch name="1.5" available="0" >
+			<name></name>
+			<num></num>
+			<download>
+				<link></link>
+				<md5></md5>
+			</download>
+			<changelog></changelog>
+		</branch>
+	</channel>
+	<channel name="private" available="0" >
+		<branch name="1.5" available="0" >
+			<name></name>
+			<num></num>
+			<download>
+				<link></link>
+				<md5></md5>
+			</download>
+			<changelog></changelog>
+		</branch>
+	</channel>
+	<autoupgrade>
+		<last_version>7.0.0</last_version>
+		<download>
+			<link>https://github.com/PrestaShop/autoupgrade/releases/download/v7.0.0/autoupgrade-v7.0.0.zip</link>
+			<md5>c0d83aea9dbb03d7f2f698d011144d43</md5>
+		</download>
+		<changelog></changelog>
+	</autoupgrade>
+</prestashop>

--- a/upgrade/sql/1.7.8.8.sql
+++ b/upgrade/sql/1.7.8.8.sql
@@ -1,0 +1,5 @@
+SET SESSION sql_mode='';
+SET NAMES 'utf8';
+
+DELETE FROM `PREFIX_configuration` WHERE `name` = 'PS_SMARTY_CACHING_TYPE';
+UPDATE `PREFIX_translation` set theme = null WHERE `theme` = 'classic';


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers |
|------------------|---------|
| **Description?**  | - Use of the new distribution API to retrieve MD5 files.<br>- Versioning of the `channel.xml` file directly in the project following its deprecation.<br>- Added a security feature to prevent updating to a version equal to or greater than 8.<br>- Added clean cache at the end of update process, otherwise it causes an error due to an invalid cache of a module |
| **Type?**         | improvement |
| **BC breaks?**    | no |
| **Deprecations?** | no |
| **Fixed ticket?** | - |
| **Sponsor company** | - |
| **How to test?**  | on a 1.6 store:<br>- Perform local update with 1.7.x zip and xml to ensure everything works as before.<br>- Perform local update with 8.x zip and xml to ensure the process stops.<br>- Perform major / minor update to ensure everything works as before. |
