### PR TITLE
Run command "assets:install" during the update process for PS 9.0.1

### DIFF
--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -1038,10 +1038,13 @@ class UpgradeContainer
     public function loadNecessaryClasses(): void
     {
         // PrestaShop v9.0.0
-        class_exists(Table::class);
-        class_exists(TableStyle::class);
-        class_exists(Helper::class);
-        class_exists(ResponseHeaderBag::class);
+        if (php_sapi_name() === 'cli') {
+            class_exists(Table::class);
+            class_exists(TableStyle::class);
+            class_exists(Helper::class);
+        } else {
+            class_exists(ResponseHeaderBag::class);
+        }
     }
 
     /**

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -673,17 +673,24 @@ class UpgradeSelfCheck
         if (!class_exists(ConfigurationTest::class)) {
             return [];
         }
-        $functions = [];
-        foreach ([
-                     'fopen', 'fclose', 'fread', 'fwrite', 'rename', 'file_exists', 'unlink', 'rmdir', 'mkdir', 'getcwd',
-                     'chdir', 'chmod',
-                 ] as $function) {
+
+        $neededFunctions = [
+            'fopen', 'fclose', 'fread', 'fwrite', 'rename', 'file_exists', 'unlink', 'rmdir', 'mkdir', 'getcwd',
+            'chdir', 'chmod',
+        ];
+
+        if ($this->destinationVersion === '9.0.0') {
+            $neededFunctions[] = 'symlink';
+        }
+
+        $missingFunctions = [];
+        foreach ($neededFunctions as $function) {
             if (!ConfigurationTest::test_system([$function])) {
-                $functions[] = $function;
+                $missingFunctions[] = $function;
             }
         }
 
-        return $functions;
+        return $missingFunctions;
     }
 
     /**

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -676,7 +676,7 @@ class UpgradeSelfCheck
         $functions = [];
         foreach ([
                      'fopen', 'fclose', 'fread', 'fwrite', 'rename', 'file_exists', 'unlink', 'rmdir', 'mkdir', 'getcwd',
-                     'chdir', 'chmod', 'symlink',
+                     'chdir', 'chmod',
                  ] as $function) {
             if (!ConfigurationTest::test_system([$function])) {
                 $functions[] = $function;

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -33,6 +33,7 @@ use PrestaShop\Module\AutoUpgrade\Log\LoggerInterface;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\ThemeAdapter;
+use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Domain\Theme\Command\AdaptThemeToRTLLanguagesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Theme\ValueObject\ThemeName;
@@ -120,6 +121,8 @@ abstract class CoreUpgrader
         $this->runRecurrentQueries();
 
         $this->logger->info($this->container->getTranslator()->trans('Database update OK')); // no error!
+
+        $this->installAssets();
 
         $this->logger->info($this->container->getTranslator()->trans('Updating languages'));
         $this->upgradeLanguages();
@@ -868,5 +871,27 @@ abstract class CoreUpgrader
             throw new UpgradeException($this->container->getTranslator()->trans("An error was raised when warming up the core cache: \n %s", [implode("\n", $output)]));
         }
         $this->logger->debug($this->container->getTranslator()->trans('Core cache has been generated to avoid dependency conflicts.'));
+    }
+
+    /**
+     * PrestaShop 9.0.1 adds an helper function that runs "assets:install".
+     * It install some bundles assets via symlink or hard copy if symlink aren't possible in this environment.
+     */
+    private function installAssets(): void
+    {
+        $classPath = '\PrestaShop\PrestaShop\Adapter\Bundle\AssetsInstaller';
+        $containerClassPath = '\PrestaShop\PrestaShop\Adapter\SymfonyContainer';
+
+        if (!class_exists($classPath) || !class_exists($containerClassPath)) {
+            // Nothing to do if the class does not exist in the version we update to.
+            return;
+        }
+
+        $this->logger->info($this->container->getTranslator()->trans('Installing assets'));
+
+        /** @var \PrestaShop\PrestaShop\Adapter\Bundle\AssetsInstaller */
+        $service = SymfonyContainer::getInstance()
+            ->get($classPath);
+        $service->installAssets($this->container->getProperty(UpgradeContainer::PS_ADMIN_SUBDIR));
     }
 }

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -33,7 +33,6 @@ use PrestaShop\Module\AutoUpgrade\Log\LoggerInterface;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\ThemeAdapter;
-use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Domain\Theme\Command\AdaptThemeToRTLLanguagesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Theme\ValueObject\ThemeName;
@@ -879,19 +878,27 @@ abstract class CoreUpgrader
      */
     private function installAssets(): void
     {
-        $classPath = '\PrestaShop\PrestaShop\Adapter\Bundle\AssetsInstaller';
-        $containerClassPath = '\PrestaShop\PrestaShop\Adapter\SymfonyContainer';
-
-        if (!class_exists($classPath) || !class_exists($containerClassPath)) {
+        if (!class_exists('PrestaShop\PrestaShop\Adapter\Bundle\AssetsInstaller')) {
             // Nothing to do if the class does not exist in the version we update to.
             return;
         }
 
         $this->logger->info($this->container->getTranslator()->trans('Installing assets'));
 
-        /** @var \PrestaShop\PrestaShop\Adapter\Bundle\AssetsInstaller */
-        $service = SymfonyContainer::getInstance()
-            ->get($classPath);
-        $service->installAssets($this->container->getProperty(UpgradeContainer::PS_ADMIN_SUBDIR));
+        // Calling PrestaShop\PrestaShop\Adapter\Bundle\AssetsInstaller::installAssets() is impossible at the time of writing of this method.
+        // Attempting to call it from Update Assistant v7 triggers a collision between the versions of the package smyfony/console provided
+        // by the core and Update Assistant. We run a basic exec to avoid it.
+
+        $rootPath = $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH);
+        $adminSubDir = $this->container->getProperty(UpgradeContainer::PS_ADMIN_SUBDIR);
+        $command = 'php ' . $rootPath . '/bin/console assets:install --symlink --no-interaction --env=prod ' . $adminSubDir;
+        $output = [];
+        $resultCode = 0;
+
+        exec($command, $output, $resultCode);
+
+        if ($resultCode !== 0) {
+            throw new UpgradeException($this->container->getTranslator()->trans("An error was raised while installing assets: \n %s", [implode("\n", $output)]));
+        }
     }
 }

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -898,7 +898,7 @@ abstract class CoreUpgrader
         exec($command, $output, $resultCode);
 
         if ($resultCode !== 0) {
-            throw new UpgradeException($this->container->getTranslator()->trans("An error was raised while installing assets: \n %s", [implode("\n", $output)]));
+            throw new UpgradeException($this->container->getTranslator()->trans("A code %d was returned while installing assets: \n %s", [$resultCode, implode("\n", $output)]));
         }
     }
 }

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -859,15 +859,11 @@ abstract class CoreUpgrader
      */
     public function warmupCoreCache(): void
     {
-        $rootPath = $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH);
-        $command = 'php ' . $rootPath . '/bin/console cache:warmup --no-interaction --no-optional-warmers --env=prod';
-        $output = [];
-        $resultCode = 0;
+        $args = 'cache:warmup --no-interaction --no-optional-warmers --env=prod';
+        $result = $this->callCoreConsoleCommand($args);
 
-        exec($command, $output, $resultCode);
-
-        if ($resultCode !== 0) {
-            throw new UpgradeException($this->container->getTranslator()->trans("An error was raised when warming up the core cache: \n %s", [implode("\n", $output)]));
+        if ($result['returnCode'] !== 0) {
+            throw new UpgradeException($this->container->getTranslator()->trans("An error was raised when warming up the core cache: \n %s", [implode("\n", $result['output'])]));
         }
         $this->logger->debug($this->container->getTranslator()->trans('Core cache has been generated to avoid dependency conflicts.'));
     }
@@ -889,16 +885,38 @@ abstract class CoreUpgrader
         // Attempting to call it from Update Assistant v7 triggers a collision between the versions of the package symfony/console provided
         // by the core and Update Assistant. We run a basic exec to avoid it.
 
-        $rootPath = $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH);
         $adminSubDir = $this->container->getProperty(UpgradeContainer::PS_ADMIN_SUBDIR);
-        $command = 'php ' . $rootPath . '/bin/console assets:install --symlink --no-interaction --env=prod ' . $adminSubDir;
-        $output = [];
-        $resultCode = 0;
+        $args = 'assets:install --symlink --no-interaction --env=prod ' . $adminSubDir;
+        $result = $this->callCoreConsoleCommand($args);
 
-        exec($command, $output, $resultCode);
-
-        if ($resultCode !== 0) {
-            throw new UpgradeException($this->container->getTranslator()->trans("A code %d was returned while installing assets: \n %s", [$resultCode, implode("\n", $output)]));
+        if ($result['returnCode'] !== 0) {
+            throw new UpgradeException($this->container->getTranslator()->trans("A code %d was returned while installing assets: \n %s", [$result['returnCode'], implode("\n", $result['output'])]));
         }
+    }
+
+    /**
+     * The shell may be very minimal on some hosts (e.g. dash on Debian/Ubuntu, or restricted shells in shared hosting).
+     * That often means the $PATH is stripped down and php is not found. So we try to rely first on the console file when it is executable.
+     *
+     * @return array{returnCode: int, output: string[]}
+     */
+    private function callCoreConsoleCommand(string $args)
+    {
+        $rootPath = $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH);
+        $command = $rootPath . '/bin/console';
+
+        if (!is_executable($command)) {
+            $command = 'php ' . $command;
+        }
+
+        $output = [];
+        $returnCode = 0;
+
+        exec($command . ' ' . $args, $output, $returnCode);
+
+        return [
+            'returnCode' => $returnCode,
+            'output' => $output,
+        ];
     }
 }

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -886,7 +886,7 @@ abstract class CoreUpgrader
         $this->logger->info($this->container->getTranslator()->trans('Installing assets'));
 
         // Calling PrestaShop\PrestaShop\Adapter\Bundle\AssetsInstaller::installAssets() is impossible at the time of writing of this method.
-        // Attempting to call it from Update Assistant v7 triggers a collision between the versions of the package smyfony/console provided
+        // Attempting to call it from Update Assistant v7 triggers a collision between the versions of the package symfony/console provided
         // by the core and Update Assistant. We run a basic exec to avoid it.
 
         $rootPath = $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Prepare Update Assistant to be compliant with PS 9.0.1. It replaces the management of symlink inside the archive with the command "assets:install".
| Type?             | new feature
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/38892, fixes https://github.com/PrestaShop/PrestaShop/issues/38960<br>Related to https://github.com/PrestaShop/PrestaShop/pull/39327
| Sponsor company   | @PrestaShopCorp
| How to test?      | Update can run even if the server does not handle symlinks