### PR TITLE
Add missing hooks for PS v8.2.2 and v9.0.0

### DIFF
--- a/upgrade/sql/9.0.0-catchup.sql
+++ b/upgrade/sql/9.0.0-catchup.sql
@@ -60,7 +60,6 @@ UPDATE `PREFIX_hook_module` AS hm
 INNER JOIN `PREFIX_hook` AS hfrom ON hm.id_hook = hfrom.id_hook AND hfrom.name = 'displayAdminOrderSideBottom'
 INNER JOIN `PREFIX_hook` AS hto ON hto.name = 'displayAdminOrderBottom'
 SET hm.id_hook = hto.id_hook;
-DELETE FROM `PREFIX_hook` WHERE name = 'displayAdminOrderSideBottom';
 
 UPDATE `PREFIX_country` SET `zip_code_format` = 'NNNNN' WHERE `iso_code` = "KR";
 
@@ -118,7 +117,7 @@ INSERT INTO `PREFIX_hook` (`name`, `title`, `description`, `position`) VALUES
   ('actionListModules','Add modules to the module manager list','This hook allows you to add modules to the list of modules displayed in the module manager page', '1'),
   ('actionValidateOrderAfter','After validating an order','This hook is called after validating an order by core', '1'),
   ('displayBackOfficeEmployeeMenu','Administration Employee menu','This hook is displayed in the employee menu', '1'),
-  ('displayEmptyModuleCategoryExtraMessage','Extra message to display for an empty modules category','This hook allows to add an extra message to display in the Module manager page when a category does not have any module', '1'),
+  ('displayEmptyModuleCategoryExtraMessage', 'Extra message to display for an empty modules category', "This hook allows to add an extra message to display in the Module manager page when a category doesn't have any module", '1'),
   ('actionStateGridPresenterModifier','Modify state grid template data','This hook allows to modify data which is about to be used in template for state grid', '1'),
   ('actionTitleGridPresenterModifier','Modify title grid template data','This hook allows to modify data which is about to be used in template for title grid', '1')
 ON DUPLICATE KEY UPDATE `title` = VALUES(`title`), `description` = VALUES(`description`);

--- a/upgrade/sql/9.0.0.sql
+++ b/upgrade/sql/9.0.0.sql
@@ -386,7 +386,17 @@ INSERT INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`
   (NULL, 'actionBeforeUpdateSearchTermFormHandler', 'Modify search term identifiable object data before updating it', 'This hook allows to modify search term identifiable object forms data before it was updated', '1'),
   (NULL, 'actionAfterUpdateSearchTermFormHandler', 'Modify search term identifiable object data after updating it', 'This hook allows to modify search term identifiable object forms data after it was updated', '1'),
   (NULL, 'actionBeforeCreateSearchTermFormHandler', 'Modify search term identifiable object data before creating it', 'This hook allows to modify search term identifiable object forms data before it was created', '1'),
-  (NULL, 'actionAfterCreateSearchTermFormHandler', 'Modify search term identifiable object data after creating it', 'This hook allows to modify search term identifiable object forms data after it was created', '1')
+  (NULL, 'actionAfterCreateSearchTermFormHandler', 'Modify search term identifiable object data after creating it', 'This hook allows to modify search term identifiable object forms data after it was created', '1'),
+  (NULL, 'actionDuplicateCartData', 'Cart duplication', 'This hook is triggered after all the cart related data has been duplicated', '1'),
+  (NULL, 'actionFeatureFormBuilderModifier', 'Modify feature identifiable object form', 'This hook allows to modify feature identifiable object forms content by modifying form builder data or FormBuilder itself', '1'),
+  (NULL, 'actionGetPdfRenderer', 'Provide a PDF renderer', 'This hook allows to provide a custom PDF renderer to generate PDF files', '1'),
+  (NULL, 'actionObjectDuplicateAfter', 'After duplicating an object', 'This hook is called after duplicating an object by the core.', '1'),
+  (NULL, 'actionProductGetAttributesGroupsAfter', 'Triggers after getting product attributes groups', 'Allows to modify product attributes groups after they are retrieved from the database.', '1'),
+  (NULL, 'actionProductGetAttributesGroupsBefore', 'Triggers before getting product attributes groups', 'Allows to modify product attributes groups SQL query before they are retrieved from the database.', '1'),
+  (NULL, 'actionSubmitAccountBefore', 'Before customer account creation', 'This hook is called before a customer account creation', '1'),
+  (NULL, 'displayAdminStoreInformation', 'Display extra store information', 'This hook displays content in the Information page to add store information', '1'),
+  (NULL, 'displayCartExtraProductInfo', 'Extra information in shopping cart product line', 'This hook adds extra information to the product lines, in the shopping cart', '1'),
+  (NULL, 'displayEmptyModuleCategoryExtraMessage', 'Extra message to display for an empty modules category', "This hook allows to add an extra message to display in the Module manager page when a category doesn't have any module", '1')
 ON DUPLICATE KEY UPDATE `title` = VALUES(`title`), `description` = VALUES(`description`);
 
 /* Auto generated hooks removed for version 9.0.0 */


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Changes have been brought to the Core repository but are missing on this one. This PR sync the list, otherwise we won't be able to release Update Assistant 7.1 once PS v9 is ready.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Related to https://github.com/PrestaShop/PrestaShop/pull/38232, https://github.com/PrestaShop/PrestaShop/pull/38408, https://github.com/PrestaShop/PrestaShop/pull/38488 and https://github.com/PrestaShop/PrestaShop/pull/38567
| Sponsor company   | @PrestaShopCorp
| How to test?      | Clean installation of PS v9 and updates to this version bring the same changes.