### PR TITLE
Provide absolute URL to fix routing issues

### DIFF
--- a/controllers/admin/AdminSelfUpgradeController.php
+++ b/controllers/admin/AdminSelfUpgradeController.php
@@ -229,13 +229,6 @@ class AdminSelfUpgradeController extends ModuleAdminController
                 $this->context->employee->id,
                 $this->context->language->iso_code
             );
-
-            if (isset($_GET['refreshCurrentVersion'])) {
-                // delete the potential xml files we saved in config/xml (from last release and from current)
-                $upgrader->clearXmlMd5File($this->upgradeContainer->getProperty(UpgradeContainer::PS_VERSION));
-                $upgrader->clearXmlMd5File($upgrader->getDestinationVersion());
-                Tools14::redirectAdmin($this->context->link->getAdminLink('AdminSelfUpgrade', false) . '&conf=5&token=' . Tools14::getValue('token'));
-            }
         }
     }
 

--- a/controllers/admin/AdminSelfUpgradeController.php
+++ b/controllers/admin/AdminSelfUpgradeController.php
@@ -110,8 +110,6 @@ class AdminSelfUpgradeController extends ModuleAdminController
 
         $this->db = Db::getInstance();
 
-        self::$currentIndex = $_SERVER['SCRIPT_NAME'] . (($controller = Tools14::getValue('controller')) ? '?controller=' . $controller : '');
-
         if (defined('_PS_ADMIN_DIR_')) {
             // Check that the Update assistant working directory is existing or create it
             if (!file_exists($this->autoupgradePath) && !@mkdir($this->autoupgradePath)) {
@@ -236,7 +234,7 @@ class AdminSelfUpgradeController extends ModuleAdminController
                 // delete the potential xml files we saved in config/xml (from last release and from current)
                 $upgrader->clearXmlMd5File($this->upgradeContainer->getProperty(UpgradeContainer::PS_VERSION));
                 $upgrader->clearXmlMd5File($upgrader->getDestinationVersion());
-                Tools14::redirectAdmin(self::$currentIndex . '&conf=5&token=' . Tools14::getValue('token'));
+                Tools14::redirectAdmin($this->context->link->getAdminLink('AdminSelfUpgrade', false) . '&conf=5&token=' . Tools14::getValue('token'));
             }
         }
     }

--- a/controllers/admin/AdminSelfUpgradeController.php
+++ b/controllers/admin/AdminSelfUpgradeController.php
@@ -21,7 +21,6 @@
 
 use PrestaShop\Module\AutoUpgrade\DocumentationLinks;
 use PrestaShop\Module\AutoUpgrade\Router\Router;
-use PrestaShop\Module\AutoUpgrade\Tools14;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 use PrestaShop\Module\AutoUpgrade\VersionUtils;
 use Symfony\Component\HttpFoundation\Request;


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Provide absolute URL to fix routing issues. Fixes potential issues coming from relative URLs not being reliable after symfony migration. See https://github.com/PrestaShop/PrestaShop/issues/39185. cc @Touxten 
| Type?             | refactor
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/39185
| Sponsor company   | TRENDO s.r.o.
| How to test?      | Just test the module can be configured correctly and loads in the backoffice, so we didn't break anything or have some typo. (On nginx server, this could be problematic.)
