### PR TITLE
Fix execution of upgrade file 1.7.0.0.sql

### DIFF
--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -418,7 +418,7 @@ abstract class CoreUpgrader
             if (!empty($matches[1])) {
                 $drop = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . $matches[1] . '`;';
                 if ($this->db->execute($drop, false)) {
-                    $this->logger->debug('<div class="upgradeDbOk">' . $this->container->getTranslator()->trans('[DROP] SQL %s table has been dropped.', array('`' . _DB_PREFIX_ . $matches[1] . '`'), 'Modules.Autoupgrade.Admin') . '</div>');
+                    $this->logger->debug('<div class="upgradeDbOk">[DROP] SQL `' . _DB_PREFIX_ . $matches[1] . '` table has been dropped.</div>');
                 }
             }
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | On a upgrade from PS 1.6.1.24, the execution of the upgrade file 1.7.0.0 fails because of the loading of the Core Translator relying on a database table being modified at the same time.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/38550
| Sponsor company   | @PrestaShopCorp
| How to test?      | Update a shop running 1.6.1.24. Updating to 1.7.8.11 must work.