### PR TITLE
Fix upgrade to 9.0.2: increase customer_message.user_agent field length from 128 to 255

### DIFF
--- a/upgrade/sql/9.0.2.sql
+++ b/upgrade/sql/9.0.2.sql
@@ -1,6 +1,10 @@
 SET SESSION sql_mode='';
 SET NAMES 'utf8mb4';
 
+-- https://github.com/PrestaShop/PrestaShop/pull/39606
+ALTER TABLE `PREFIX_customer_message`
+    MODIFY `user_agent` varchar(255) NOT NULL;
+
 -- https://github.com/PrestaShop/PrestaShop/pull/39914
 INSERT IGNORE INTO `PREFIX_authorization_role` (`slug`) VALUES
   ('ROLE_MOD_TAB_DEFAULT_READ'),


### PR DESCRIPTION

Questions | Answers
-- | --
Description? | This PR updates the auto-upgrade SQL script for 9.0.1 to increase the customer_message.user_agentfield size from 128 to 255 characters. This prevents customer messages from being silently rejected when the user agent string (especially on some mobile devices such as iPhone Safari) exceeds 128 chars.
Type? | bug fix
BC breaks? | no
Deprecations? | no
Fixed ticket? | Related to [PrestaShop/PrestaShop#39606](https://github.com/PrestaShop/PrestaShop/pull/39606)
Sponsor company | N/A
How to test? | 1. Upgrade a shop to 9.0.1 using this module. 2. Check the ps_customer_message table: the column user_agent should now have a length of 255. 3. Try posting a customer message with a long mobile user agent (e.g. Safari iPhone UA ~135 chars). 4. The message should now be saved correctly.


