### PR TITLE
Fix the redirection to the module manager after login on PS v9

### DIFF
--- a/controllers/admin/self-managed/UpdatePagePostUpdateController.php
+++ b/controllers/admin/self-managed/UpdatePagePostUpdateController.php
@@ -78,7 +78,14 @@ class UpdatePagePostUpdateController extends AbstractPageWithStepController
     public function confirmModuleManagerDialog(): JsonResponse
     {
         $this->upgradeContainer->initPrestaShopCore();
-        $moduleManagerLink = Context::getContext()->link->getAdminLink('AdminModules');
+
+        // All the different versions of PrestaShop require a different controller name to the Module Manager.
+        // The existing names in the database plus the management of redirect requires us to use different values, because:
+        // - With AdminModulesSf on PS 1.7, we get the proper module/manage, then AdminLogin without the next parameter,
+        // - With AdminModules on PS 9, we get the AdminLogin login page with the next paramater, but then a missing controller error.
+        $destinationController = version_compare($this->upgradeContainer->getProperty(UpgradeContainer::PS_VERSION), '9', '>=')
+            ? 'AdminModulesSf' : 'AdminModules';
+        $moduleManagerLink = Context::getContext()->link->getAdminLink($destinationController);
 
         return AjaxResponseBuilder::hydrationResponse(
             PageSelectors::DIALOG_PARENT_ID,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | On PrestaShop v9, the legacy Controller `AdminModules` is not anymore valid to redirect the user to the Modules Manager after an update. We now use `AdminModulesSf` that has been introduced on PS 1.7.0.0
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/38699
| Sponsor company   | @PrestaShopCorp
| How to test?      | Redirect to the Module Manager on PS v9 from the post update page works. All the previous versions are still able to redirect to the Modules Manager.