### PR TITLE
[FIX] Duplicated typo on event

### DIFF
--- a/views/templates/dialogs/dialog-confirm-module-manager.html.twig
+++ b/views/templates/dialogs/dialog-confirm-module-manager.html.twig
@@ -33,7 +33,7 @@
     {{ 'Cancel'|trans({}) }}
   </button>
 
-  <a class="btn btn-primary" href="{{ module_manager_link }}" data-au-tracking="[SUE] Module Manager Clicked From Post-Update">
+  <a class="btn btn-primary" href="{{ module_manager_link }}" data-au-tracking="Module Manager Clicked From Post-Update">
     <i class="material-icons">exit_to_app</i>
     {{ 'Go to Module Manager'|trans({}) }}
   </a>


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix typo on event, [SUE] is present on the template but already added by JS.
| Type?             | bug fix 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | @PrestaShopCorp
| How to test?      | Test the event en check segment