### PR TITLE
Fix: Issue upgrading PrestaShop 9.0.0 on Windows

### DIFF
--- a/classes/ZipAction.php
+++ b/classes/ZipAction.php
@@ -61,6 +61,11 @@ class ZipAction
      */
     private $prodRootDir;
 
+    /**
+     * @var bool
+     */
+    private $isWinOs;
+
     public function __construct(Filesystem $filesystem, Translator $translator, LoggerInterface $logger, UpgradeConfiguration $updateConfiguration, string $prodRootDir)
     {
         $this->filesystem = $filesystem;
@@ -69,6 +74,7 @@ class ZipAction
         $this->prodRootDir = $prodRootDir;
         $this->configMaxNbFilesCompressedInARow = $updateConfiguration->getNumberOfFilesPerCall();
         $this->configMaxFileSizeAllowed = $updateConfiguration->getMaxFileToBackup();
+        $this->isWinOs = stripos(PHP_OS, 'WIN') === 0;
     }
 
     /**
@@ -222,7 +228,16 @@ class ZipAction
             $nameIndex = $zip->getNameIndex($i);
 
             try {
-                $this->filesystem->symlink($zip->getFromIndex($i), $to_dir . DIRECTORY_SEPARATOR . $nameIndex);
+                if ($this->isWinOs) {
+                    $path = $zip->getFromIndex($i);
+                    if (!file_exists(realpath($path))) {
+                        // The path does not exist, so we are using the path that was extracted from the ZIP archive.
+                        $path = $to_dir . DIRECTORY_SEPARATOR . $this->normalizeWinPath($path);
+                    }
+                    $this->filesystem->symlink($path, $to_dir . DIRECTORY_SEPARATOR . $nameIndex, true);
+                } else {
+                    $this->filesystem->symlink($zip->getFromIndex($i), $to_dir . DIRECTORY_SEPARATOR . $nameIndex);
+                }
             } catch (IOException $e) {
                 $this->logger->warning(
                     $this->translator->trans(
@@ -243,6 +258,32 @@ class ZipAction
         $this->logger->debug($this->translator->trans('Content of archive %zip% is extracted', ['%zip%' => $from_file]));
 
         return true;
+    }
+
+    /**
+     * Normalizes a Windows (or mixed) path into a clean and consistent format.
+     *
+     * @param string $path Path to normalize
+     *
+     * @return string Normalized path
+     */
+    private function normalizeWinPath(string $path): string
+    {
+        $parts = [];
+
+        foreach (explode('/', str_replace('\\', '/', $path)) as $segment) {
+            if ($segment === '' || $segment === '.') {
+                continue;
+            }
+
+            if ($segment === '..') {
+                array_pop($parts);
+            } else {
+                $parts[] = $segment;
+            }
+        }
+
+        return implode(DIRECTORY_SEPARATOR, $parts);
     }
 
     /**


### PR DESCRIPTION
Fix symlink handling: skip symbolic links on Windows to prevent errors
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | On Windows, symbolic links are not handled correctly. To avoid update failures, instead of trying to create symlinks with `Filesystem->symlink`, we simply extract the file.This is not the most elegant solution, but it prevents the upgrade from failing on Windows environments.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/39607
| Sponsor company   | @Codencode
| How to test?      | Update PrestaShop to version 9.0.0 on Windows operating system