### PR TITLE
Introduce a safe mode of PrestaShop to avoid loading modules

### DIFF
--- a/classes/Task/Update/UpdateDatabase.php
+++ b/classes/Task/Update/UpdateDatabase.php
@@ -70,6 +70,7 @@ class UpdateDatabase extends AbstractTask
                 return ExitCode::SUCCESS;
             }
             $this->container->getFileStorage()->clean(UpgradeFileNames::SQL_TO_EXECUTE_LIST);
+            $this->container->getSafeMode()->disable();
             $this->getCoreUpgrader()->finalizeCoreUpdate();
         } catch (UpgradeException $e) {
             $this->next = TaskName::TASK_ERROR;
@@ -113,7 +114,6 @@ class UpdateDatabase extends AbstractTask
             $this->container->getCacheCleaner()->cleanFolders();
         }
 
-        // Migrating settings file
         $this->container->initPrestaShopAutoloader();
         $this->container->initPrestaShopCore();
     }
@@ -129,6 +129,8 @@ class UpdateDatabase extends AbstractTask
         $this->container->getUpdateState()->setProgressPercentage(
             $this->container->getCompletionCalculator()->getBasePercentageOfTask(self::class)
         );
+
+        $this->container->getSafeMode()->enable();
 
         $this->getCoreUpgrader()->writeNewSettings();
 

--- a/classes/Task/Update/UpdateDatabase.php
+++ b/classes/Task/Update/UpdateDatabase.php
@@ -136,7 +136,7 @@ class UpdateDatabase extends AbstractTask
             $this->logger->info($this->container->getTranslator()->trans('Keeping non native modules enabled'));
         }
 
-        $this->container->getSafeMode()->enable();
+        $this->container->getQuarantineZone()->addAll();
 
         $this->getCoreUpgrader()->writeNewSettings();
 

--- a/classes/Task/Update/UpdateDatabase.php
+++ b/classes/Task/Update/UpdateDatabase.php
@@ -70,7 +70,6 @@ class UpdateDatabase extends AbstractTask
                 return ExitCode::SUCCESS;
             }
             $this->container->getFileStorage()->clean(UpgradeFileNames::SQL_TO_EXECUTE_LIST);
-            $this->container->getSafeMode()->disable();
             $this->getCoreUpgrader()->finalizeCoreUpdate();
         } catch (UpgradeException $e) {
             $this->next = TaskName::TASK_ERROR;
@@ -130,6 +129,13 @@ class UpdateDatabase extends AbstractTask
             $this->container->getCompletionCalculator()->getBasePercentageOfTask(self::class)
         );
 
+        if ($this->container->getUpdateConfiguration()->shouldDeactivateCustomModules()) {
+            $this->logger->info($this->container->getTranslator()->trans('Disabling all non native modules'));
+            $this->getCoreUpgrader()->disableCustomModules();
+        } else {
+            $this->logger->info($this->container->getTranslator()->trans('Keeping non native modules enabled'));
+        }
+
         $this->container->getSafeMode()->enable();
 
         $this->getCoreUpgrader()->writeNewSettings();
@@ -142,13 +148,6 @@ class UpdateDatabase extends AbstractTask
         }
 
         $this->getCoreUpgrader()->setupUpdateEnvironment();
-
-        if ($this->container->getUpdateConfiguration()->shouldDeactivateCustomModules()) {
-            $this->logger->info($this->container->getTranslator()->trans('Disabling all non native modules'));
-            $this->getCoreUpgrader()->disableCustomModules();
-        } else {
-            $this->logger->info($this->container->getTranslator()->trans('Keeping non native modules enabled'));
-        }
 
         return ExitCode::SUCCESS;
     }

--- a/classes/Task/Update/UpdateModules.php
+++ b/classes/Task/Update/UpdateModules.php
@@ -154,6 +154,8 @@ class UpdateModules extends AbstractTask
             return ExitCode::FAIL;
         }
 
+        $this->container->getSafeMode()->disable();
+
         if ($total_modules_to_upgrade) {
             $this->logger->info($this->translator->trans('%s modules will be updated.', [$total_modules_to_upgrade]));
         }

--- a/classes/Task/Update/UpdateModules.php
+++ b/classes/Task/Update/UpdateModules.php
@@ -69,6 +69,7 @@ class UpdateModules extends AbstractTask
 
             try {
                 $this->logger->debug($this->translator->trans('Checking updates of module %module%...', ['%module%' => $moduleInfos['name']]));
+                $this->container->getQuarantineZone()->removeOne($moduleInfos['name']);
 
                 $moduleDownloaderContext = new ModuleDownloaderContext($moduleInfos);
                 $moduleSourceList->setSourcesIn($moduleDownloaderContext);
@@ -124,6 +125,9 @@ class UpdateModules extends AbstractTask
             $this->next = TaskName::TASK_UPDATE_MODULES;
             $this->logger->info($this->translator->trans('%s modules left to check.', [$modules_left]));
         } else {
+            // Remove all remaining modules from the quarantine
+            $this->container->getQuarantineZone()->removeAll();
+
             $this->stepDone = true;
             $this->status = 'ok';
             $this->next = TaskName::TASK_CLEAN_DATABASE;
@@ -153,8 +157,6 @@ class UpdateModules extends AbstractTask
 
             return ExitCode::FAIL;
         }
-
-        $this->container->getSafeMode()->disable();
 
         if ($total_modules_to_upgrade) {
             $this->logger->info($this->translator->trans('%s modules will be updated.', [$total_modules_to_upgrade]));

--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -646,7 +646,7 @@ class UpgradeContainer
     public function getQuarantineZone(): QuarantineZone
     {
         if (null === $this->quarantineZone) {
-            $this->quarantineZone = new QuarantineZone($this->getDb());
+            $this->quarantineZone = new QuarantineZone();
         }
 
         return $this->quarantineZone;

--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -58,6 +58,7 @@ use PrestaShop\Module\AutoUpgrade\UpgradeTools\CacheCleaner;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\FileFilter;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\FilesystemAdapter;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\ModuleAdapter;
+use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\SafeMode;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\Source\Provider\AbstractModuleSourceProvider;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\Source\Provider\ComposerSourceProvider;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\Source\Provider\LocalSourceProvider;
@@ -216,6 +217,9 @@ class UpgradeContainer
 
     /** @var PrestashopVersionService */
     private $prestashopVersionService;
+
+    /** @var SafeMode */
+    private $safeMode;
 
     /** @var UpgradeSelfCheck */
     private $upgradeSelfCheck;
@@ -637,6 +641,15 @@ class UpgradeContainer
         }
 
         return $this->restoreState;
+    }
+
+    public function getSafeMode(): SafeMode
+    {
+        if (null === $this->safeMode) {
+            $this->safeMode = new SafeMode($this->getDb());
+        }
+
+        return $this->safeMode;
     }
 
     public function getUpdateState(): UpdateState

--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -58,7 +58,7 @@ use PrestaShop\Module\AutoUpgrade\UpgradeTools\CacheCleaner;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\FileFilter;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\FilesystemAdapter;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\ModuleAdapter;
-use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\SafeMode;
+use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\QuarantineZone;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\Source\Provider\AbstractModuleSourceProvider;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\Source\Provider\ComposerSourceProvider;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\Source\Provider\LocalSourceProvider;
@@ -218,8 +218,8 @@ class UpgradeContainer
     /** @var PrestashopVersionService */
     private $prestashopVersionService;
 
-    /** @var SafeMode */
-    private $safeMode;
+    /** @var QuarantineZone */
+    private $quarantineZone;
 
     /** @var UpgradeSelfCheck */
     private $upgradeSelfCheck;
@@ -643,13 +643,13 @@ class UpgradeContainer
         return $this->restoreState;
     }
 
-    public function getSafeMode(): SafeMode
+    public function getQuarantineZone(): QuarantineZone
     {
-        if (null === $this->safeMode) {
-            $this->safeMode = new SafeMode($this->getDb());
+        if (null === $this->quarantineZone) {
+            $this->quarantineZone = new QuarantineZone($this->getDb());
         }
 
-        return $this->safeMode;
+        return $this->quarantineZone;
     }
 
     public function getUpdateState(): UpdateState

--- a/classes/UpgradeTools/Module/ModuleAdapter.php
+++ b/classes/UpgradeTools/Module/ModuleAdapter.php
@@ -91,7 +91,8 @@ class ModuleAdapter
      */
     public function getInstalledVersionOfModules(?array $filterOnModuleNames = null): array
     {
-        $sql = 'SELECT name, version FROM ' . _DB_PREFIX_ . 'module';
+        // Handle safe mode eventually enabled
+        $sql = 'SELECT REPLACE(`name`, "' . SafeMode::DISABLED_BY_SAFE_MODE . '", "") as name, version FROM ' . _DB_PREFIX_ . 'module';
 
         if (!empty($filterOnModuleNames)) {
             $sql .= ' WHERE name IN ("' . implode('", "', $filterOnModuleNames) . '")';

--- a/classes/UpgradeTools/Module/ModuleAdapter.php
+++ b/classes/UpgradeTools/Module/ModuleAdapter.php
@@ -92,7 +92,7 @@ class ModuleAdapter
     public function getInstalledVersionOfModules(?array $filterOnModuleNames = null): array
     {
         // Handle safe mode eventually enabled
-        $sql = 'SELECT REPLACE(`name`, "' . SafeMode::DISABLED_BY_SAFE_MODE . '", "") as name, version FROM ' . _DB_PREFIX_ . 'module';
+        $sql = 'SELECT REPLACE(`name`, "' . QuarantineZone::DISABLED_BY_SAFE_MODE . '", "") as name, version FROM ' . _DB_PREFIX_ . 'module';
 
         if (!empty($filterOnModuleNames)) {
             $sql .= ' WHERE name IN ("' . implode('", "', $filterOnModuleNames) . '")';

--- a/classes/UpgradeTools/Module/ModuleAdapter.php
+++ b/classes/UpgradeTools/Module/ModuleAdapter.php
@@ -91,7 +91,7 @@ class ModuleAdapter
      */
     public function getInstalledVersionOfModules(?array $filterOnModuleNames = null): array
     {
-        // Handle safe mode eventually enabled
+        // Select on-the-fly modules that are in quarantine zone as well (Prefixed with the tag).
         $sql = 'SELECT REPLACE(`name`, "' . QuarantineZone::DISABLED_BY_SAFE_MODE . '", "") as name, version FROM ' . _DB_PREFIX_ . 'module';
 
         if (!empty($filterOnModuleNames)) {

--- a/classes/UpgradeTools/Module/QuarantineZone.php
+++ b/classes/UpgradeTools/Module/QuarantineZone.php
@@ -20,27 +20,19 @@
 
 namespace PrestaShop\Module\AutoUpgrade\UpgradeTools\Module;
 
-use Db;
+use PrestaShop\Module\AutoUpgrade\Database\DbWrapper;
 
 class QuarantineZone
 {
     const DISABLED_BY_SAFE_MODE = 'UA_';
     const ENABLED = 1;
 
-    /** @var Db */
-    private $db;
-
-    public function __construct(Db $db)
-    {
-        $this->db = $db;
-    }
-
     /**
      * Enable the safe mode of PrestaShop by preventing the execution of modules
      */
     public function addAll(): void
     {
-        $this->db->execute('UPDATE `' . _DB_PREFIX_ . 'module` m
+        DbWrapper::execute('UPDATE `' . _DB_PREFIX_ . 'module` m
             SET `name` = CONCAT("' . self::DISABLED_BY_SAFE_MODE . '", `name`)'
         );
     }
@@ -50,14 +42,14 @@ class QuarantineZone
      */
     public function removeAll(): void
     {
-        $this->db->execute('UPDATE `' . _DB_PREFIX_ . 'module` m
+        DbWrapper::execute('UPDATE `' . _DB_PREFIX_ . 'module` m
             SET `name` = REPLACE(`name`, "' . self::DISABLED_BY_SAFE_MODE . '", "")'
         );
     }
 
     public function removeOne(string $moduleName): void
     {
-        $this->db->execute('UPDATE `' . _DB_PREFIX_ . 'module` m
+        DbWrapper::execute('UPDATE `' . _DB_PREFIX_ . 'module` m
             SET `name` = REPLACE(`name`, "' . self::DISABLED_BY_SAFE_MODE . '", "")
             WHERE `name` LIKE "%' . pSQL($moduleName) . '"'
         );

--- a/classes/UpgradeTools/Module/QuarantineZone.php
+++ b/classes/UpgradeTools/Module/QuarantineZone.php
@@ -22,7 +22,7 @@ namespace PrestaShop\Module\AutoUpgrade\UpgradeTools\Module;
 
 use Db;
 
-class SafeMode
+class QuarantineZone
 {
     const DISABLED_BY_SAFE_MODE = 'UA|';
     const ENABLED = 1;
@@ -38,7 +38,7 @@ class SafeMode
     /**
      * Enable the safe mode of PrestaShop by preventing the execution of modules
      */
-    public function enable(): void
+    public function addAll(): void
     {
         $this->db->execute('UPDATE `' . _DB_PREFIX_ . 'module` m
             SET `name` = CONCAT("' . self::DISABLED_BY_SAFE_MODE . '", `name`)'
@@ -48,10 +48,18 @@ class SafeMode
     /**
      * Disabling the safe mode of PrestaShop by restoring modules state
      */
-    public function disable(): void
+    public function removeAll(): void
     {
         $this->db->execute('UPDATE `' . _DB_PREFIX_ . 'module` m
             SET `name` = REPLACE(`name`, "' . self::DISABLED_BY_SAFE_MODE . '", "")'
+        );
+    }
+
+    public function removeOne(string $moduleName): void
+    {
+        $this->db->execute('UPDATE `' . _DB_PREFIX_ . 'module` m
+            SET `name` = REPLACE(`name`, "' . self::DISABLED_BY_SAFE_MODE . '", "")
+            WHERE `name` LIKE "%' . pSQL($moduleName) . '"'
         );
     }
 }

--- a/classes/UpgradeTools/Module/QuarantineZone.php
+++ b/classes/UpgradeTools/Module/QuarantineZone.php
@@ -24,7 +24,7 @@ use Db;
 
 class QuarantineZone
 {
-    const DISABLED_BY_SAFE_MODE = 'UA|';
+    const DISABLED_BY_SAFE_MODE = 'UA_';
     const ENABLED = 1;
 
     /** @var Db */

--- a/classes/UpgradeTools/Module/QuarantineZone.php
+++ b/classes/UpgradeTools/Module/QuarantineZone.php
@@ -22,10 +22,18 @@ namespace PrestaShop\Module\AutoUpgrade\UpgradeTools\Module;
 
 use PrestaShop\Module\AutoUpgrade\Database\DbWrapper;
 
+/**
+ * PrestaShop provides a seamless integration of modules by loading them automatically when they are installed.
+ * The autloader is called, the services added in the container...
+ *
+ * However while we update the core, we need to limit the loaded classes to the strict minimum.
+ * Adding all the modules is a risk as they may be incompatible with the destination version until we try updating them.
+ *
+ * We fake the list of installed modules by altering the links between the list of installed modules and the modules folders.
+ */
 class QuarantineZone
 {
     const DISABLED_BY_SAFE_MODE = 'UA_';
-    const ENABLED = 1;
 
     /**
      * Enable the safe mode of PrestaShop by preventing the execution of modules

--- a/classes/UpgradeTools/Module/SafeMode.php
+++ b/classes/UpgradeTools/Module/SafeMode.php
@@ -24,7 +24,7 @@ use Db;
 
 class SafeMode
 {
-    const DISABLE_FOR_SAFE_MODE = 442;
+    const DISABLED_BY_SAFE_MODE = 'UA|';
     const ENABLED = 1;
 
     /** @var Db */
@@ -41,8 +41,7 @@ class SafeMode
     public function enable(): void
     {
         $this->db->execute('UPDATE `' . _DB_PREFIX_ . 'module` m
-            SET m.`active` = ' . self::DISABLE_FOR_SAFE_MODE . '
-            WHERE m.`active` = ' . self::ENABLED
+            SET `name` = CONCAT("' . self::DISABLED_BY_SAFE_MODE . '", `name`)'
         );
     }
 
@@ -52,8 +51,7 @@ class SafeMode
     public function disable(): void
     {
         $this->db->execute('UPDATE `' . _DB_PREFIX_ . 'module` m
-            SET m.`active` = ' . self::ENABLED . '
-            WHERE m.`active` = ' . self::DISABLE_FOR_SAFE_MODE
+            SET `name` = REPLACE(`name`, "' . self::DISABLED_BY_SAFE_MODE . '", "")'
         );
     }
 }

--- a/classes/UpgradeTools/Module/SafeMode.php
+++ b/classes/UpgradeTools/Module/SafeMode.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\AutoUpgrade\UpgradeTools\Module;
+
+use Db;
+
+class SafeMode
+{
+    const DISABLE_FOR_SAFE_MODE = 442;
+    const ENABLED = 1;
+
+    /** @var Db */
+    private $db;
+
+    public function __construct(Db $db)
+    {
+        $this->db = $db;
+    }
+
+    /**
+     * Enable the safe mode of PrestaShop by preventing the execution of modules
+     */
+    public function enable(): void
+    {
+        $this->db->execute('UPDATE `' . _DB_PREFIX_ . 'module` m
+            SET m.`active` = ' . self::DISABLE_FOR_SAFE_MODE . '
+            WHERE m.`active` = ' . self::ENABLED
+        );
+    }
+
+    /**
+     * Disabling the safe mode of PrestaShop by restoring modules state
+     */
+    public function disable(): void
+    {
+        $this->db->execute('UPDATE `' . _DB_PREFIX_ . 'module` m
+            SET m.`active` = ' . self::ENABLED . '
+            WHERE m.`active` = ' . self::DISABLE_FOR_SAFE_MODE
+        );
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When updating shops from classic v8 to classic v9, we encounter many errors regarding the modules.<br><br>When we update from PrestaShop v8 to v9, the gap is quite wide regarding the improvement we're brought on PrestaShop. We made a big step forward on the Symfony version, for instance we have PHP code with strict typing... and this leads to major changes in the modules as well.<br>With this version 9, we encounter a lot of Fatal Error from the modules that don't match the updated core functions signature. And the more modules you have on the shop, higher is the risk of encountering it. In the Update process, it seems we now require a moment where we avoid loading modules until we try to update them. This covers from the **end of files update**, **database**, to the **warm-up of modules update**.<br><br>I a perfect world, I should be able to ask the Core to not load modules. However until the feature in available, we have to find another even though it looks experimental.
| Type?             | New feature
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | <ul><li>https://github.com/PrestaShop/autoupgrade/issues/1560</li></ul>
| Sponsor company   | @PrestaShopCorp
| How to test?      | Stability is improved during updates between 2 classic versions.
