### PR TITLE
Enable Symfony Kernel for module migrations

### DIFF
--- a/classes/Task/Update/UpdateModules.php
+++ b/classes/Task/Update/UpdateModules.php
@@ -93,6 +93,9 @@ class UpdateModules extends AbstractTask
                     if (!$moduleMigration->needMigration($moduleMigrationContext)) {
                         $this->logger->info($this->translator->trans('Module %s does not need to be migrated. Module is up to date.', [$moduleInfos['name']]));
                     } else {
+                        // Container may be needed to run upgrade scripts
+                        $this->container->getSymfonyAdapter()->initKernel();
+
                         $moduleMigration->runMigration($moduleMigrationContext);
                     }
                     $moduleMigration->saveVersionInDb($moduleMigrationContext);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Some modules need the Container in their migration scripts. This PR inits the Kernel before running migration to make sure modules have the necessary services when needed.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | During the update of PrestaShop, update a module as well that rely on the Symfony service container. It should fail on the `dev` branch while this PR fixes it.


## Example with `psshipping`:

### With the pull-request:

```
[2025-10-16 19:08:32] NOTICE - ModuleDownloader - Module psshipping update files (1.1.4 => 2.0.5) have been fetched from /var/www/html/**admin_folder**/autoupgrade/modules/psshipping.zip.
[2025-10-16 19:08:32] DEBUG - ZipAction - Content of archive /var/www/html/**admin_folder**/autoupgrade/tmp/modules//psshipping.zip is extracted
[2025-10-16 19:08:32] NOTICE - ModuleMigration - (1/1) Applying migration file upgrade-2.0.0.php.
[2025-10-16 19:08:33] INFO - UpdateModules - All modules have been updated.
```

### `dev` branch:

```[2025-10-14 12:04:40] NOTICE - ModuleDownloader - Module psshipping update files (1.1.4 => 2.0.5) have been fetched from /var/www/html/**admin_folder**/autoupgrade/modules/psshipping.zip.
[2025-10-14 12:04:40] DEBUG - ZipAction - Content of archive /var/www/html/**admin_folder**/autoupgrade/tmp/modules//psshipping.zip is extracted
[2025-10-14 12:04:40] NOTICE - ModuleMigration - (1/1) Applying migration file upgrade-2.0.0.php.
[2025-10-14 12:04:41] CRITICAL - ErrorHandler - /var/www/html/modules/psshipping/src/Domain/Carriers/CarrierRepository.php line 78 - Error: Call to a member function createQueryBuilder() on null
#0 /var/www/html/modules/psshipping/src/Domain/Carriers/CarrierService.php(122): PrestaShop\Module\Psshipping\Domain\Carriers\CarrierRepository->getCarriers()
#1 /var/www/html/modules/psshipping/src/Domain/Carriers/CarrierService.php(89): PrestaShop\Module\Psshipping\Domain\Carriers\CarrierService->get()
#2 /var/www/html/modules/psshipping/psshipping.php(226): PrestaShop\Module\Psshipping\Domain\Carriers\CarrierService->update()
#3 /var/www/html/modules/autoupgrade/classes/UpgradeTools/Module/ModuleMigration.php(116): Psshipping->disable()
#4 /var/www/html/modules/autoupgrade/classes/Task/Update/UpdateModules.php(96): PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\ModuleMigration->runMigration(Object(PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\ModuleMigrationContext))
#5 /var/www/html/modules/autoupgrade/classes/Task/Runner/ChainedTasks.php(66): PrestaShop\Module\AutoUpgrade\Task\Update\UpdateModules->run()
#6 /var/www/html/**admin_folder**/autoupgrade/ajax-upgradetab.php(58): PrestaShop\Module\AutoUpgrade\Task\Runner\ChainedTasks->run()
#7 {main}

-- Ends with another error --
```