### PR TITLE
[NEW UI] Fix button overflow on error pages

### DIFF
--- a/_dev/src/scss/appUI/components/_button.scss
+++ b/_dev/src/scss/appUI/components/_button.scss
@@ -27,6 +27,7 @@ $e: ".btn";
     align-items: center;
     font-weight: 500;
     text-transform: none;
+    white-space: normal;
 
     .material-icons {
       font-size: 1.25rem;

--- a/_dev/src/scss/appUI/layouts/_error.scss
+++ b/_dev/src/scss/appUI/layouts/_error.scss
@@ -88,6 +88,23 @@ $e: ".error-page";
       gap: 1rem 2rem;
     }
 
+    @container ua-error (max-width: 992px) {
+      &__container {
+        gap: 2rem;
+        padding: 2rem;
+      }
+
+      &__buttons {
+        gap: 1rem;
+
+        > * {
+          .btn {
+            height: 100%;
+          }
+        }
+      }
+    }
+
     @container ua-error (max-width: 700px) {
       &__container {
         grid-template-rows: min-content;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fixed an overflow issue caused by long buttons on specific resolution ranges in PrestaShop 1.7 and 8.0 back offices. This was due to the `.btn` styles in Bootstrap BO.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | --
| Sponsor company   | @PrestaShopCorp
| How to test?      | --

BEFORE:
![before](https://github.com/user-attachments/assets/56686e32-2dd5-42cf-8b4f-8fd8ef8470a2)

AFTER:
![after](https://github.com/user-attachments/assets/4310a93f-3a05-4568-94f8-191d72bd41e1)

