### PR TITLE
Remove magic_ ini directive that have been deleted from PHP

### DIFF
--- a/controllers/admin/AdminSelfUpgradeController.php
+++ b/controllers/admin/AdminSelfUpgradeController.php
@@ -102,8 +102,6 @@ class AdminSelfUpgradeController extends ModuleAdminController
 
         @set_time_limit(0);
         @ini_set('max_execution_time', '0');
-        @ini_set('magic_quotes_runtime', '0');
-        @ini_set('magic_quotes_sybase', '0');
 
         $this->init();
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Remove setting PHP ini values that do not exist anymore
| Type?             | refactor
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | No impact
