### PR TITLE
Redirect stderr to stdout while finding base command (7.4.x branch)

### DIFF
--- a/classes/UpgradeTools/CoreConsoleExecutable.php
+++ b/classes/UpgradeTools/CoreConsoleExecutable.php
@@ -71,7 +71,7 @@ class CoreConsoleExecutable
         $output = [];
 
         foreach ($candidates as $candidate) {
-            exec($candidate, $output, $returnCode);
+            exec($candidate . ' 2>&1', $output, $returnCode);
 
             if (!$returnCode) {
                 return $candidate;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | One report lacks that could explain to the merchant what went wrong.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Delete bin/console during the database update, remove the permissions on the file, remove PHP from the path. Some of these cases do not display a message on stdout but will on stderr.
