### PR TITLE
[FEAT] add tracking to "Go to module manager" button on post update

### DIFF
--- a/views/templates/dialogs/dialog-confirm-module-manager.html.twig
+++ b/views/templates/dialogs/dialog-confirm-module-manager.html.twig
@@ -33,7 +33,7 @@
     {{ 'Cancel'|trans({}) }}
   </button>
 
-  <a class="btn btn-primary" href="{{ module_manager_link }}">
+  <a class="btn btn-primary" href="{{ module_manager_link }}" data-au-tracking="[SUE] Module Manager Clicked From Post-Update">
     <i class="material-icons">exit_to_app</i>
     {{ 'Go to Module Manager'|trans({}) }}
   </a>


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add auto tracking on "go to module manger" button on post update page.
| Type?             | improvement 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | @PrestaShopCorp
| How to test?      | check internal related ticket