### PR TITLE
Disable upgrade notification modal

### DIFF
--- a/classes/Hooks/DisplayBackOfficeHeader.php
+++ b/classes/Hooks/DisplayBackOfficeHeader.php
@@ -115,6 +115,9 @@ class DisplayBackOfficeHeader
      */
     public function renderUpdateNotification(): string
     {
+        // Temporarily disable this modal before better solution is found
+        return $this->content;
+
         $disableModal = getenv('AUTOUPGRADE_DISABLE_AVAILABLE_UPDATE_MODAL');
         if (filter_var($disableModal, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)) {
             return $this->content;


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | I need to bring this up to attention. Just this week we had like 5 customers on Openservis hosting who upgraded and broke their shop because of upgrade to 9.0.0, that doesn't work. When we ask `"Why did you upgrade"`, the customer tells us `"Because it shown a popup, so I clicked it"`. I know there is a environment variable that disables this, but we can't put it to env of every customer, this must be a default behavior. Upgrading a shop is not something that a regular user should do in production. It fails many times if the shop is not prepared. People don't know their modules are not compatible, they are not prepared for it, they forget they have custom modifications. What also doesn't help is that the only version it offers to upgrade is 9.0.0, **we can't push people to a version that is not ready**.
| Type?             | refactor
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | [OpenServis](https://www.openservis.cz/)
| How to test?      | 

cc @ShaiMagal @Quetzacoalt91 @M0rgan01 