### PR TITLE
Add new hooks: actionOrderHasBeenShipped and actionOrderHasBeenDelivered

### DIFF
--- a/upgrade/sql/8.2.2.sql
+++ b/upgrade/sql/8.2.2.sql
@@ -16,7 +16,10 @@ INSERT INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`
   -- https://github.com/PrestaShop/PrestaShop/pull/38691
   (NULL, 'displayCartExtraProductInfo','Extra information in shopping cart product line','This hook adds extra information to the product lines, in the shopping cart', '1'),
   -- https://github.com/PrestaShop/PrestaShop/pull/38772
-  (NULL, 'displayCustomerAccountTop','Customer account displayed in Front Office (Top part)','This hook displays new elements on the customer account page on Top', '1')
+  (NULL, 'displayCustomerAccountTop','Customer account displayed in Front Office (Top part)','This hook displays new elements on the customer account page on Top', '1'),
+  -- https://github.com/PrestaShop/PrestaShop/pull/39162
+  (NULL, 'actionOrderHasBeenShipped', 'Called when checking if an order has been shipped', 'Allows modules to override or react to the hasBeenShipped() method of the Order class.', '1'),
+  (NULL, 'actionOrderHasBeenDelivered', 'Called when checking if an order has been delivered', 'Allows modules to override or react to the hasBeenDelivered() method of the Order class.', '1')
 ON DUPLICATE KEY UPDATE `title` = VALUES(`title`), `description` = VALUES(`description`);
 
 ALTER TABLE `PREFIX_product_shop` ADD INDEX `shop_tax` (`id_shop`, `id_tax_rules_group`);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add new hooks: actionOrderHasBeenShipped and actionOrderHasBeenDelivered
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Discussion https://github.com/PrestaShop/PrestaShop/discussions/38503
Related PRs | https://github.com/PrestaShop/PrestaShop/pull/39162
| Sponsor company   | Codencode
| How to test?      | Indicate how to verify that this change works as expected.
