### PR TITLE
Fix readme check command

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 This module allows to update your store to a more recent version of PrestaShop. It can be used as a CLI tool or with a web assistant.
 The latest versions of the module are compatible with all PrestaShop 1.7 and higher releases.
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > This module has a specific [Release Process][release-process]. If you do release a new version, make sure to follow it.
 
 ## Branches
@@ -87,7 +87,7 @@ If you download a ZIP archive that contains the source code or if you want to us
 * Enter into folder **autoupgrade** and run the command `composer install`  ([composer](https://getcomposer.org/)).
 * Enter into folder **autoupgrade/_dev** and run the commands `npm install` and `npm run vite:build` ([npm](https://docs.npmjs.com/)).
 * Create a new ZIP archive from the of **autoupgrade** folder.
-* Now you can install it in your store. For example, you can upload it using the dropzone in Module Manager back office page. 
+* Now you can install it in your store. For example, you can upload it using the dropzone in Module Manager back office page.
 
 ## Running an update on PrestaShop
 
@@ -110,7 +110,7 @@ $ php bin/console
 The requirements can be reviewed to confirm the store is safe to update:
 
 ```
-$ php bin/console update:check <your-admin-dir>
+$ php bin/console update:check-requirements <your-admin-dir>
 ```
 
 A backup of the store is created with:

--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ The requirements can be reviewed to confirm the store is safe to update:
 $ php bin/console update:check-requirements <your-admin-dir>
 ```
 
+To see which new versions are available for your installation use:
+
+```
+$ php bin/console update:check-new-version <your-admin-dir>
+```
+
 A backup of the store is created with:
 
 ```


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Readme has old `check` command. Its really `check-requirements`
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     |no
| Fixed ticket?     | -
| Sponsor company   | 
| How to test?      | try to follow readme for `check` command => get error "Command "update:check" is ambiguous.". With this change the check-requiremenst command works.

Also add a new section for checking for new version in the readme instructions