### PR TITLE
Fix update command - get channel version

### DIFF
--- a/classes/Commands/UpdateCommand.php
+++ b/classes/Commands/UpdateCommand.php
@@ -101,8 +101,6 @@ class UpdateCommand extends AbstractCommand
                 if (!$updateState->isInitialized()) {
                     $updateState->initDefault($this->upgradeContainer->getProperty(UpgradeContainer::PS_VERSION), $this->upgradeContainer->getUpgrader(), $this->upgradeContainer->getUpdateConfiguration());
                 }
-
-                $updateConfiguration = $this->upgradeContainer->getUpdateConfiguration();
             }
 
             $this->calculateUpdateTypeAfterConfigLoad();
@@ -208,10 +206,14 @@ class UpdateCommand extends AbstractCommand
                 }
                 break;
             case UpgradeConfiguration::CHANNEL_ONLINE:
-                $destinationVersion = $this->upgradeContainer->getUpgrader()->getOnlineMaxDestinationRelease()->getVersion();
+                $destinationVersion = $this->upgradeContainer->getUpgrader()->getOnlineMaxDestinationRelease()
+                    ? $this->upgradeContainer->getUpgrader()->getOnlineMaxDestinationRelease()->getVersion()
+                    : null;
                 break;
             case UpgradeConfiguration::CHANNEL_ONLINE_RECOMMENDED:
-                $destinationVersion = $this->upgradeContainer->getUpgrader()->getOnlineRecommendedDestinationRelease()->getVersion();
+                $destinationVersion = $this->upgradeContainer->getUpgrader()->getOnlineRecommendedDestinationRelease()
+                    ? $this->upgradeContainer->getUpgrader()->getOnlineRecommendedDestinationRelease()->getVersion()
+                    : null;
                 break;
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | we need to check that there is a realese before retrieving the version 
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | -
| How to test?      | use update command without channel specified on v9.0.0