### PR TITLE
[FIX] Load right remote xml file

### DIFF
--- a/classes/Models/UpdateNotificationConfiguration.php
+++ b/classes/Models/UpdateNotificationConfiguration.php
@@ -88,7 +88,7 @@ class UpdateNotificationConfiguration
         return $this->version;
     }
 
-    public function setReleaseNote(string $releaseNote): void
+    public function setReleaseNote(?string $releaseNote): void
     {
         $this->releaseNote = $releaseNote;
     }

--- a/classes/Services/DistributionApiService.php
+++ b/classes/Services/DistributionApiService.php
@@ -34,8 +34,8 @@ class DistributionApiService
 
     /** @var array<string, string> */
     private static $factories = [
-        self::PRESTASHOP_ENDPOINT   => 'createPrestashopReleaseCollection',
-        self::AUTOUPGRADE_ENDPOINT  => 'createAutoupgradeReleaseCollection',
+        self::PRESTASHOP_ENDPOINT => 'createPrestashopReleaseCollection',
+        self::AUTOUPGRADE_ENDPOINT => 'createAutoupgradeReleaseCollection',
     ];
 
     /** @var Translator */
@@ -60,7 +60,7 @@ class DistributionApiService
      *
      * @param string $path
      *
-     * @return PrestashopRelease[] | AutoupgradeRelease[]
+     * @return PrestashopRelease[]|AutoupgradeRelease[]
      */
     public function getApiEndpoint(string $path): array
     {
@@ -74,10 +74,7 @@ class DistributionApiService
             $jsonResponse = json_decode($response, true);
 
             if (JSON_ERROR_NONE !== json_last_error()) {
-                throw new DistributionApiException(
-                    $this->translator->trans('Invalid JSON from Distribution API: %s', [json_last_error_msg()]),
-                    DistributionApiException::API_NOT_CALLABLE_CODE
-                );
+                throw new DistributionApiException($this->translator->trans('Invalid JSON from Distribution API: %s', [json_last_error_msg()]), DistributionApiException::API_NOT_CALLABLE_CODE);
             }
 
             $method = self::$factories[$path];
@@ -110,9 +107,11 @@ class DistributionApiService
     }
 
     /**
-     * @throws DistributionApiException
+     * @param string $version
      *
      * @return PrestashopRelease|null
+     *
+     * @throws DistributionApiException
      */
     public function getRelease(string $version): ?PrestashopRelease
     {
@@ -165,6 +164,7 @@ class DistributionApiService
 
     /**
      * @param mixed[] $data
+     *
      * @return PrestashopRelease[]
      */
     private function createPrestashopReleaseCollection(array $data): array
@@ -190,6 +190,7 @@ class DistributionApiService
 
     /**
      * @param array{ 'prestashop': mixed[] } $data
+     *
      * @return AutoupgradeRelease[]
      */
     private function createAutoupgradeReleaseCollection(array $data): array

--- a/classes/Services/DistributionApiService.php
+++ b/classes/Services/DistributionApiService.php
@@ -30,7 +30,7 @@ class DistributionApiService
 {
     public const PRESTASHOP_ENDPOINT = 'prestashop';
     public const AUTOUPGRADE_ENDPOINT = 'autoupgrade';
-    public const API_URL = 'https://integration-api.prestashop-project.org';
+    public const API_URL = 'https://api.prestashop-project.org';
 
     /** @var array<string, string> */
     private static $factories = [

--- a/classes/Services/DistributionApiService.php
+++ b/classes/Services/DistributionApiService.php
@@ -33,11 +33,17 @@ class DistributionApiService
     private $translator;
 
     /**
+     * @var array<string, mixed>
+     */
+    private $apiEndpoint;
+
+    /**
      * @param Translator $translator
      */
     public function __construct(Translator $translator)
     {
         $this->translator = $translator;
+        $this->apiEndpoint = [];
     }
 
     /**
@@ -49,13 +55,17 @@ class DistributionApiService
      */
     public function getApiEndpoint(string $path)
     {
-        $response = @file_get_contents(self::API_URL . $path);
+        if (!isset($this->apiEndpoint[$path])) {
+            $response = @file_get_contents(self::API_URL . $path);
 
-        if (!$response) {
-            throw new DistributionApiException($this->translator->trans('Error when retrieving data from Distribution API'), DistributionApiException::API_NOT_CALLABLE_CODE);
+            if (!$response) {
+                throw new DistributionApiException($this->translator->trans('Error when retrieving data from Distribution API'), DistributionApiException::API_NOT_CALLABLE_CODE);
+            }
+
+            $this->apiEndpoint[$path] = json_decode($response, true);
         }
 
-        return json_decode($response, true);
+        return $this->apiEndpoint[$path];
     }
 
     /**
@@ -77,6 +87,39 @@ class DistributionApiService
         }
 
         throw new DistributionApiException($this->translator->trans('No version match in Distribution api for %s', [$targetVersion]), DistributionApiException::VERSION_NOT_FOUND_CODE);
+    }
+
+    /**
+     * @throws DistributionApiException
+     *
+     * @return PrestashopRelease|null
+     */
+    public function getRelease(string $version): ?PrestashopRelease
+    {
+        $data = $this->getApiEndpoint('/prestashop');
+
+        if (empty($data)) {
+            throw new DistributionApiException($this->translator->trans('Unable to retrieve Prestashop releases from distribution API.'), DistributionApiException::EMPTY_DATA_CODE);
+        }
+
+        foreach ($data as $versionInfo) {
+            if ($versionInfo['version'] === $version) {
+                return new PrestashopRelease(
+                    $versionInfo['version'],
+                    $versionInfo['stability'],
+                    $versionInfo['distribution'],
+                    $versionInfo['php_max_version'],
+                    $versionInfo['php_min_version'],
+                    $versionInfo['zip_download_url'],
+                    $versionInfo['xml_download_url'],
+                    $versionInfo['zip_md5'],
+                    $versionInfo['release_notes_url'],
+                    $versionInfo['distribution_version']
+                );
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/classes/Services/DistributionApiService.php
+++ b/classes/Services/DistributionApiService.php
@@ -28,12 +28,21 @@ use PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator;
 
 class DistributionApiService
 {
+    public const PRESTASHOP_ENDPOINT = '/prestashop';
+    public const AUTOUPGRADE_ENDPOINT = '/autoupgrade';
     public const API_URL = 'https://api.prestashop-project.org';
+
+    /** @var array<string, string> */
+    private static $factories = [
+        self::PRESTASHOP_ENDPOINT   => 'createPrestashopReleaseCollection',
+        self::AUTOUPGRADE_ENDPOINT  => 'createAutoupgradeReleaseCollection',
+    ];
+
     /** @var Translator */
     private $translator;
 
     /**
-     * @var array<string, mixed>
+     * @var array{ '/prestashop'?: PrestashopRelease[], '/autoupgrade'?: AutoupgradeRelease[] }
      */
     private $apiEndpoint;
 
@@ -51,9 +60,9 @@ class DistributionApiService
      *
      * @param string $path
      *
-     * @return mixed|null
+     * @return PrestashopRelease[] | AutoupgradeRelease[]
      */
-    public function getApiEndpoint(string $path)
+    public function getApiEndpoint(string $path): array
     {
         if (!isset($this->apiEndpoint[$path])) {
             $response = @file_get_contents(self::API_URL . $path);
@@ -62,7 +71,18 @@ class DistributionApiService
                 throw new DistributionApiException($this->translator->trans('Error when retrieving data from Distribution API'), DistributionApiException::API_NOT_CALLABLE_CODE);
             }
 
-            $this->apiEndpoint[$path] = json_decode($response, true);
+            $jsonResponse = json_decode($response, true);
+
+            if (JSON_ERROR_NONE !== json_last_error()) {
+                throw new DistributionApiException(
+                    $this->translator->trans('Invalid JSON from Distribution API: %s', [json_last_error_msg()]),
+                    DistributionApiException::API_NOT_CALLABLE_CODE
+                );
+            }
+
+            $method = self::$factories[$path];
+
+            $this->apiEndpoint[$path] = $this->$method($jsonResponse);
         }
 
         return $this->apiEndpoint[$path];
@@ -75,13 +95,13 @@ class DistributionApiService
      */
     public function getPhpVersionRequirements(string $targetVersion): array
     {
-        $data = $this->getApiEndpoint('/prestashop');
+        $data = $this->getApiEndpoint(self::PRESTASHOP_ENDPOINT);
 
-        foreach ($data as $versionInfo) {
-            if ($versionInfo['version'] === $targetVersion) {
+        foreach ($data as $prestashopRelease) {
+            if ($prestashopRelease->getVersion() === $targetVersion) {
                 return [
-                    'php_min_version' => $versionInfo['php_min_version'],
-                    'php_max_version' => $versionInfo['php_max_version'],
+                    'php_min_version' => $prestashopRelease->getPhpMinVersion(),
+                    'php_max_version' => $prestashopRelease->getPhpMaxVersion(),
                 ];
             }
         }
@@ -96,26 +116,15 @@ class DistributionApiService
      */
     public function getRelease(string $version): ?PrestashopRelease
     {
-        $data = $this->getApiEndpoint('/prestashop');
+        $data = $this->getApiEndpoint(self::PRESTASHOP_ENDPOINT);
 
         if (empty($data)) {
-            throw new DistributionApiException($this->translator->trans('Unable to retrieve Prestashop releases from distribution API.'), DistributionApiException::EMPTY_DATA_CODE);
+            throw new DistributionApiException($this->translator->trans('Unable to retrieve Prestashop %s release from distribution API.', [$version]), DistributionApiException::EMPTY_DATA_CODE);
         }
 
-        foreach ($data as $versionInfo) {
-            if ($versionInfo['version'] === $version) {
-                return new PrestashopRelease(
-                    $versionInfo['version'],
-                    $versionInfo['stability'],
-                    $versionInfo['distribution'],
-                    $versionInfo['php_max_version'],
-                    $versionInfo['php_min_version'],
-                    $versionInfo['zip_download_url'],
-                    $versionInfo['xml_download_url'],
-                    $versionInfo['zip_md5'],
-                    $versionInfo['release_notes_url'],
-                    $versionInfo['distribution_version']
-                );
+        foreach ($data as $prestashopRelease) {
+            if ($prestashopRelease->getVersion() === $version) {
+                return $prestashopRelease;
             }
         }
 
@@ -129,12 +138,37 @@ class DistributionApiService
      */
     public function getReleases(): array
     {
-        $data = $this->getApiEndpoint('/prestashop');
+        $data = $this->getApiEndpoint(self::PRESTASHOP_ENDPOINT);
 
         if (empty($data)) {
             throw new DistributionApiException($this->translator->trans('Unable to retrieve Prestashop releases from distribution API.'), DistributionApiException::EMPTY_DATA_CODE);
         }
 
+        return $data;
+    }
+
+    /**
+     * @throws DistributionApiException
+     *
+     * @return AutoupgradeRelease[]
+     */
+    public function getAutoupgradeCompatibilities(): array
+    {
+        $data = $this->getApiEndpoint(self::AUTOUPGRADE_ENDPOINT);
+
+        if (empty($data)) {
+            throw new DistributionApiException($this->translator->trans('Unable to retrieve Update Assistant compatibilities from distribution API.'), DistributionApiException::EMPTY_DATA_CODE);
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param mixed[] $data
+     * @return PrestashopRelease[]
+     */
+    private function createPrestashopReleaseCollection(array $data): array
+    {
         $releases = [];
         foreach ($data as $versionInfo) {
             $releases[] = new PrestashopRelease(
@@ -155,19 +189,13 @@ class DistributionApiService
     }
 
     /**
-     * @throws DistributionApiException
-     *
+     * @param array{ 'prestashop': mixed[] } $data
      * @return AutoupgradeRelease[]
      */
-    public function getAutoupgradeCompatibilities(): array
+    private function createAutoupgradeReleaseCollection(array $data): array
     {
-        $data = $this->getApiEndpoint('/autoupgrade');
-
-        if (empty($data) || empty($data['prestashop'])) {
-            throw new DistributionApiException($this->translator->trans('Unable to retrieve Update Assistant compatibilities from distribution API.'), DistributionApiException::EMPTY_DATA_CODE);
-        }
-
         $releases = [];
+
         foreach ($data['prestashop'] as $versionInfo) {
             $releases[] = new AutoupgradeRelease(
                 $versionInfo['prestashop_min'],

--- a/classes/Services/DistributionApiService.php
+++ b/classes/Services/DistributionApiService.php
@@ -28,9 +28,9 @@ use PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator;
 
 class DistributionApiService
 {
-    public const PRESTASHOP_ENDPOINT = '/prestashop';
-    public const AUTOUPGRADE_ENDPOINT = '/autoupgrade';
-    public const API_URL = 'https://api.prestashop-project.org';
+    public const PRESTASHOP_ENDPOINT = 'prestashop';
+    public const AUTOUPGRADE_ENDPOINT = 'autoupgrade';
+    public const API_URL = 'https://integration-api.prestashop-project.org';
 
     /** @var array<string, string> */
     private static $factories = [
@@ -42,9 +42,9 @@ class DistributionApiService
     private $translator;
 
     /**
-     * @var array{ '/prestashop'?: PrestashopRelease[], '/autoupgrade'?: AutoupgradeRelease[] }
+     * @var array{ 'prestashop'?: PrestashopRelease[], 'autoupgrade'?: AutoupgradeRelease[] }
      */
-    private $apiEndpoint;
+    private $endpointData;
 
     /**
      * @param Translator $translator
@@ -52,37 +52,31 @@ class DistributionApiService
     public function __construct(Translator $translator)
     {
         $this->translator = $translator;
-        $this->apiEndpoint = [];
+        $this->endpointData = [];
     }
 
     /**
      * @throws DistributionApiException
      *
-     * @param string $path
+     * @param string $endPoint
      *
-     * @return PrestashopRelease[]|AutoupgradeRelease[]
+     * @return mixed|null
      */
-    public function getApiEndpoint(string $path): array
+    public function getApiEndpoint(string $endPoint)
     {
-        if (!isset($this->apiEndpoint[$path])) {
-            $response = @file_get_contents(self::API_URL . $path);
+        $response = @file_get_contents(self::API_URL . '/' . $endPoint);
 
-            if (!$response) {
-                throw new DistributionApiException($this->translator->trans('Error when retrieving data from Distribution API'), DistributionApiException::API_NOT_CALLABLE_CODE);
-            }
-
-            $jsonResponse = json_decode($response, true);
-
-            if (JSON_ERROR_NONE !== json_last_error()) {
-                throw new DistributionApiException($this->translator->trans('Invalid JSON from Distribution API: %s', [json_last_error_msg()]), DistributionApiException::API_NOT_CALLABLE_CODE);
-            }
-
-            $method = self::$factories[$path];
-
-            $this->apiEndpoint[$path] = $this->$method($jsonResponse);
+        if (!$response) {
+            throw new DistributionApiException($this->translator->trans('Error when retrieving data from Distribution API'), DistributionApiException::API_NOT_CALLABLE_CODE);
         }
 
-        return $this->apiEndpoint[$path];
+        $jsonResponse = json_decode($response, true);
+
+        if (JSON_ERROR_NONE !== json_last_error()) {
+            throw new DistributionApiException($this->translator->trans('Invalid JSON from Distribution API: %s', [json_last_error_msg()]), DistributionApiException::API_NOT_CALLABLE_CODE);
+        }
+
+        return $jsonResponse;
     }
 
     /**
@@ -92,7 +86,7 @@ class DistributionApiService
      */
     public function getPhpVersionRequirements(string $targetVersion): array
     {
-        $data = $this->getApiEndpoint(self::PRESTASHOP_ENDPOINT);
+        $data = $this->getEndpointData(self::PRESTASHOP_ENDPOINT);
 
         foreach ($data as $prestashopRelease) {
             if ($prestashopRelease->getVersion() === $targetVersion) {
@@ -115,11 +109,7 @@ class DistributionApiService
      */
     public function getRelease(string $version): ?PrestashopRelease
     {
-        $data = $this->getApiEndpoint(self::PRESTASHOP_ENDPOINT);
-
-        if (empty($data)) {
-            throw new DistributionApiException($this->translator->trans('Unable to retrieve Prestashop %s release from distribution API.', [$version]), DistributionApiException::EMPTY_DATA_CODE);
-        }
+        $data = $this->getReleases();
 
         foreach ($data as $prestashopRelease) {
             if ($prestashopRelease->getVersion() === $version) {
@@ -137,29 +127,41 @@ class DistributionApiService
      */
     public function getReleases(): array
     {
-        $data = $this->getApiEndpoint(self::PRESTASHOP_ENDPOINT);
-
-        if (empty($data)) {
-            throw new DistributionApiException($this->translator->trans('Unable to retrieve Prestashop releases from distribution API.'), DistributionApiException::EMPTY_DATA_CODE);
-        }
-
-        return $data;
+        return $this->getEndpointData(self::PRESTASHOP_ENDPOINT);
     }
 
     /**
-     * @throws DistributionApiException
-     *
      * @return AutoupgradeRelease[]
+     *
+     * @throws DistributionApiException
      */
     public function getAutoupgradeCompatibilities(): array
     {
-        $data = $this->getApiEndpoint(self::AUTOUPGRADE_ENDPOINT);
+        return $this->getEndpointData(self::AUTOUPGRADE_ENDPOINT);
+    }
 
-        if (empty($data)) {
-            throw new DistributionApiException($this->translator->trans('Unable to retrieve Update Assistant compatibilities from distribution API.'), DistributionApiException::EMPTY_DATA_CODE);
+    /**
+     * @param self::PRESTASHOP_ENDPOINT|self::AUTOUPGRADE_ENDPOINT $endPoint
+     *
+     * @return AutoupgradeRelease[]|PrestashopRelease[]
+     *
+     * @throws DistributionApiException
+     */
+    private function getEndpointData(string $endPoint): array
+    {
+        if (!isset($this->endpointData[$endPoint])) {
+            $jsonResponse = $this->getApiEndpoint($endPoint);
+
+            if (empty($jsonResponse) || ($endPoint === self::AUTOUPGRADE_ENDPOINT && empty($jsonResponse['prestashop']))) {
+                throw new DistributionApiException($this->translator->trans('Unable to retrieve "%s" data from distribution API.', [$endPoint]), DistributionApiException::EMPTY_DATA_CODE);
+            }
+
+            $method = self::$factories[$endPoint];
+
+            $this->endpointData[$endPoint] = $this->$method($jsonResponse);
         }
 
-        return $data;
+        return $this->endpointData[$endPoint];
     }
 
     /**

--- a/classes/Services/PhpVersionResolverService.php
+++ b/classes/Services/PhpVersionResolverService.php
@@ -37,9 +37,6 @@ class PhpVersionResolverService
     /** @var string */
     private $currentPsVersion;
 
-    /**
-     * @param DistributionApiService $distributionApiService
-     */
     public function __construct(DistributionApiService $distributionApiService, string $currentPsVersion)
     {
         $this->distributionApiService = $distributionApiService;

--- a/classes/Task/Update/UpdateFiles.php
+++ b/classes/Task/Update/UpdateFiles.php
@@ -233,9 +233,6 @@ class UpdateFiles extends AbstractTask
         if ($updateConfiguration->isChannelLocal()) {
             $archiveXml = $updateConfiguration->getLocalChannelXml();
             $this->container->getFileLoader()->addXmlMd5File($this->container->getUpgrader()->getDestinationVersion(), $this->container->getProperty(UpgradeContainer::DOWNLOAD_PATH) . DIRECTORY_SEPARATOR . $archiveXml);
-        } else {
-            // va chercher l'url xml
-            // telecharge et le met au bon endroit
         }
 
         // Get path to the folder with release we will use to upgrade and check if it's valid

--- a/classes/Task/Update/UpdateFiles.php
+++ b/classes/Task/Update/UpdateFiles.php
@@ -233,6 +233,9 @@ class UpdateFiles extends AbstractTask
         if ($updateConfiguration->isChannelLocal()) {
             $archiveXml = $updateConfiguration->getLocalChannelXml();
             $this->container->getFileLoader()->addXmlMd5File($this->container->getUpgrader()->getDestinationVersion(), $this->container->getProperty(UpgradeContainer::DOWNLOAD_PATH) . DIRECTORY_SEPARATOR . $archiveXml);
+        } else {
+            // va chercher l'url xml
+            // telecharge et le met au bon endroit
         }
 
         // Get path to the folder with release we will use to upgrade and check if it's valid

--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -528,7 +528,7 @@ class UpgradeContainer
     public function getFileLoader(): FileLoader
     {
         if (null === $this->fileLoader) {
-            $this->fileLoader = new FileLoader($this->getFileSystem());
+            $this->fileLoader = new FileLoader($this->getFileSystem(), $this->getDistributionApiService());
         }
 
         return $this->fileLoader;

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -862,7 +862,7 @@ abstract class CoreUpgrader
     public function warmupCoreCache(): void
     {
         $rootPath = $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH);
-        $command = 'php ' . $rootPath . '/bin/console cache:warmup --no-interaction --env=prod';
+        $command = 'php ' . $rootPath . '/bin/console cache:warmup --no-interaction --no-optional-warmers --env=prod';
         $output = [];
         $resultCode = 0;
 

--- a/classes/Xml/FileLoader.php
+++ b/classes/Xml/FileLoader.php
@@ -75,6 +75,7 @@ class FileLoader
      * and their respective md5sum.
      *
      * @return SimpleXMLElement|false if error
+     *
      * @throws DistributionApiException
      */
     public function getXmlMd5File(?string $version, bool $refresh = false)

--- a/classes/Xml/FileLoader.php
+++ b/classes/Xml/FileLoader.php
@@ -21,6 +21,8 @@
 
 namespace PrestaShop\Module\AutoUpgrade\Xml;
 
+use PrestaShop\Module\AutoUpgrade\Exceptions\DistributionApiException;
+use PrestaShop\Module\AutoUpgrade\Services\DistributionApiService;
 use PrestaShop\Module\AutoUpgrade\Tools14;
 use PrestaShop\Module\AutoUpgrade\Upgrader;
 use SimpleXMLElement;
@@ -28,16 +30,17 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class FileLoader
 {
-    const BASE_URL_MD5_FILES = 'https://api.prestashop.com/xml/md5/';
-
     /** @var array<string, string> */
     private $version_md5 = [];
     /** @var Filesystem */
     private $filesystem;
+    /** @var DistributionApiService */
+    private $distributionApiService;
 
-    public function __construct(Filesystem $filesystem)
+    public function __construct(Filesystem $filesystem, DistributionApiService $distributionApiService)
     {
         $this->filesystem = $filesystem;
+        $this->distributionApiService = $distributionApiService;
     }
 
     /**
@@ -72,6 +75,7 @@ class FileLoader
      * and their respective md5sum.
      *
      * @return SimpleXMLElement|false if error
+     * @throws DistributionApiException
      */
     public function getXmlMd5File(?string $version, bool $refresh = false)
     {
@@ -79,7 +83,15 @@ class FileLoader
             return @simplexml_load_file($this->version_md5[$version]);
         }
 
-        return $this->getXmlFile(_PS_ROOT_DIR_ . '/config/xml/' . $version . '.xml', self::BASE_URL_MD5_FILES . $version . '.xml', $refresh);
+        $releaseInfo = $this->distributionApiService->getRelease($version);
+
+        if ($releaseInfo === null) {
+            return false;
+        }
+
+        $releaseXmlRemoteFile = $releaseInfo->getXmlDownloadUrl();
+
+        return $this->getXmlFile(_PS_ROOT_DIR_ . '/config/xml/' . $version . '.xml', $releaseXmlRemoteFile, $refresh);
     }
 
     public function addXmlMd5File(string $version, string $path): void

--- a/tests/unit/Services/PhpVersionResolverServiceTest.php
+++ b/tests/unit/Services/PhpVersionResolverServiceTest.php
@@ -145,7 +145,7 @@ class PhpVersionResolverServiceTest extends TestCase
             ->willReturn(json_decode(@file_get_contents(__DIR__ . '/../../fixtures/api-distribution/empty_prestashop.json'), true));
 
         $this->expectException(DistributionApiException::class);
-        $this->expectExceptionMessage('Unable to retrieve Prestashop releases from distribution API.');
+        $this->expectExceptionMessage('Unable to retrieve "prestashop" data from distribution API.');
 
         $this->phpVersionResolverService->getPrestashopDestinationRelease(80000);
     }
@@ -159,12 +159,12 @@ class PhpVersionResolverServiceTest extends TestCase
     {
         $this->distributionApiService->method('getApiEndpoint')
             ->will($this->returnValueMap([
-                ['/prestashop', json_decode(@file_get_contents(__DIR__ . '/../../fixtures/api-distribution/prestashop.json'), true)],
-                ['/autoupgrade', json_decode(@file_get_contents(__DIR__ . '/../../fixtures/api-distribution/empty_autoupgrade.json'), true)],
+                [DistributionApiService::PRESTASHOP_ENDPOINT, json_decode(@file_get_contents(__DIR__ . '/../../fixtures/api-distribution/prestashop.json'), true)],
+                [DistributionApiService::AUTOUPGRADE_ENDPOINT, json_decode(@file_get_contents(__DIR__ . '/../../fixtures/api-distribution/empty_autoupgrade.json'), true)],
             ]));
 
         $this->expectException(DistributionApiException::class);
-        $this->expectExceptionMessage('Unable to retrieve Update Assistant compatibilities from distribution API.');
+        $this->expectExceptionMessage('Unable to retrieve "autoupgrade" data from distribution API.');
 
         $this->phpVersionResolverService->getPrestashopDestinationRelease(80000);
     }
@@ -223,8 +223,8 @@ class PhpVersionResolverServiceTest extends TestCase
     {
         $this->distributionApiService->method('getApiEndpoint')
             ->will($this->returnValueMap([
-                ['/prestashop', json_decode(@file_get_contents(__DIR__ . '/../../fixtures/api-distribution/prestashop.json'), true)],
-                ['/autoupgrade', json_decode(@file_get_contents(__DIR__ . '/../../fixtures/api-distribution/autoupgrade.json'), true)],
+                [DistributionApiService::PRESTASHOP_ENDPOINT, json_decode(@file_get_contents(__DIR__ . '/../../fixtures/api-distribution/prestashop.json'), true)],
+                [DistributionApiService::AUTOUPGRADE_ENDPOINT, json_decode(@file_get_contents(__DIR__ . '/../../fixtures/api-distribution/autoupgrade.json'), true)],
             ]));
 
         $this->assertEquals($expected, $this->phpVersionResolverService->getPrestashopDestinationRelease($input));


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | On upgrade and restore process we try to load the XML file from old deprecated API, this PR fix this to use the updated distribution API endpoint.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     |  no
| Fixed ticket?     | N/A
| Sponsor company   | @PrestaShopCorp
| How to test?      | Try upgrade on V9 if everything work the fix it's ok !

Fix:
 - cache warmup
 - load XML from distribution API data
 - display the modal if no release not provided
