### PR TITLE
Clear cache folders after an update and a restore

### DIFF
--- a/classes/Task/Restore/RestoreComplete.php
+++ b/classes/Task/Restore/RestoreComplete.php
@@ -49,6 +49,8 @@ class RestoreComplete extends AbstractTask
         $this->logger->info($this->translator->trans('Running opcache_reset'));
         $this->container->resetOpcache();
 
+        $this->container->getCacheCleaner()->cleanFolders();
+
         return ExitCode::SUCCESS;
     }
 }

--- a/classes/Task/Update/UpdateComplete.php
+++ b/classes/Task/Update/UpdateComplete.php
@@ -88,6 +88,8 @@ class UpdateComplete extends AbstractTask
         $this->logger->info($this->translator->trans('Running opcache_reset'));
         $this->container->resetOpcache();
 
+        $this->container->getCacheCleaner()->cleanFolders();
+
         return ExitCode::SUCCESS;
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Make sure cache folders are cleaned at the end of the process to avoid layers of cached data to prevent the front office to load.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/38753
| Sponsor company   | @PrestaShopCorp
| How to test?      | Update -> Restore -> Update -> Check front office is accessible