### PR TITLE
Fix URL of redirection after deletion of last backup

### DIFF
--- a/classes/Router/UrlGenerator.php
+++ b/classes/Router/UrlGenerator.php
@@ -61,6 +61,6 @@ class UrlGenerator
         parse_str($request->server->get('QUERY_STRING'), $queryStringParams);
         $nextQueryParams = http_build_query(array_merge($queryStringParams, $params, ['route' => $destinationRoute]));
 
-        return $request->getSchemeAndHttpHost() . $request->getBaseUrl() . $request->getPathInfo() . '?' . $nextQueryParams;
+        return $request->getSchemeAndHttpHost() . $request->getBaseUrl() . rtrim($request->getPathInfo(), '/') . '?' . $nextQueryParams;
     }
 }

--- a/tests/unit/Router/UrlGeneratorTest.php
+++ b/tests/unit/Router/UrlGeneratorTest.php
@@ -18,6 +18,7 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */
 use PHPUnit\Framework\TestCase;
+use PrestaShop\Module\AutoUpgrade\Router\Routes;
 use PrestaShop\Module\AutoUpgrade\Router\UrlGenerator;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -126,5 +127,23 @@ class UrlGeneratorTest extends TestCase
         $expectedAbsoluteUrlPathToAdmin = '/hello-world/admin-wololo';
         $this->assertSame($expectedAbsoluteUrlPathToShop, $this->urlGenerator->getShopAbsolutePathFromRequest($request));
         $this->assertSame($expectedAbsoluteUrlPathToAdmin, $this->urlGenerator->getShopAdminAbsolutePathFromRequest($request));
+    }
+
+    public function testGetUrlToRoute()
+    {
+        $server = [
+            'HTTP_HOST' => 'localhost:8001',
+            'SERVER_PORT' => '8001',
+            'QUERY_STRING' => '',
+            'PHP_SELF' => '/admin-dev/autoupgrade/ajax-upgradetab.php',
+            'SCRIPT_FILENAME' => '/var/www/html/admin-dev/autoupgrade/ajax-upgradetab.php',
+            'REQUEST_URI' => '/admin-dev/autoupgrade/ajax-upgradetab.php?route=home-page-submit-form',
+        ];
+
+        $request = new Request([], [], [], [], [], $server);
+
+        $expected = 'http://localhost:8001/admin-dev/autoupgrade/ajax-upgradetab.php?route=home-page';
+
+        $this->assertSame($expected, $this->urlGenerator->getUrlToRoute($request, Routes::HOME_PAGE));
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | On some environments (reproduced on Nginx), there is an Error 404 appearing after the last backup is deleted and the user redirected to the home page. This PR changes the URL of the redirection.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/38566
| Sponsor company   | @PrestaShopCorp
| How to test?      | Deleting the last backup on a store redirects properly on the home page.