### PR TITLE
Update call to bin/console by relying on PHP binary first

### DIFF
--- a/classes/Exceptions/CommandLineException.php
+++ b/classes/Exceptions/CommandLineException.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\AutoUpgrade\Exceptions;
+
+use Exception;
+
+/**
+ * Exception to use when calling the command line fails
+ */
+class CommandLineException extends Exception
+{
+}

--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -55,6 +55,7 @@ use PrestaShop\Module\AutoUpgrade\Twig\AssetsEnvironment;
 use PrestaShop\Module\AutoUpgrade\Twig\TransFilterExtension;
 use PrestaShop\Module\AutoUpgrade\Twig\TransFilterExtension3;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\CacheCleaner;
+use PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreConsoleExecutable;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\FileFilter;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\FilesystemAdapter;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\ModuleAdapter;
@@ -205,6 +206,9 @@ class UpgradeContainer
 
     /** @var ConfigurationValidator */
     private $configurationValidator;
+
+    /** @var CoreConsoleExecutable */
+    private $coreConsoleExecutable;
 
     /** @var LocalChannelConfigurationValidator */
     private $localChannelConfigurationValidator;
@@ -943,6 +947,17 @@ class UpgradeContainer
         }
 
         return $this->configurationValidator;
+    }
+
+    public function getCoreConsoleExecutable(): CoreConsoleExecutable
+    {
+        if (null === $this->coreConsoleExecutable) {
+            $this->coreConsoleExecutable = new CoreConsoleExecutable(
+                $this->getProperty(self::PS_ROOT_PATH)
+            );
+        }
+
+        return $this->coreConsoleExecutable;
     }
 
     /**

--- a/classes/UpgradeTools/CoreConsoleExecutable.php
+++ b/classes/UpgradeTools/CoreConsoleExecutable.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\AutoUpgrade\UpgradeTools;
+
+use RuntimeException;
+
+class CoreConsoleExecutable
+{
+    /** @var string */
+    private $binConsolePath;
+
+    public function __construct(string $shopRootPath)
+    {
+        $this->binConsolePath = $shopRootPath . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'console';
+    }
+
+    /**
+     * The shell may be very minimal on some hosts (e.g. dash on Debian/Ubuntu, or restricted shells in shared hosting).
+     * That often means the $PATH is stripped down and php is not found. So we try to rely first on the console file when it is executable.
+     *
+     * @return array{returnCode: int, output: string[]}
+     */
+    public function callCommand(string $args)
+    {
+        $fullCommand = $this->getBaseCommand() . ' ' . $args . ' 2>&1';
+
+        $output = [];
+        $returnCode = 0;
+
+        exec($fullCommand, $output, $returnCode);
+
+        return [
+            'returnCode' => $returnCode,
+            'output' => $output,
+        ];
+    }
+
+    /**
+     * Find out what command can be called to reach the bin/console of PrestaShop
+     *
+     * @throws RuntimeException
+     */
+    private function getBaseCommand(): string
+    {
+        $candidates = [
+            'php ' . $this->binConsolePath,
+            $this->binConsolePath,
+        ];
+
+        $returnCode = 0;
+
+        foreach ($candidates as $candidate) {
+            exec($candidate, $null, $returnCode);
+
+            if (!$returnCode) {
+                return $candidate;
+            }
+        }
+
+        throw new RuntimeException('Could not find a valid way to call PrestaShop\'s bin/console. Check your environment PATH or add executable permission on the file.');
+    }
+}

--- a/classes/UpgradeTools/CoreConsoleExecutable.php
+++ b/classes/UpgradeTools/CoreConsoleExecutable.php
@@ -21,6 +21,7 @@
 
 namespace PrestaShop\Module\AutoUpgrade\UpgradeTools;
 
+use PrestaShop\Module\AutoUpgrade\Exceptions\CommandLineException;
 use RuntimeException;
 
 class CoreConsoleExecutable
@@ -76,6 +77,6 @@ class CoreConsoleExecutable
             }
         }
 
-        throw new RuntimeException('Could not find a valid way to call PrestaShop\'s bin/console. Check your environment PATH or add executable permission on the file.');
+        throw new CommandLineException('Could not find a valid way to call PrestaShop\'s bin/console. Check your environment PATH or add executable permission on the file.');
     }
 }

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -905,14 +905,15 @@ abstract class CoreUpgrader
         $rootPath = $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH);
         $command = $rootPath . '/bin/console';
 
-        if (!is_executable($command)) {
-            $command = 'php ' . $command;
-        }
-
         $output = [];
         $returnCode = 0;
 
-        exec($command . ' ' . $args, $output, $returnCode);
+        exec('php ' . $command . ' ' . $args, $output, $returnCode);
+
+        // If PHP binary is not part of the $PATH, try relying directly on the console file.
+        if ($returnCode === 127 && is_executable($command)) {
+            exec($command . ' ' . $args, $output, $returnCode);
+        }
 
         return [
             'returnCode' => $returnCode,

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -860,7 +860,7 @@ abstract class CoreUpgrader
     public function warmupCoreCache(): void
     {
         $args = 'cache:warmup --no-interaction --no-optional-warmers --env=prod';
-        $result = $this->callCoreConsoleCommand($args);
+        $result = $this->container->getCoreConsoleExecutable()->callCommand($args);
 
         if ($result['returnCode'] !== 0) {
             throw new UpgradeException($this->container->getTranslator()->trans("An error was raised when warming up the core cache: \n %s", [implode("\n", $result['output'])]));
@@ -887,37 +887,10 @@ abstract class CoreUpgrader
 
         $adminSubDir = $this->container->getProperty(UpgradeContainer::PS_ADMIN_SUBDIR);
         $args = 'assets:install --symlink --no-interaction --env=prod ' . $adminSubDir;
-        $result = $this->callCoreConsoleCommand($args);
+        $result = $this->container->getCoreConsoleExecutable()->callCommand($args);
 
         if ($result['returnCode'] !== 0) {
             throw new UpgradeException($this->container->getTranslator()->trans("A code %d was returned while installing assets: \n %s", [$result['returnCode'], implode("\n", $result['output'])]));
         }
-    }
-
-    /**
-     * The shell may be very minimal on some hosts (e.g. dash on Debian/Ubuntu, or restricted shells in shared hosting).
-     * That often means the $PATH is stripped down and php is not found. So we try to rely first on the console file when it is executable.
-     *
-     * @return array{returnCode: int, output: string[]}
-     */
-    private function callCoreConsoleCommand(string $args)
-    {
-        $rootPath = $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH);
-        $command = $rootPath . '/bin/console';
-
-        $output = [];
-        $returnCode = 0;
-
-        exec('php ' . $command . ' ' . $args, $output, $returnCode);
-
-        // If PHP binary is not part of the $PATH, try relying directly on the console file.
-        if ($returnCode === 127 && is_executable($command)) {
-            exec($command . ' ' . $args, $output, $returnCode);
-        }
-
-        return [
-            'returnCode' => $returnCode,
-            'output' => $output,
-        ];
     }
 }

--- a/tests/unit/UpgradeTools/CoreConsoleExecutableTest.php
+++ b/tests/unit/UpgradeTools/CoreConsoleExecutableTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace unit\UpgradeTools;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\Module\AutoUpgrade\Exceptions\CommandLineException;
+use PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreConsoleExecutable;
+
+class CoreConsoleExecutableTest extends TestCase
+{
+    private $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/prestashop_test_' . uniqid();
+        mkdir($this->tempDir . '/bin', 0777, true);
+
+        // In the context of unit tests, we obviously don't have access to PrestaShop's bin/console.
+        // Let's create a fake console file that exits 0
+        $consoleFile = $this->tempDir . '/bin/console';
+        file_put_contents($consoleFile, "#!/usr/bin/env php\n<?php\necho 'wololo';\nexit(0);");
+        chmod($consoleFile, 0755);
+    }
+
+    protected function tearDown(): void
+    {
+        unlink($this->tempDir . '/bin/console');
+    }
+
+    public function testCallCommandWorks(): void
+    {
+        $coreConsole = new CoreConsoleExecutable($this->tempDir);
+        $result = $coreConsole->callCommand('assets:install');
+
+        $this->assertTrue(is_array($result));
+        $this->assertArrayHasKey('returnCode', $result);
+        $this->assertEquals(0, $result['returnCode']);
+
+        $this->assertSame([
+            'returnCode' => 0,
+            'output' => ['wololo'],
+        ], $result);
+    }
+
+    public function testCallCommandFails(): void
+    {
+        $this->expectException(CommandLineException::class);
+
+        // Create an environment where console is not found
+        $badDir = sys_get_temp_dir() . '/' . uniqid();
+        mkdir($badDir . '/bin', 0777, true);
+        $consoleFile = $badDir . '/bin/console';
+
+        // Any other issue like the missing permission flag could work too, but displays a text in the output.
+        file_put_contents($consoleFile, "#!/usr/bin/env php\n<?php\necho 'wololo';\nexit(1);");
+        chmod($consoleFile, 0755);
+
+        $coreConsole = new CoreConsoleExecutable($badDir);
+        $coreConsole->callCommand('assets:install');
+
+        unlink($badDir . '/bin/console');
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When installing the assets for PrestaShop 9.0.1, some environment cannot call `bin/console` without being prefixed by `php`, because of the following error: `/usr/bin/env: 'php': No such file or directory`. This PR tries to rely first on the PHP binary, and directly on the filein case of error. It is even able to fallback on the second call instead of choosing only one to call.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Update to PrestaShop 9.0.1. The Docker image `prestashop/prestashop-flashlight:8.2.3-8.1-fpm-bookworm-nginx` used to fail, and should not with this PR. Other tests should be done to find an environment we've missed even with this fix.