### PR TITLE
Add new type column on cart_rule_product_rule_group table

### DIFF
--- a/upgrade/sql/9.1.0.sql
+++ b/upgrade/sql/9.1.0.sql
@@ -43,3 +43,5 @@ ALTER TABLE `PREFIX_cart_rule_product_rule` MODIFY COLUMN `type` ENUM(
     'products', 'categories', 'attributes',
     'manufacturers', 'suppliers', 'combinations'
 ) NOT NULL;
+
+/* PHP:add_column('cart_rule_product_rule_group', 'type', 'ENUM("at_least_one_product_rule", "all_product_rules") NOT NULL DEFAULT "at_least_one_product_rule"'); */;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add new type column on cart_rule_product_rule_group table
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Sponsor company   | ~
| How to test?      | Upgrade from a lower version to 9.1.0, the table `cart_rule_product_rule_group` should contain a new enum column, all existing rows have the default value `at_least_one_product_rule`

Related PR from the core:
https://github.com/PrestaShop/PrestaShop/pull/39418