### PR TITLE
[FIX] Restore file doesn't delete link

### DIFF
--- a/classes/Task/Restore/RestoreFiles.php
+++ b/classes/Task/Restore/RestoreFiles.php
@@ -69,7 +69,7 @@ class RestoreFiles extends AbstractTask
                 $vfile = str_replace($this->container->getProperty(UpgradeContainer::PS_ROOT_PATH), '', $v);
                 $toRemove[] = str_replace($this->container->getProperty(UpgradeContainer::PS_ROOT_PATH), '', $vfile);
 
-                if (!isset($fromArchive[$vfile]) && is_file($v)) {
+                if (!isset($fromArchive[$vfile]) && (is_file($v) || is_link($v))) {
                     $toRemoveOnly[$vfile] = str_replace($this->container->getProperty(UpgradeContainer::PS_ROOT_PATH), '', $vfile);
                 }
             }


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | After test from v9 we got an issue with delete simlink on restore. This PR catch this issue.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fix https://github.com/PrestaShop/PrestaShop/issues/38600
| Sponsor company   | @PrestaShopCorp
| How to test?      | Check Issue or internal ticket