### PR TITLE
Enable buffer on module migration

### DIFF
--- a/classes/UpgradeTools/Module/ModuleMigration.php
+++ b/classes/UpgradeTools/Module/ModuleMigration.php
@@ -153,6 +153,7 @@ class ModuleMigration
         $sandboxedFilePath = $updateDirectory . DIRECTORY_SEPARATOR . $uniqueMethodName . '.php';
 
         try {
+            ob_start();
             $this->filesystem->dumpFile($sandboxedFilePath, str_replace($methodName, $uniqueMethodName, file_get_contents($filePath)));
 
             require_once $sandboxedFilePath;
@@ -165,6 +166,10 @@ class ModuleMigration
             throw (new UpgradeException($this->translator->trans('Could not write temporary file %s.', [$sandboxedFilePath])))->setSeverity(UpgradeException::SEVERITY_WARNING);
         } finally {
             $this->filesystem->remove($sandboxedFilePath);
+            // If the module echoed during the migration, we catch it in the logger.
+            // This avoids the error "headers already sent" as well if the next migration needs headers.
+            $this->logger->debug(ob_get_contents());
+            ob_end_clean();
         }
     }
 }


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | If modules migration scripts echoes stuff before another tries to set headers, we encounter the following error when updating the modules: `Failed to start the session because headers have already been sent by "/var/www/html/modules/pagesnotfound/upgrade/pagesnotfound_upgrade_module_2_0_2.php" at line 1`. This is currently taken care of in https://github.com/PrestaShop/PrestaShop/issues/39823, but we also need a safe net inside this module in case we missed something in the native modules or if a third party one has the same issue.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/39823
| Sponsor company   | @PrestaShopCorp
| How to test?      | The CI is still correct on this PR, but will allow the CI of https://github.com/PrestaShop/autoupgrade/pull/1504 to pass at last.