### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-zip": "*",
         "symfony/filesystem": "^3.0",
         "doctrine/collections": "^1.8",
-        "segmentio/analytics-php": "^1.8",
+        "segmentio/analytics-php": "^3.6",
         "symfony/dotenv": "^4.4",
         "symfony/http-foundation": "^4.4",
         "symfony/console": "^3.4",


### PR DESCRIPTION
Prestahop 9.0 has support for PHP 8.1 - 8.4,
but Autoupgrade does not have even PHP 8.1 support due to version 1.8.0 of segmentio/analytics-php.

Bump segmentio/analytics-php version to gain compatibility with supported versions of PHP.
3.6.0 brings PHP8.1 * 8.2 support.
3.8.0 brings PHP.8.3 support.



