### PR TITLE
Display last output when missing the base command (7.4.x branch)

### DIFF
--- a/classes/UpgradeTools/CoreConsoleExecutable.php
+++ b/classes/UpgradeTools/CoreConsoleExecutable.php
@@ -68,15 +68,16 @@ class CoreConsoleExecutable
         ];
 
         $returnCode = 0;
+        $output = [];
 
         foreach ($candidates as $candidate) {
-            exec($candidate, $null, $returnCode);
+            exec($candidate, $output, $returnCode);
 
             if (!$returnCode) {
                 return $candidate;
             }
         }
 
-        throw new CommandLineException('Could not find a valid way to call PrestaShop\'s bin/console. Check your environment PATH or add executable permission on the file.');
+        throw new CommandLineException("Could not find a valid way to call PrestaShop's bin/console. Check your environment PATH or add executable permission on the file.\n" . implode("\n", $output));
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When encountering an issue with the installation of assets, I though this was caused by a `bin/console` that can't be called, but this actually caused by a module that was breaking the core.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Delete bin/console during the update, we should expect the installation of assets to fail with some details.

<img width="1456" height="1319" alt="Capture d’écran du 2025-10-08 17-09-48" src="https://github.com/user-attachments/assets/184258d4-c6bd-41d5-8bc5-7053e6e3622a" />
