### PR TITLE
Make display of release notes optional in update notification modal

### DIFF
--- a/views/templates/hooks/dialog-update-notification.html.twig
+++ b/views/templates/hooks/dialog-update-notification.html.twig
@@ -49,7 +49,9 @@
             {% elseif version_type == 'major' %}
               {{ 'Major releases introduce new features that may break backward compatibility, as well as new backward-compatible features and bug fixes.'|trans({}) }}
             {% endif %}
-            <a class="dialog-notification__link" href="{{ release_note }}" target="_blank">{{ 'See the update'|trans({}) }}</a>
+            {% if release_note is not empty %}
+              <a class="dialog-notification__link" href="{{ release_note }}" target="_blank">{{ 'See the update'|trans({}) }}</a>
+            {% endif %}
           </p>
         </div>
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | If a new release is displayed on the new update notification modal but does not have a release note yet, clicking on the "See the update" will have no effect but refreshing the page. This PR hides the link when the release has no notes attached. 
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | See below


### How to test?

You can fake the release 8.2.2 by modifying the function `getAutoupgradeCompatibilities()` in the file `autoupgrade/classes/Services/DistributionApiService.php`:

```php
    public function getAutoupgradeCompatibilities(): array
    {
        // return $this->getEndpointData(self::AUTOUPGRADE_ENDPOINT);

        return $this->createAutoupgradeReleaseCollection(json_decode('{
  "prestashop": [
    {
      "prestashop_min": "1.7.0.0",
      "prestashop_max": "8.2.2",
      "autoupgrade_recommended": {
        "last_version": "7.1.0",
        "download": {
          "link": "https://github.com/PrestaShop/autoupgrade/releases/download/v7.1.0/autoupgrade-v7.1.0.zip",
          "md5": "974024b034c55773ee2df93e18fded42"
        },
        "changelog": "https://github.com/PrestaShop/autoupgrade/releases/tag/v7.1.0"
      }
    },
    {
      "prestashop_min": "9.0.0",
      "prestashop_max": "9.0.0",
      "autoupgrade_recommended": {
        "last_version": "7.1.0",
        "download": {
          "link": "https://github.com/PrestaShop/autoupgrade/releases/download/v7.1.0/autoupgrade-v7.1.0.zip",
          "md5": "974024b034c55773ee2df93e18fded42"
        },
        "changelog": "https://github.com/PrestaShop/autoupgrade/releases/tag/v7.1.0"
      }
    },
    {
      "prestashop_min": "1.6.0.0",
      "prestashop_max": "1.7.8.11",
      "autoupgrade_recommended": {
        "last_version": "4.16.4",
        "download": {
          "link": "https://github.com/PrestaShop/autoupgrade/releases/download/v4.16.4/autoupgrade.zip",
          "md5": "3639dd7c9910f2805777cbcae129ef1a"
        }
      }
    }
  ]
}
', true));
    }
```
<img width="960" height="560" alt="Capture d’écran du 2025-07-31 12-08-39" src="https://github.com/user-attachments/assets/91e42ab6-d37b-43c3-8123-b52b277947e3" />
<img width="960" height="560" alt="Capture d’écran du 2025-07-31 12-08-22" src="https://github.com/user-attachments/assets/68c9552b-9d41-4140-ba0d-efd94910a31d" />


