### PR TITLE
Check PHP function symlink exists in pre-requirements

### DIFF
--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -676,7 +676,7 @@ class UpgradeSelfCheck
         $functions = [];
         foreach ([
                      'fopen', 'fclose', 'fread', 'fwrite', 'rename', 'file_exists', 'unlink', 'rmdir', 'mkdir', 'getcwd',
-                     'chdir', 'chmod',
+                     'chdir', 'chmod', 'symlink',
                  ] as $function) {
             if (!ConfigurationTest::test_system([$function])) {
                 $functions[] = $function;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | As PrestaShop v9 provides symbolic links, we must make sure the module will be able to handle them. We check it for all versions of PrestaShop because some environment already got symlinks from other actions, so they will be handled in backup and restore.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | https://github.com/PrestaShop/PrestaShop/issues/38892
| Sponsor company   | @PrestaShopCorp
| How to test?      | Disable `symlink` in your PHP environment by adding `disable_functions=symlink` in your php.ini. After restarting your PHP engine, the module should prevent you to pass the requirements step by displaying a message about the missing symlink method.