### PR TITLE
Fix errors displayed two times in CLI

### DIFF
--- a/classes/Log/CliLogger.php
+++ b/classes/Log/CliLogger.php
@@ -114,14 +114,14 @@ class CliLogger extends Logger
 
         $log = $this->formatLog($level, $message);
 
-        if ($level > self::ERROR) {
-            $this->err->writeln($log);
-        }
-
         if (!$this->isFiltered($level)) {
-            $this->out->writeln($log);
-            if ($level === self::INFO) {
-                $this->lastInfo = $log;
+            if ($level > self::ERROR) {
+                $this->err->writeln($log);
+            } else {
+                $this->out->writeln($log);
+                if ($level === self::INFO) {
+                    $this->lastInfo = $log;
+                }
             }
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix the logger to avoid errors to be displayed two times on the terminal.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Trigger an error while running a task in CLI, The error should be displayed once.

## This PR

<img width="1690" height="768" alt="Capture d’écran du 2025-10-21 17-40-10" src="https://github.com/user-attachments/assets/c38629d6-dc89-4d5a-8f01-366a2f827d60" />

## `dev` branch

<img width="1690" height="1339" alt="image" src="https://github.com/user-attachments/assets/026c0161-2a3d-4300-92c8-fd9cafb5d141" />
