### PR TITLE
Avoid the timeout on nightly builds with PS 1.7.3.0

### DIFF
--- a/tests/UI/campaigns/sanity/03_catalogFO/01_filterProducts.spec.ts
+++ b/tests/UI/campaigns/sanity/03_catalogFO/01_filterProducts.spec.ts
@@ -91,6 +91,11 @@ test.describe('FO - Catalog : Filter Products by categories in Home page', async
 
   test('should filter products by subcategory and check result', async () => {
     await foClassicCategoryPage.reloadPage(page);
+    // Based on the scenario, the mouse already points to a menu that must be opened in the next steps.
+    // On PS 1.7.3.0, the menu does not react if the mouse hovers it while the JS is being initialized,
+    // so we move it elsewhere.
+    await page.mouse.move(0, 0);
+
     if (allProductsNumber > 7) {
       await foClassicCategoryPage.goToSubCategory(page, dataCategories.accessories.id, dataCategories.stationery.id);
     } else {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | On the nightly checks, there is a timeout on the run with PrestaShop 1.7.3.0
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | The nightly must succeed.
