### PR TITLE
Prevent issues to happen while unlinking a non-existing but cached file

### DIFF
--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -703,9 +703,6 @@ abstract class CoreUpgrader
     {
         $files = [
             $this->container->getProperty(UpgradeContainer::PS_ADMIN_PATH) . DIRECTORY_SEPARATOR . 'themes' . DIRECTORY_SEPARATOR . 'default' . DIRECTORY_SEPARATOR . 'template' . DIRECTORY_SEPARATOR . 'controllers' . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR . 'header.tpl',
-            _PS_ROOT_DIR_ . '/app/cache/dev/class_index.php',
-            _PS_ROOT_DIR_ . '/app/cache/prod/class_index.php',
-            _PS_ROOT_DIR_ . '/cache/class_index.php',
             _PS_ROOT_DIR_ . '/config/xml/blog-fr.xml',
             _PS_ROOT_DIR_ . '/config/xml/default_country_modules_list.xml',
             _PS_ROOT_DIR_ . '/config/xml/modules_list.xml',
@@ -714,8 +711,6 @@ abstract class CoreUpgrader
             _PS_ROOT_DIR_ . '/config/xml/tab_modules_list.xml',
             _PS_ROOT_DIR_ . '/config/xml/trusted_modules_list.xml',
             _PS_ROOT_DIR_ . '/config/xml/untrusted_modules_list.xml',
-            _PS_ROOT_DIR_ . '/var/cache/dev/class_index.php',
-            _PS_ROOT_DIR_ . '/var/cache/prod/class_index.php',
         ];
         foreach ($files as $path) {
             if ($this->fileSystem->exists($path)) {

--- a/classes/UpgradeTools/FilesystemAdapter.php
+++ b/classes/UpgradeTools/FilesystemAdapter.php
@@ -21,7 +21,9 @@
 
 namespace PrestaShop\Module\AutoUpgrade\UpgradeTools;
 
+use CallbackFilterIterator;
 use FilesystemIterator;
+use IteratorIterator;
 use RecursiveCallbackFilterIterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -242,17 +244,24 @@ class FilesystemAdapter
     {
         $hasDeletedItems = false;
 
-        if ($this->filesystem->exists($folderToClear)) {
-            foreach (scandir($folderToClear) as $item) {
-                if ($item !== '.' && $item !== '..' && $item !== 'index.php') {
-                    $path = $folderToClear . DIRECTORY_SEPARATOR . $item;
-                    $this->filesystem->remove($path);
-
-                    $hasDeletedItems = true;
-                }
-            }
+        if (!$this->filesystem->exists($folderToClear)) {
+            return $hasDeletedItems;
         }
 
-        return $hasDeletedItems;
+        $directory = new FilesystemIterator(
+            $folderToClear, FilesystemIterator::SKIP_DOTS | FilesystemIterator::CURRENT_AS_FILEINFO
+        );
+        $filter = new CallbackFilterIterator($directory, function ($current) {
+            return $current->getFilename() !== 'index.php';
+        });
+        $iterator = new IteratorIterator($filter);
+
+        foreach ($iterator as $file) {
+            $this->filesystem->remove($file);
+        }
+
+        clearstatcache();
+
+        return (bool) iterator_count($iterator);
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | While testing the pull-request https://github.com/PrestaShop/autoupgrade/pull/1327 with an OPCache too strong (invalidate_timestamps = 0 or with memory space or revalidation frequency too large), we have issues during the deletion of cache. This PR is an attempt to fix them.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Use the configuration provided below and make updates (i.e 8.2.0 to 8.2.1). The process should fail during the cleanup of the store during the database update step.

### Configuration of OPCache used

```ini
[OPcache]
  opcache.memory_consumption=512
  opcache.interned_strings_buffer=8
  opcache.max_accelerated_files=40000
  opcache.revalidate_freq=120
  #opcache.revalidate_freq=0
  opcache.fast_shutdown=1
  opcache.enable_cli=1

  #opcache.validate_timestamps=0

```

### Error 1 during cleanup of XML (?) files
```
[2025-05-01 10:57:45] DEBUG - ChainedTasks - Step UpdateDatabase
[2025-05-01 10:57:45] INFO - UpdateDatabase - Updating database data and structure
[2025-05-01 10:57:45] DEBUG - CoreUpgrader81 - API keys not present in parameters, generating
[2025-05-01 10:57:45] DEBUG - CoreUpgrader81 - Keys generated using openssl_pkey_new, exporting private and public keys
[2025-05-01 10:57:45] DEBUG - CoreUpgrader81 - Updating parameters file
[2025-05-01 10:57:45] DEBUG - CoreUpgrader81 - Invalidating opcache for parameters file
[2025-05-01 10:57:45] DEBUG - CoreUpgrader81 - Parameters file updated
[2025-05-01 10:57:45] INFO - UpdateDatabase - Checking version validity
[2025-05-01 10:57:49] INFO - UpdateDatabase - Keeping non native modules enabled
[2025-05-01 10:57:49] INFO - CoreUpgrader - Running generic queries
[2025-05-01 10:57:49] INFO - CoreUpgrader - Database update OK
[2025-05-01 10:57:49] INFO - CoreUpgrader - Updating languages
[2025-05-01 10:57:49] DEBUG - CoreUpgrader80 - Downloading language pack for en
[2025-05-01 10:57:49] DEBUG - CoreUpgrader80 - Installing en language pack
[2025-05-01 10:57:49] DEBUG - CoreUpgrader80 - Generating mail templates for en
[2025-05-01 10:57:52] DEBUG - CoreUpgrader80 - Downloading language pack for fr
[2025-05-01 10:57:53] DEBUG - CoreUpgrader80 - Installing fr language pack
[2025-05-01 10:57:53] DEBUG - CoreUpgrader80 - Generating mail templates for fr
[2025-05-01 10:57:55] INFO - CoreUpgrader - Regenerating htaccess
[2025-05-01 10:57:55] INFO - CoreUpgrader - Cleaning XML files
[2025-05-01 10:57:55] CRITICAL - ErrorHandler - /var/www/html/modules/autoupgrade/vendor/symfony/filesystem/Filesystem.php line 183 - Symfony\Component\Filesystem\Exception\IOException: Failed to remove file "/var/www/html/var/cache/dev/class_index.php": unlink(/var/www/html/var/cache/dev/class_index.php): No such file or directory
#0 /var/www/html/modules/autoupgrade/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php(722): Symfony\Component\Filesystem\Filesystem->remove(Array)
#1 /var/www/html/modules/autoupgrade/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php(131): PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreUpgrader->cleanXmlFiles()
#2 /var/www/html/modules/autoupgrade/classes/Task/Update/UpdateDatabase.php(73): PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreUpgrader->finalizeCoreUpdate()
#3 /var/www/html/modules/autoupgrade/classes/Task/Runner/ChainedTasks.php(65): PrestaShop\Module\AutoUpgrade\Task\Update\UpdateDatabase->run()
#4 /var/www/html/**admin_folder**/autoupgrade/ajax-upgradetab.php(54): PrestaShop\Module\AutoUpgrade\Task\Runner\ChainedTasks->run()
#5 {main}
```

### Error 2 during cleaning of folders

```
/var/www/html/modules/autoupgrade/vendor/symfony/filesystem/Filesystem.php line 180 - Symfony\Component\Filesystem\Exception\IOException: Failed to remove directory "/var/www/html/var/cache//prod": rmdir(/var/www/html/var/cache//prod): Directory not empty
#0 /var/www/html/modules/autoupgrade/classes/UpgradeTools/FilesystemAdapter.php(249): Symfony\Component\Filesystem\Filesystem->remove(Array)
#1 /var/www/html/modules/autoupgrade/classes/UpgradeTools/CacheCleaner.php(74): PrestaShop\Module\AutoUpgrade\UpgradeTools\FilesystemAdapter->clearDirectory('/var/www/html/v...')
#2 /var/www/html/modules/autoupgrade/classes/Task/Update/UpdateDatabase.php(113): PrestaShop\Module\AutoUpgrade\UpgradeTools\CacheCleaner->cleanFolders()
#3 /var/www/html/modules/autoupgrade/classes/Task/Runner/ChainedTasks.php(62): PrestaShop\Module\AutoUpgrade\Task\Update\UpdateDatabase->init()
#4 /var/www/html/admin-dev/autoupgrade/ajax-upgradetab.php(53): PrestaShop\Module\AutoUpgrade\Task\Runner\ChainedTasks->run()
#5 {main}
It seems there was an issue with the server. This type of error usually happens when:
        The server is temporarily unavailable.
        There's a misconfiguration or unexpected problem on the server.
HTTP request failed. Type: ERR_BAD_RESPONSE - HTTP Code: 500
```