### PR TITLE
[FEAT] Add usage of AUTOUPGRADE_DISABLE_AVAILABLE_UPDATE_MODAL variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,15 @@ impact.
 | `backup:create`                             | `PS_AUTOUP_KEEP_IMAGES`                       | `--include-images`             | `true` (default), `false`, `'true'`, `'false'`, `'1'`, `'0'`, `1`, `0`, `'on'`, `'off'` | If enabled, retains all images in the backup. This operation can take a long time depending on the storage of your images                     |
 | `backup:restore`                            | no option available                           | `--backup`                     | Valid file name                                                                         | Specify the backup name to restore. The allowed values can be found with backup:list command)                                                 |
 | `backup:delete`                             | no option available                           | `--backup`                     | Valid file name                                                                         | Specify the backup name to delete. The allowed values can be found with backup:list command)                                                  |
+|                                             |                                               |                                |                                                                                         |                                                                                                                                               |
+
+### Back Office Environment Variables
+
+You can configure module behavior by setting the following environment variables on your server or in your `.htaccess` file::
+
+| Variable                                                    | Possible Values   | Default | Behavior                                                                                                                   |
+|-------------------------------------------------------------|-------------------|---------|----------------------------------------------------------------------------------------------------------------------------|
+| `AUTOUPGRADE_DISABLE_AVAILABLE_UPDATE_MODAL`                | `true`, `false`   | `true`  | `true` disables the update modal and short-circuits the entire check (no API call, no timestamp update, no modal display). |
 
 ## Test module updates locally
 

--- a/README.md
+++ b/README.md
@@ -198,9 +198,9 @@ impact.
 
 You can configure the module behavior by setting the following environment variables on your server or in your `.htaccess` file::
 
-| Variable                                                    | Possible Values   | Default | Behavior                                                                                                                   |
-|-------------------------------------------------------------|-------------------|---------|----------------------------------------------------------------------------------------------------------------------------|
-| `AUTOUPGRADE_DISABLE_AVAILABLE_UPDATE_MODAL`                | `true`, `false`   | `true`  | `true` disables the update modal and short-circuits the entire check (no API call, no timestamp update, no modal display). |
+| Variable                                                    | Possible Values   | Default | Behavior                                                                                                            |
+|-------------------------------------------------------------|-------------------|---------|---------------------------------------------------------------------------------------------------------------------|
+| `AUTOUPGRADE_DISABLE_AVAILABLE_UPDATE_MODAL`                | `true`, `false`   | `true`  | `true` disables the update modal and shorts the entire check (no API call, no timestamp update, no modal display).  |
 
 ## Test module updates locally
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ impact.
 
 ### Back Office Environment Variables
 
-You can configure module behavior by setting the following environment variables on your server or in your `.htaccess` file::
+You can configure the module behavior by setting the following environment variables on your server or in your `.htaccess` file::
 
 | Variable                                                    | Possible Values   | Default | Behavior                                                                                                                   |
 |-------------------------------------------------------------|-------------------|---------|----------------------------------------------------------------------------------------------------------------------------|

--- a/classes/Hooks/DisplayBackOfficeHeader.php
+++ b/classes/Hooks/DisplayBackOfficeHeader.php
@@ -115,6 +115,11 @@ class DisplayBackOfficeHeader
      */
     public function renderUpdateNotification(): string
     {
+        $disableModal = getenv('AUTOUPGRADE_DISABLE_AVAILABLE_UPDATE_MODAL');
+        if ($disableModal !== false && filter_var($disableModal, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)) {
+            return $this->content;
+        }
+
         if (
             !$this->updateNotificationConfiguration->getTimestamp()
             || time() > $this->updateNotificationConfiguration->getTimestamp()

--- a/classes/Hooks/DisplayBackOfficeHeader.php
+++ b/classes/Hooks/DisplayBackOfficeHeader.php
@@ -116,7 +116,7 @@ class DisplayBackOfficeHeader
     public function renderUpdateNotification(): string
     {
         $disableModal = getenv('AUTOUPGRADE_DISABLE_AVAILABLE_UPDATE_MODAL');
-        if ($disableModal !== false && filter_var($disableModal, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)) {
+        if (filter_var($disableModal, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)) {
             return $this->content;
         }
 


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Introduce the `AUTOUPGRADE_DISABLE_AVAILABLE_UPDATE_MODAL` environment variable to enable or disable the update notification modal.
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | @PrestaShopCorp
| How to test?      | 1.1. In your Back Office `.htaccess` (or server environment), set:<br>   ```SetEnv AUTOUPGRADE_DISABLE_AVAILABLE_UPDATE_MODAL true``` <br>1.2. *(alternative)* Set the environment variable `AUTOUPGRADE_DISABLE_AVAILABLE_UPDATE_MODAL` to `true` on your `docker-compose.yml`<br>2. Clear PrestaShop cache.<br>3. Reload user default BO page and verify that the update modal **never** appears, even when an update is available.<br>4. Remove the variable or set it to `false`, clear cache again, reload BO, and confirm that the modal **does** appear when an update is available.