### PR TITLE
Stop using Tools14::file_get_contents that unexpectedly cleans the current PHP buffer in some cases

### DIFF
--- a/autoupgrade.php
+++ b/autoupgrade.php
@@ -223,6 +223,10 @@ class Autoupgrade extends Module
             return '';
         }
 
+        if (isset($this->context->controller->ajax) && $this->context->controller->ajax) {
+            return '';
+        }
+
         return (new \PrestaShop\Module\AutoUpgrade\Hooks\DisplayBackOfficeHeader($this->getUpgradeContainer()))->renderUpdateNotification();
     }
 

--- a/classes/Parameters/FileStorage.php
+++ b/classes/Parameters/FileStorage.php
@@ -21,7 +21,6 @@
 
 namespace PrestaShop\Module\AutoUpgrade\Parameters;
 
-use PrestaShop\Module\AutoUpgrade\Tools14;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -60,7 +59,7 @@ class FileStorage
         $config = [];
 
         if ($this->filesystem->exists($configFilePath)) {
-            $config = @unserialize(base64_decode(Tools14::file_get_contents($configFilePath)));
+            $config = @unserialize(base64_decode(file_get_contents($configFilePath)));
         }
 
         return $config;

--- a/classes/Tools14.php
+++ b/classes/Tools14.php
@@ -168,49 +168,6 @@ class Tools14
         return in_array(ini_get('allow_url_fopen'), ['On', 'on', '1']) || !preg_match('/^https?:\/\//', $url);
     }
 
-    public static function file_get_contents(string $url, bool $use_include_path = false, $stream_context = null, int $curl_timeout = 5)
-    {
-        if (!extension_loaded('openssl') && strpos('https://', $url) === true) {
-            $url = str_replace('https', 'http', $url);
-        }
-        if ($stream_context == null && preg_match('/^https?:\/\//', $url)) {
-            $stream_context = @stream_context_create(['http' => ['timeout' => $curl_timeout, 'header' => "User-Agent:MyAgent/1.0\r\n"]]);
-        }
-        if (self::shouldUseFopen($url)) {
-            $var = @file_get_contents($url, $use_include_path, $stream_context);
-
-            /* PSCSX-3205 buffer output ? */
-            if (self::getValue('ajaxMode') && ob_get_level() && ob_get_length() > 0) {
-                ob_clean();
-            }
-
-            if ($var) {
-                return $var;
-            }
-        } elseif (function_exists('curl_init')) {
-            $curl = curl_init();
-            curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-            curl_setopt($curl, CURLOPT_URL, $url);
-            curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 5);
-            curl_setopt($curl, CURLOPT_TIMEOUT, $curl_timeout);
-            curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 0);
-            $opts = stream_context_get_options($stream_context);
-            if (isset($opts['http']['method']) && self::strtolower($opts['http']['method']) == 'post') {
-                curl_setopt($curl, CURLOPT_POST, true);
-                if (isset($opts['http']['content'])) {
-                    parse_str($opts['http']['content'], $datas);
-                    curl_setopt($curl, CURLOPT_POSTFIELDS, $datas);
-                }
-            }
-            $content = curl_exec($curl);
-            curl_close($curl);
-
-            return $content;
-        }
-
-        return false;
-    }
-
     public static function nl2br(string $str): string
     {
         return str_replace(["\r\n", "\r", "\n"], '<br />', $str);

--- a/classes/Xml/FileLoader.php
+++ b/classes/Xml/FileLoader.php
@@ -23,7 +23,6 @@ namespace PrestaShop\Module\AutoUpgrade\Xml;
 
 use PrestaShop\Module\AutoUpgrade\Exceptions\DistributionApiException;
 use PrestaShop\Module\AutoUpgrade\Services\DistributionApiService;
-use PrestaShop\Module\AutoUpgrade\Tools14;
 use PrestaShop\Module\AutoUpgrade\Upgrader;
 use SimpleXMLElement;
 use Symfony\Component\Filesystem\Filesystem;
@@ -58,7 +57,7 @@ class FileLoader
         // End TODO
 
         if ($refresh || !$this->filesystem->exists($xml_localfile) || @filemtime($xml_localfile) < (time() - (3600 * Upgrader::DEFAULT_CHECK_VERSION_DELAY_HOURS))) {
-            $xml_string = Tools14::file_get_contents($xml_remotefile, false, stream_context_create(['http' => ['timeout' => 10]]));
+            $xml_string = file_get_contents($xml_remotefile, false, stream_context_create(['http' => ['timeout' => 10]]));
             $xml = @simplexml_load_string($xml_string);
             if ($xml !== false) {
                 $this->filesystem->dumpFile($xml_localfile, $xml_string);


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Remove the code responsible of dropping the buffer that was ready for display.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/39068
| Sponsor company   | @PrestaShopCorp
| How to test?      | Follow the steps in the issue