### PR TITLE
Send error with proper log type during Unzip

### DIFF
--- a/classes/Task/Update/Unzip.php
+++ b/classes/Task/Update/Unzip.php
@@ -73,7 +73,7 @@ class Unzip extends AbstractTask
         if (!$res) {
             $this->next = TaskName::TASK_ERROR;
             $this->setErrorFlag();
-            $this->logger->info($this->translator->trans(
+            $this->logger->error($this->translator->trans(
                 'Unable to extract %filepath% file into %destination% folder...',
                 [
                     '%filepath%' => $filepath,
@@ -95,7 +95,7 @@ class Unzip extends AbstractTask
             $subRes = $this->container->getZipAction()->extract($newZip, $destExtract);
             if (!$subRes) {
                 $this->next = TaskName::TASK_ERROR;
-                $this->logger->info($this->translator->trans(
+                $this->logger->error($this->translator->trans(
                     'Unable to extract %filepath% file into %destination% folder...',
                     [
                         '%filepath%' => $filepath,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix of a log type for an error sent as info.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Related to https://github.com/PrestaShop/PrestaShop/issues/39607, where the screenshot shows an issue in the logs. The last line should be an error. <br><img width="1617" height="848" alt="Image" src="https://github.com/user-attachments/assets/a0dbeaeb-9fdd-4102-a3a1-ee81e2e795ee" />
| Sponsor company   | @PrestaShopCorp
| How to test?      | Make the unzip of the release fail. The last line in the log should be an error, not a success.

