### PR TITLE
Prevent an issue happening during the update of modules about headers already sent

### DIFF
--- a/tests/fixtures/mymodule/upgrade/upgrade-1.3.1.php
+++ b/tests/fixtures/mymodule/upgrade/upgrade-1.3.1.php
@@ -1,0 +1,25 @@
+The PHP tag must be always the first thing in a PHP file, otherwise it echoes stuff.
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+function upgrade_module_1_3_1(Module $module): bool
+{
+    // The important thing in this file is the part before the <?php tag
+    return true;
+}

--- a/tests/fixtures/mymodule/upgrade/upgrade-1.3.2.php
+++ b/tests/fixtures/mymodule/upgrade/upgrade-1.3.2.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+function upgrade_module_1_3_2(Module $module): bool
+{
+    session_start();
+
+    return true;
+}

--- a/tests/unit/UpgradeTools/Module/ModuleMigrationTest.php
+++ b/tests/unit/UpgradeTools/Module/ModuleMigrationTest.php
@@ -261,4 +261,22 @@ class ModuleMigrationTest extends TestCase
 
         $this->assertNull($this->moduleMigration->saveVersionInDb($moduleMigrationContext));
     }
+
+    public function testMigrationWithEchoThenHeadersSent()
+    {
+        $mymodule = new \fixtures\mymodule\mymodule();
+        $mymodule->version = '1.3.2';
+        $dbVersion = '1.3.0';
+
+        $moduleMigrationContext = new ModuleMigrationContext($mymodule, $dbVersion);
+
+        $this->logger->expects($this->exactly(2))
+            ->method('notice')
+            ->withConsecutive(
+                ['(1/2) Applying migration file upgrade-1.3.1.php.'],
+                ['(2/2) Applying migration file upgrade-1.3.2.php.']
+            );
+        $this->assertTrue($this->moduleMigration->needMigration($moduleMigrationContext));
+        $this->moduleMigration->runMigration($moduleMigrationContext);
+    }
 }


### PR DESCRIPTION


<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | If modules migration scripts echoes stuff before another tries to set headers, we encounter the following error when updating the modules: `Failed to start the session because headers have already been sent by "/var/www/html/modules/pagesnotfound/upgrade/pagesnotfound_upgrade_module_2_0_2.php" at line 1`. This is currently taken care of in https://github.com/PrestaShop/PrestaShop/issues/39823, but we also need a safe net inside this module in case we missed something in the native modules or if a third party one has the same issue.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/39823
| Sponsor company   | @PrestaShopCorp
| How to test?      | This PR will show the unit tests failing with the first commit, and the second one will fix it. This PR should then be merged in https://github.com/PrestaShop/autoupgrade/pull/1504 to help the rest of the changes to work.