### PR TITLE
Prepare change of index with pre-deletion of duplicates in image_type table bug, compliant with MySQL

### DIFF
--- a/upgrade/php/ps_901_set_unicity_on_image_type.php
+++ b/upgrade/php/ps_901_set_unicity_on_image_type.php
@@ -96,12 +96,15 @@ function ps_901_set_unicity_on_image_type(): bool
 
     // Keep most recent values of duplicated image type related to active themes.
     // This request covers the case where different shops on a multi-environment have different themes, where we will keep the highest ID.
-    return DbWrapper::execute('DELETE from ' . _DB_PREFIX_ . 'image_type
+    // Subrequest is nested 2 times to avoid Error 1093 "You can't specify target table 'image_type' for update in FROM clause"
+    return DbWrapper::execute('DELETE FROM ' . _DB_PREFIX_ . 'image_type
         WHERE id_image_type NOT IN (
-            SELECT MAX(`id_image_type`)
-            FROM ' . _DB_PREFIX_ . 'image_type
-            WHERE `theme_name` IS NULL OR `theme_name` IN ("' . implode('", "', $themesList) . '")
-            GROUP BY `name`
+            SELECT `max_id_image_type` FROM (
+                SELECT MAX(`id_image_type`) AS `max_id_image_type`
+                FROM ' . _DB_PREFIX_ . 'image_type
+                WHERE `theme_name` IS NULL OR `theme_name` IN ("' . implode('", "', $themesList) . '")
+                GROUP BY `name`
+            ) AS derived
         )
     ');
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When updating to PS 9.0.1, an index of two columns is replaced by an index of only one column. We risk an issue in the case where different themes have been installed on the shop. This follows #1491 that brought a first version of the fix only compatible with MariaDB.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/autoupgrade/pull/1467#issuecomment-3384488781
| Sponsor company   | @PrestaShopCorp
| How to test?      | See below

## How to test

### From an updated shop on PrestaShop v9.0.0

#### Case 1: Hummingbird is active during the update

**Prerequisites:**

* Update to PrestaShop 9.0.0 with a default configuration,
* If necessary, open the page _Design > Image Settings_ and customize the values,
* Check your images type look like this in the database (Value may differ with your recent changes):

```
+---------------+-------------------+-------+--------+----------+------------+---------------+-----------+--------+-------------+
| id_image_type | name              | width | height | products | categories | manufacturers | suppliers | stores | theme_name  |
+---------------+-------------------+-------+--------+----------+------------+---------------+-----------+--------+-------------+
|             1 | cart_default      |   125 |    125 |        1 |          0 |             0 |         0 |      0 | NULL        |
|             2 | small_default     |    98 |     98 |        1 |          1 |             1 |         1 |      0 | NULL        |
|             3 | medium_default    |   452 |    452 |        1 |          0 |             1 |         1 |      0 | NULL        |
|             4 | home_default      |   250 |    250 |        1 |          0 |             0 |         0 |      0 | NULL        |
|             5 | large_default     |   800 |    800 |        1 |          0 |             1 |         1 |      0 | NULL        |
|             6 | category_default  |   141 |    180 |        0 |          1 |             0 |         0 |      0 | NULL        |
|             7 | stores_default    |   170 |    115 |        0 |          0 |             0 |         0 |      1 | NULL        |
+---------------+-------------------+-------+--------+----------+------------+---------------+-----------+--------+-------------+
```
* Update to PrestaShop v9.0.1
* Check the database contents again

**Expected result:** You keep all the images type details as they were before the update. Only the column `theme_name` is deleted.

#### Case 2: Hummingbird is active during the update

**Prerequisites:**

* Update to PrestaShop 9.0.0 with a default configuration
* Switch to the theme Hummingbird
* If necessary, open the page _Design > Image Settings_ and customize the values,
* Check your images type look like this in the database (Value may differ with your recent changes):

```
+---------------+-------------------+-------+--------+----------+------------+---------------+-----------+--------+-------------+
| id_image_type | name              | width | height | products | categories | manufacturers | suppliers | stores | theme_name  |
+---------------+-------------------+-------+--------+----------+------------+---------------+-----------+--------+-------------+
|             1 | cart_default      |   125 |    125 |        1 |          0 |             0 |         0 |      0 | NULL        |
|             2 | small_default     |    98 |     98 |        1 |          1 |             1 |         1 |      0 | NULL        |
|             3 | medium_default    |   452 |    452 |        1 |          0 |             1 |         1 |      0 | NULL        |
|             4 | home_default      |   250 |    250 |        1 |          0 |             0 |         0 |      0 | NULL        |
|             5 | large_default     |   800 |    800 |        1 |          0 |             1 |         1 |      0 | NULL        |
|             6 | category_default  |   141 |    180 |        0 |          1 |             0 |         0 |      0 | NULL        |
|             7 | stores_default    |   170 |    115 |        0 |          0 |             0 |         0 |      1 | NULL        |
|             8 | cart_default      |   125 |    125 |        1 |          0 |             0 |         0 |      0 | hummingbird |
|             9 | small_default     |    98 |     98 |        1 |          1 |             1 |         1 |      0 | hummingbird |
|            10 | medium_default    |   452 |    452 |        1 |          0 |             1 |         1 |      0 | hummingbird |
|            11 | home_default      |   250 |    250 |        1 |          0 |             0 |         0 |      0 | hummingbird |
|            12 | large_default     |   800 |    800 |        1 |          0 |             1 |         1 |      0 | hummingbird |
|            13 | category_default  |   141 |    180 |        0 |          1 |             0 |         0 |      0 | hummingbird |
|            14 | stores_default    |   170 |    115 |        0 |          0 |             0 |         0 |      1 | hummingbird |
|            15 | default_xs        |   120 |    120 |        1 |          1 |             1 |         1 |      0 | hummingbird |
|            16 | default_s         |   160 |    160 |        1 |          1 |             0 |         0 |      0 | hummingbird |
|            17 | default_m         |   200 |    200 |        1 |          0 |             1 |         1 |      1 | hummingbird |
|            18 | default_md        |   320 |    320 |        1 |          1 |             0 |         0 |      0 | hummingbird |
|            19 | default_xl        |   400 |    400 |        1 |          0 |             0 |         0 |      1 | hummingbird |
|            20 | product_main      |   720 |    720 |        1 |          0 |             0 |         0 |      0 | hummingbird |
|            21 | category_cover    |  1000 |    200 |        0 |          1 |             0 |         0 |      0 | hummingbird |
|            22 | product_main_2x   |  1440 |   1440 |        1 |          0 |             0 |         0 |      0 | hummingbird |
|            23 | category_cover_2x |  2000 |    400 |        0 |          1 |             0 |         0 |      0 | hummingbird |
+---------------+-------------------+-------+--------+----------+------------+---------------+-----------+--------+-------------+
```
* Update to PrestaShop v9.0.1
* Check the database contents again

**Expected result:** You keep the images type details that were assigned to hummingbird (IDs 8 to 23). The column `theme_name` is deleted.

#### Case 3: Classic is active during the update

**Prerequisites:**

* Update to PrestaShop 9.0.0 with a default configuration
* Switch to the theme Hummingbird
* Switch to the theme Classic
* If necessary, open the page _Design > Image Settings_ and customize the values,
* Check your images type look like this in the database (Value may differ with your recent changes):

<img width="1380" height="1325" alt="image" src="https://github.com/user-attachments/assets/40970165-5531-4020-9e5c-3c8a0bf9ef4a" />
Or in the database:

```
+---------------+-------------------+-------+--------+----------+------------+---------------+-----------+--------+-------------+
| id_image_type | name              | width | height | products | categories | manufacturers | suppliers | stores | theme_name  |
+---------------+-------------------+-------+--------+----------+------------+---------------+-----------+--------+-------------+
|             1 | cart_default      |   125 |    125 |        1 |          0 |             0 |         0 |      0 | NULL        |
|             2 | small_default     |    98 |     98 |        1 |          1 |             1 |         1 |      0 | NULL        |
|             3 | medium_default    |   452 |    452 |        1 |          0 |             1 |         1 |      0 | NULL        |
|             4 | home_default      |   250 |    250 |        1 |          0 |             0 |         0 |      0 | NULL        |
|             5 | large_default     |   800 |    800 |        1 |          0 |             1 |         1 |      0 | NULL        |
|             6 | category_default  |   141 |    180 |        0 |          1 |             0 |         0 |      0 | NULL        |
|             7 | stores_default    |   170 |    115 |        0 |          0 |             0 |         0 |      1 | NULL        |
|             8 | cart_default      |   125 |    125 |        1 |          0 |             0 |         0 |      0 | hummingbird |
|             9 | small_default     |    98 |     98 |        1 |          1 |             1 |         1 |      0 | hummingbird |
|            10 | medium_default    |   452 |    452 |        1 |          0 |             1 |         1 |      0 | hummingbird |
|            11 | home_default      |   250 |    250 |        1 |          0 |             0 |         0 |      0 | hummingbird |
|            12 | large_default     |   800 |    800 |        1 |          0 |             1 |         1 |      0 | hummingbird |
|            13 | category_default  |   141 |    180 |        0 |          1 |             0 |         0 |      0 | hummingbird |
|            14 | stores_default    |   170 |    115 |        0 |          0 |             0 |         0 |      1 | hummingbird |
|            15 | default_xs        |   120 |    120 |        1 |          1 |             1 |         1 |      0 | hummingbird |
|            16 | default_s         |   160 |    160 |        1 |          1 |             0 |         0 |      0 | hummingbird |
|            17 | default_m         |   200 |    200 |        1 |          0 |             1 |         1 |      1 | hummingbird |
|            18 | default_md        |   320 |    320 |        1 |          1 |             0 |         0 |      0 | hummingbird |
|            19 | default_xl        |   400 |    400 |        1 |          0 |             0 |         0 |      1 | hummingbird |
|            20 | product_main      |   720 |    720 |        1 |          0 |             0 |         0 |      0 | hummingbird |
|            21 | category_cover    |  1000 |    200 |        0 |          1 |             0 |         0 |      0 | hummingbird |
|            22 | product_main_2x   |  1440 |   1440 |        1 |          0 |             0 |         0 |      0 | hummingbird |
|            23 | category_cover_2x |  2000 |    400 |        0 |          1 |             0 |         0 |      0 | hummingbird |
|            24 | cart_default      |   125 |    125 |        1 |          0 |             0 |         0 |      0 | classic     |
|            25 | small_default     |    98 |     98 |        1 |          1 |             1 |         1 |      0 | classic     |
|            26 | medium_default    |   452 |    452 |        1 |          0 |             1 |         1 |      0 | classic     |
|            27 | home_default      |   250 |    250 |        1 |          0 |             0 |         0 |      0 | classic     |
|            28 | large_default     |   800 |    800 |        1 |          0 |             1 |         1 |      0 | classic     |
|            29 | category_default  |   141 |    180 |        0 |          1 |             0 |         0 |      0 | classic     |
|            30 | stores_default    |   170 |    115 |        0 |          0 |             0 |         0 |      1 | classic     |
+---------------+-------------------+-------+--------+----------+------------+---------------+-----------+--------+-------------+
```
* Update to PrestaShop v9.0.1
* Check the database contents again

**Expected result:** You keep the images type details that were assigned to classic (IDs 24 to 30). The column `theme_name` is deleted.


#### Case 4: In a multishop context, Classic is active on the shop 1 and Hummingbird is on the shop 2

**Prerequisites:**

* Update to PrestaShop 9.0.0 with a default configuration
* Switch to the theme Hummingbird
* Switch to the theme Classic
* Enable multishop
* Create a new shop with Hummingbird
* If necessary, open the page _Design > Image Settings_ and customize the values,
* Check your images type look like this in the database (Value may differ with your recent changes):

<img width="1380" height="1325" alt="image" src="https://github.com/user-attachments/assets/40970165-5531-4020-9e5c-3c8a0bf9ef4a" />
Or in the database:

```
+---------------+-------------------+-------+--------+----------+------------+---------------+-----------+--------+-------------+
| id_image_type | name              | width | height | products | categories | manufacturers | suppliers | stores | theme_name  |
+---------------+-------------------+-------+--------+----------+------------+---------------+-----------+--------+-------------+
|             1 | cart_default      |   125 |    125 |        1 |          0 |             0 |         0 |      0 | NULL        |
|             2 | small_default     |    98 |     98 |        1 |          1 |             1 |         1 |      0 | NULL        |
|             3 | medium_default    |   452 |    452 |        1 |          0 |             1 |         1 |      0 | NULL        |
|             4 | home_default      |   250 |    250 |        1 |          0 |             0 |         0 |      0 | NULL        |
|             5 | large_default     |   800 |    800 |        1 |          0 |             1 |         1 |      0 | NULL        |
|             6 | category_default  |   141 |    180 |        0 |          1 |             0 |         0 |      0 | NULL        |
|             7 | stores_default    |   170 |    115 |        0 |          0 |             0 |         0 |      1 | NULL        |
|             8 | cart_default      |   125 |    125 |        1 |          0 |             0 |         0 |      0 | hummingbird |
|             9 | small_default     |    98 |     98 |        1 |          1 |             1 |         1 |      0 | hummingbird |
|            10 | medium_default    |   452 |    452 |        1 |          0 |             1 |         1 |      0 | hummingbird |
|            11 | home_default      |   250 |    250 |        1 |          0 |             0 |         0 |      0 | hummingbird |
|            12 | large_default     |   800 |    800 |        1 |          0 |             1 |         1 |      0 | hummingbird |
|            13 | category_default  |   141 |    180 |        0 |          1 |             0 |         0 |      0 | hummingbird |
|            14 | stores_default    |   170 |    115 |        0 |          0 |             0 |         0 |      1 | hummingbird |
|            15 | default_xs        |   120 |    120 |        1 |          1 |             1 |         1 |      0 | hummingbird |
|            16 | default_s         |   160 |    160 |        1 |          1 |             0 |         0 |      0 | hummingbird |
|            17 | default_m         |   200 |    200 |        1 |          0 |             1 |         1 |      1 | hummingbird |
|            18 | default_md        |   320 |    320 |        1 |          1 |             0 |         0 |      0 | hummingbird |
|            19 | default_xl        |   400 |    400 |        1 |          0 |             0 |         0 |      1 | hummingbird |
|            20 | product_main      |   720 |    720 |        1 |          0 |             0 |         0 |      0 | hummingbird |
|            21 | category_cover    |  1000 |    200 |        0 |          1 |             0 |         0 |      0 | hummingbird |
|            22 | product_main_2x   |  1440 |   1440 |        1 |          0 |             0 |         0 |      0 | hummingbird |
|            23 | category_cover_2x |  2000 |    400 |        0 |          1 |             0 |         0 |      0 | hummingbird |
|            24 | cart_default      |   125 |    125 |        1 |          0 |             0 |         0 |      0 | classic     |
|            25 | small_default     |    98 |     98 |        1 |          1 |             1 |         1 |      0 | classic     |
|            26 | medium_default    |   452 |    452 |        1 |          0 |             1 |         1 |      0 | classic     |
|            27 | home_default      |   250 |    250 |        1 |          0 |             0 |         0 |      0 | classic     |
|            28 | large_default     |   800 |    800 |        1 |          0 |             1 |         1 |      0 | classic     |
|            29 | category_default  |   141 |    180 |        0 |          1 |             0 |         0 |      0 | classic     |
|            30 | stores_default    |   170 |    115 |        0 |          0 |             0 |         0 |      1 | classic     |
+---------------+-------------------+-------+--------+----------+------------+---------------+-----------+--------+-------------+
```
* Update to PrestaShop v9.0.1
* Check the database contents again

**Expected result:** You keep the images type details that were assigned to classic AND hummingbird. If two lines share the same name, only the one with the highest ID is kept (IDs 15 to 30). The column `theme_name` is deleted.
