### PR TITLE
Display the post restore checklist only in case of success

### DIFF
--- a/classes/Commands/RestoreCommand.php
+++ b/classes/Commands/RestoreCommand.php
@@ -80,10 +80,10 @@ class RestoreCommand extends AbstractBackupCommand
             $controller->init();
             $exitCode = $controller->run();
 
-            $version = $this->upgradeContainer->getPrestaShopConfiguration()->getPrestaShopVersion();
-            $major = VersionUtils::splitPrestaShopVersion($version)['major'];
+            if ($exitCode === ExitCode::SUCCESS) {
+                $this->printPostProcessChecklist($output);
+            }
 
-            $output->writeln('We recommend you to visit the Post-restore checklist page in the developer documentation for any further help: ' . DocumentationLinks::getDevDocUpdateAssistantPostRestoreUrl($major));
             $this->logger->debug('Process completed with exit code: ' . $exitCode);
 
             return $exitCode;
@@ -91,5 +91,13 @@ class RestoreCommand extends AbstractBackupCommand
             $this->logger->error("An error occurred during the restoration process:\n" . $e);
             throw $e;
         }
+    }
+
+    private function printPostProcessChecklist(OutputInterface $output): void
+    {
+        $version = $this->upgradeContainer->getPrestaShopConfiguration()->getPrestaShopVersion();
+        $major = VersionUtils::splitPrestaShopVersion($version)['major'];
+
+        $output->writeln('We recommend you to visit the Post-restore checklist page in the developer documentation for any further help: ' . DocumentationLinks::getDevDocUpdateAssistantPostRestoreUrl($major));
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | During tests of the restore process that failed, we discovered some of the success messages were displayed anyway. This PR add some filters.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/38582
| Sponsor company   | @PrestaShopCorp
| How to test?      | Start a restore via CLI and make it fail. The success message about the post restore checklist must not appear.