### PR TITLE
Update PHPStan config files for PS 9 (7.4.x branch)

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -93,7 +93,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        presta-versions: ['1.7.2.5', '1.7.3.4', '1.7.4.4', '1.7.5.1', '1.7.6', '1.7.7', '1.7.8', '8.0.0', 'latest']
+        presta-versions: ['1.7.2.5', '1.7.3.4', '1.7.4.4', '1.7.5.1', '1.7.6', '1.7.7', '1.7.8', '8.0.0', '9.0.0', 'latest']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/tests/phpstan/phpstan-9.0.0.neon
+++ b/tests/phpstan/phpstan-9.0.0.neon
@@ -14,6 +14,10 @@ parameters:
 			path: ./../../classes/UpgradeSelfCheck.php
 			count: 2
 		-
+			identifier: argument.type
+			path: ./../../autoupgrade.php
+			count: 1
+		-
 			# Some PrestaShop may not have the method PrestaShopAutoload::generateIndex
 			identifier: function.impossibleType
 			path: ./../../classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | CI is red for PHPStan since PrestaShop 9.0.1 
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | PHPStan workflow is now green