### PR TITLE
Add nullable type on implicit types

### DIFF
--- a/classes/Models/PrestashopRelease.php
+++ b/classes/Models/PrestashopRelease.php
@@ -47,7 +47,7 @@ class PrestashopRelease
     public function __construct(
         string $version,
         string $stability,
-        string $distribution = null,
+        ?string $distribution = null,
         ?string $phpMaxVersion = null,
         ?string $phpMinVersion = null,
         ?string $zipDownloadUrl = null,

--- a/classes/Models/UpdateNotificationConfiguration.php
+++ b/classes/Models/UpdateNotificationConfiguration.php
@@ -47,7 +47,7 @@ class UpdateNotificationConfiguration
     /**
      * @param array{lastCheck: array{timestamp: int|null, version: string|null, releaseNote: string|null}, employees: array<array{employeeID: int, timestamp: int}>}|null $configuration
      */
-    public function __construct(array $configuration = null)
+    public function __construct(?array $configuration = null)
     {
         if ($configuration) {
             $lastCheck = $configuration['lastCheck'];


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | `<b>Deprecated</b>:  PrestaShop\Module\AutoUpgrade\Models\PrestashopRelease::__construct(): Implicitly marking parameter $distribution as nullable is deprecated, the explicit nullable type must be used instead in <b>modules/autoupgrade/classes/Models/PrestashopRelease.php</b> on line <b>47</b><br />`
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fix reported issue via Error reporting modal of Update Assistant
| Sponsor company   | @PrestaShopCorp
| How to test?      | Running PrestaShop on PHP 8.4 with the error reporting as -1, plus `_PS_DISPLAY_COMPATIBILITY_WARNING_` as `true` in config/defines.inc.php should trigger the error on the `dev` branch.