### PR TITLE
Remove theme_name field from update sql file

### DIFF
--- a/upgrade/sql/9.0.1.sql
+++ b/upgrade/sql/9.0.1.sql
@@ -11,3 +11,10 @@ ON DUPLICATE KEY UPDATE `title` = VALUES(`title`), `description` = VALUES(`descr
 INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES
   ('PS_MIN_LOGGER_LEVEL_IN_DB', '1', NOW(), NOW())
 ON DUPLICATE KEY UPDATE `value` = VALUES(`value`);
+
+/* Remove theme_name field from image_type table */
+/* https://github.com/PrestaShop/PrestaShop/pull/39554 */
+ALTER TABLE `PREFIX_image_type`
+    DROP COLUMN `theme_name`,
+    DROP INDEX `UNIQ_907C95215E237E0614E48A3B`,
+    ADD UNIQUE KEY `UNIQ_907C95215E237E06` (`name`);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Remove theme_name field from update sql file
| Type?             | bug fix 
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | Fixes PrestaShop/PrestaShop#38745
| Sponsor company   |PrestaShop SA
| How to test?      | Check the db after an upgrade to 9.0.x the field should not be there.
