### PR TITLE
[FEAT] remove all folder on uninstall except backups

### DIFF
--- a/autoupgrade.php
+++ b/autoupgrade.php
@@ -131,33 +131,10 @@ class Autoupgrade extends Module
             $ajaxTab->delete();
         }
 
-        // Remove the 'autoupgrade' working directory
-        $this->_cleanDirectoryExcept(_PS_ADMIN_DIR_ . DIRECTORY_SEPARATOR . 'autoupgrade', ['backup']);
+        // Remove the 'autoupgrade' admin directory except backups
+        $this->getUpgradeContainer()->getFilesystemAdapter()->clearDirectory(_PS_ADMIN_DIR_ . DIRECTORY_SEPARATOR . 'autoupgrade', ['backup']);
 
         return parent::uninstall();
-    }
-
-    /**
-     * @param string $directory
-     * @param string[] $excluded
-     *
-     * @return void
-     */
-    public function _cleanDirectoryExcept(string $directory, array $excluded = []): void
-    {
-        foreach (scandir($directory) as $item) {
-            if ($item === '.' || $item === '..' || in_array($item, $excluded, true)) {
-                continue;
-            }
-
-            $path = $directory . DIRECTORY_SEPARATOR . $item;
-
-            if (is_dir($path)) {
-                Tools::deleteDirectory($path);
-            } elseif (is_file($path)) {
-                Tools::deleteFile($path);
-            }
-        }
     }
 
     /**

--- a/autoupgrade.php
+++ b/autoupgrade.php
@@ -131,10 +131,33 @@ class Autoupgrade extends Module
             $ajaxTab->delete();
         }
 
-        // Remove the 1-click upgrade working directory
-        self::_removeDirectory(_PS_ADMIN_DIR_ . DIRECTORY_SEPARATOR . 'autoupgrade');
+        // Remove the 'autoupgrade' working directory
+        $this->_cleanDirectoryExcept(_PS_ADMIN_DIR_ . DIRECTORY_SEPARATOR . 'autoupgrade', ['backup']);
 
         return parent::uninstall();
+    }
+
+    /**
+     * @param string $directory
+     * @param string[] $excluded
+     *
+     * @return void
+     */
+    public function _cleanDirectoryExcept(string $directory, array $excluded = []): void
+    {
+        foreach (scandir($directory) as $item) {
+            if ($item === '.' || $item === '..' || in_array($item, $excluded, true)) {
+                continue;
+            }
+
+            $path = $directory . DIRECTORY_SEPARATOR . $item;
+
+            if (is_dir($path)) {
+                Tools::deleteDirectory($path);
+            } elseif (is_file($path)) {
+                Tools::deleteFile($path);
+            }
+        }
     }
 
     /**
@@ -157,29 +180,6 @@ class Autoupgrade extends Module
         $this->_errors[] = $error;
 
         return false;
-    }
-
-    /**
-     * @param string $dir
-     *
-     * @return void
-     */
-    private static function _removeDirectory($dir)
-    {
-        if ($handle = @opendir($dir)) {
-            while (false !== ($entry = @readdir($handle))) {
-                if ($entry != '.' && $entry != '..') {
-                    if (is_dir($dir . DIRECTORY_SEPARATOR . $entry) === true) {
-                        self::_removeDirectory($dir . DIRECTORY_SEPARATOR . $entry);
-                    } else {
-                        @unlink($dir . DIRECTORY_SEPARATOR . $entry);
-                    }
-                }
-            }
-
-            @closedir($handle);
-            @rmdir($dir);
-        }
     }
 
     /**

--- a/classes/UpgradeTools/FilesystemAdapter.php
+++ b/classes/UpgradeTools/FilesystemAdapter.php
@@ -232,15 +232,17 @@ class FilesystemAdapter
     }
 
     /**
-     * Clears the contents of a given directory, optionally deleting the directory itself.
-     *
-     * @throws IOException if the removal of a file or directory fails
+     * Clears the contents of a given directory, excluding specified items,
+     * * optionally deleting the directory itself.
      *
      * @param string $folderToClear the absolute path of the directory to be cleared
+     * @param string[] $excluded list of file or directory names to exclude from deletion
      *
      * @return bool returns `true` if any files/folders were deleted, `false` otherwise
+     *
+     * @throws IOException if the removal of a file or directory fails
      */
-    public function clearDirectory(string $folderToClear): bool
+    public function clearDirectory(string $folderToClear, array $excluded = []): bool
     {
         $hasDeletedItems = false;
 
@@ -248,20 +250,25 @@ class FilesystemAdapter
             return $hasDeletedItems;
         }
 
+        $excluded[] = 'index.php';
+
         $directory = new FilesystemIterator(
             $folderToClear, FilesystemIterator::SKIP_DOTS | FilesystemIterator::CURRENT_AS_FILEINFO
         );
-        $filter = new CallbackFilterIterator($directory, function ($current) {
-            return $current->getFilename() !== 'index.php';
+
+        $filter = new CallbackFilterIterator($directory, function ($current) use ($excluded) {
+            return !in_array($current->getFilename(), $excluded, true);
         });
+
         $iterator = new IteratorIterator($filter);
 
         foreach ($iterator as $file) {
             $this->filesystem->remove($file);
+            $hasDeletedItems = true;
         }
 
         clearstatcache();
 
-        return (bool) iterator_count($iterator);
+        return $hasDeletedItems;
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | We now keep the backup file when uninstalling autoupgrade in case the module is reinstalled later and the user wants to reuse a backup made previously-
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | @PrestaShopCorp
| How to test?      | Make a backup, uninstall and reinstall the module, the backup must still be present.
