### PR TITLE
Add missing changes for PS 9.0.1 and 9.0.0 (with catch-up script)

### DIFF
--- a/upgrade/php/add_index_if_not_exists.php
+++ b/upgrade/php/add_index_if_not_exists.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+use PrestaShop\Module\AutoUpgrade\Database\DbWrapper;
+
+/**
+ * This function creates an index if it does not exist. Particularly useful for catch-up scripts where the creation could be run twice.
+ *
+ * Note: if the index already exists, the script does not check if the requested columns are the same as the existing ones. It just returns.
+ *
+ * @throws \PrestaShop\Module\AutoUpgrade\Exceptions\UpdateDatabaseException
+ */
+function add_index_if_not_exists(string $table, string $index, string $parameters): bool
+{
+    // Verify if we need to create unique key
+    $keys = DbWrapper::executeS(
+        'SHOW KEYS FROM ' . _DB_PREFIX_ . $table . " WHERE Key_name='" . $index . "'"
+    );
+
+    if (!empty($keys)) {
+        return true;
+    }
+
+    return DbWrapper::execute('ALTER TABLE `' . _DB_PREFIX_ . $table . '` ADD INDEX `' . $index . '` ' . $parameters);
+}

--- a/upgrade/php/add_index_if_not_exists.php
+++ b/upgrade/php/add_index_if_not_exists.php
@@ -31,12 +31,12 @@ function add_index_if_not_exists(string $table, string $index, string $parameter
 {
     // Verify if we need to create unique key
     $keys = DbWrapper::executeS(
-        'SHOW KEYS FROM ' . _DB_PREFIX_ . $table . " WHERE Key_name='" . $index . "'"
+        'SHOW KEYS FROM `' . _DB_PREFIX_ . pSQL($table) . "` WHERE Key_name='" . pSQL($index) . "'"
     );
 
     if (!empty($keys)) {
         return true;
     }
 
-    return DbWrapper::execute('ALTER TABLE `' . _DB_PREFIX_ . $table . '` ADD INDEX `' . $index . '` ' . $parameters);
+    return DbWrapper::execute('ALTER TABLE `' . _DB_PREFIX_ . pSQL($table) . '` ADD INDEX `' . pSQL($index) . '` ' . pSQL($parameters));
 }

--- a/upgrade/sql/9.0.0.sql
+++ b/upgrade/sql/9.0.0.sql
@@ -393,7 +393,9 @@ INSERT INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`
   (NULL, 'actionProductGetAttributesGroupsBefore', 'Triggers before getting product attributes groups', 'Allows to modify product attributes groups SQL query before they are retrieved from the database.', '1'),
   (NULL, 'actionProductGetAttributesGroupsAfter', 'Triggers after getting product attributes groups', 'Allows to modify product attributes groups after they are retrieved from the database.', '1'),
   (NULL, 'actionGetPdfRenderer', 'Provide a PDF renderer', 'This hook allows to provide a custom PDF renderer to generate PDF files', '1'),
-  (NULL, 'displayAdminStoreInformation', 'Display extra store information', 'This hook displays content in the Information page to add store information', '1')
+  (NULL, 'displayAdminStoreInformation', 'Display extra store information', 'This hook displays content in the Information page to add store information', '1'),
+  -- https://github.com/PrestaShop/PrestaShop/pull/34133
+  (NULL, 'actionSubmitAccountBefore', 'Before customer account creation', 'This hook is called before a customer account creation', '1')
 ON DUPLICATE KEY UPDATE `title` = VALUES(`title`), `description` = VALUES(`description`);
 
 /* Auto generated hooks removed for version 9.0.0 */
@@ -430,6 +432,7 @@ ALTER TABLE `PREFIX_attachment_lang` MODIFY COLUMN `name` varchar(255) DEFAULT N
 /* Add id_product in customer message table */
 /* https://github.com/PrestaShop/PrestaShop/pull/37861 */
 /* PHP:add_column('customer_message', 'id_product', 'INT UNSIGNED DEFAULT NULL AFTER `id_employee`'); */;
+ALTER TABLE `PREFIX_customer_message` ADD INDEX `id_product` (`id_product`);
 
 /* Update Admin API tabs and roles */
 UPDATE `PREFIX_tab` SET `wording`='Admin API', `wording_domain`='Admin.Navigation.Menu', `class_name`='AdminAdminAPI', `route_name`='admin_api_index', `active`=1 WHERE `class_name`='AdminAuthorizationServer';

--- a/upgrade/sql/9.0.1-catchup.sql
+++ b/upgrade/sql/9.0.1-catchup.sql
@@ -1,0 +1,9 @@
+-- PrestaShop 9.0.0 missing changes
+
+INSERT INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES
+  -- https://github.com/PrestaShop/PrestaShop/pull/34133
+  (NULL, 'actionSubmitAccountBefore', 'Before customer account creation', 'This hook is called before a customer account creation', '1')
+ON DUPLICATE KEY UPDATE `title` = VALUES(`title`), `description` = VALUES(`description`);
+
+-- https://github.com/PrestaShop/PrestaShop/pull/37861
+/* PHP:add_index_if_not_exists('customer_message', 'id_product', '(`id_product`)'); */;

--- a/upgrade/sql/9.0.1.sql
+++ b/upgrade/sql/9.0.1.sql
@@ -5,7 +5,9 @@ INSERT INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`
   -- https://github.com/PrestaShop/PrestaShop/pull/39366
   (NULL, 'actionCheckoutStepRenderTemplate','Modify the parameters of the checkout step template rendering','This hook is called when rendering every checkout step template', '1'),
   -- https://github.com/PrestaShop/PrestaShop/pull/39277
-  (NULL, 'actionModifyHtmlPurifierConfig', 'Called when configuring HTMLPurifier', 'Allows modules to modify the HTMLPurifier definition by adding custom allowed HTML elements or attributes during Tools::purifyHTML().', '1')
+  (NULL, 'actionModifyHtmlPurifierConfig', 'Called when configuring HTMLPurifier', 'Allows modules to modify the HTMLPurifier definition by adding custom allowed HTML elements or attributes during Tools::purifyHTML().', '1'),
+  -- https://github.com/PrestaShop/PrestaShop/pull/38487
+  (NULL, 'actionGetPdfTemplateObject', 'Get PDF template object', 'This hook allows to recieve a PDF template object from modules', '1')
 ON DUPLICATE KEY UPDATE `title` = VALUES(`title`), `description` = VALUES(`description`);
 
 INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Update scripts for PS 9.0.0 and 9.0.1 with the differences found when comparing a updated shop and a fresh installation.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | When using https://github.com/PrestaShop/SeamlessUpgradeToolbox/tree/main/autoupgrade-scripts, we should not find differences in the hooks of the database structure.

### Related PRs:
#### PrestaShop 9.0.0
* https://github.com/PrestaShop/PrestaShop/pull/34133
* https://github.com/PrestaShop/PrestaShop/pull/37861

#### PrestaShop 9.0.1
* https://github.com/PrestaShop/PrestaShop/pull/38487