### PR TITLE
Block ajax requests to the shop while a process runs

### DIFF
--- a/_dev/src/ts/appUI/api/ShopRequestsGuard.ts
+++ b/_dev/src/ts/appUI/api/ShopRequestsGuard.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+/**
+ * While we run a process of update or restore, we alter the store in many ways.
+ * We try to control when to initialize the Core, or emptying the cache when necessary.
+ *
+ * If an ajax request is sent to the shop in parallel, we encounter side effects
+ * of cache partially generated, HTTP 500 in the logs caused by PrestaShop being modified etc.
+ *
+ * To avoid these issues, Update Assistant will prevent requests to reach the shop.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/issues/39509
+ */
+const PREFIX = "Update Assistant's guard:";
+let filterRequestsToShop = false;
+
+(function (): void {
+  // Save references to the original methods
+  const origOpen = XMLHttpRequest.prototype.open;
+
+  XMLHttpRequest.prototype.open = function (...args: [method: string, url: string | URL]) {
+    const url = args[1];
+    const filtered = !isRequestAllowed(String(url));
+
+    if (filterRequestsToShop && filtered) {
+      console.debug(`${PREFIX} Request filtered (${url})`);
+      this.abort();
+    } else {
+      // @ts-expect-error because we're sending the same params as we receive them. Typescript is lost becaused of the overloads.
+      origOpen.apply(this, args);
+    }
+  };
+})();
+
+export const isRequestAllowed = (url: string): boolean => {
+  // Block all requests targeting the shop unless they are for Update Assistant
+  if (!url.startsWith('/') && !url.includes(window.location.host)) {
+    return true;
+  }
+  return url.includes('autoupgrade');
+};
+
+export function disableFilteringOfRequestsToShop(): void {
+  console.debug(`${PREFIX} Requests to the shop are allowed.`);
+
+  filterRequestsToShop = false;
+}
+
+export function enableFilteringOfRequestsToShop(): void {
+  console.debug(`${PREFIX} Requests to the shop are now filtered.`);
+
+  filterRequestsToShop = true;
+}

--- a/_dev/src/ts/appUI/components/ProcessContainer.ts
+++ b/_dev/src/ts/appUI/components/ProcessContainer.ts
@@ -23,6 +23,10 @@ import { ProcessContainerCallbacks } from '../types/Process';
 import Process from '../utils/Process';
 import ProgressTracker from './ProgressTracker';
 import BrowserTab from './BrowserTab';
+import {
+  disableFilteringOfRequestsToShop,
+  enableFilteringOfRequestsToShop
+} from '../api/ShopRequestsGuard';
 
 export default class ProcessContainer implements DomLifecycle {
   #progressTracker: ProgressTracker = new ProgressTracker(this.#progressTrackerContainer);
@@ -44,6 +48,7 @@ export default class ProcessContainer implements DomLifecycle {
     });
 
     this.#enableExitConfirmation();
+    enableFilteringOfRequestsToShop();
 
     await process.startProcess(this.initialAction);
   };
@@ -72,6 +77,7 @@ export default class ProcessContainer implements DomLifecycle {
 
   #onProcessEnd = async (response: ApiResponseAction): Promise<void> => {
     this.#disableExitConfirmation();
+    disableFilteringOfRequestsToShop();
     if (response.error) {
       this.#onError(response);
     } else {
@@ -82,6 +88,7 @@ export default class ProcessContainer implements DomLifecycle {
 
   #onError = (response: ApiResponseAction): void => {
     this.#disableExitConfirmation();
+    disableFilteringOfRequestsToShop();
     this.#progressTracker.updateProgress(response);
     this.#progressTracker.endProgress();
     this.#browserTab.setError();

--- a/_dev/tests/api/ShopRequestsGuard.test.ts
+++ b/_dev/tests/api/ShopRequestsGuard.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+import { isRequestAllowed } from '../../src/ts/appUI/api/ShopRequestsGuard';
+
+describe('ShopRequestsGuard', () => {
+  describe('isRequestAllowed', () => {
+    const dataSet = [
+      {
+        urlRequest: '/admin-dev/common/notifications/ack?_token=',
+        urlShop:
+          'http://localhost:8001/admin-dev/?controller=AdminSelfUpgrade&token=&route=restore-page-post-restore',
+        expectedValue: false
+      },
+      {
+        urlRequest: 'http://localhost:8001/admin-dev/common/notifications?_token=',
+        urlShop:
+          'http://localhost:8001/admin-dev/?controller=AdminSelfUpgrade&token=&route=restore-page-post-restore',
+        expectedValue: false
+      },
+      {
+        urlRequest:
+          '/admin-dev/autoupgrade/ajax-upgradetab.php?route=restore-page-backup-selection',
+        urlShop:
+          'http://localhost:8001/admin-dev/?controller=AdminSelfUpgrade&token=&route=restore-page-post-restore',
+        expectedValue: true
+      }
+    ];
+
+    it.each(dataSet)(
+      'checks the URLs can be called',
+      ({
+        urlRequest,
+        urlShop,
+        expectedValue
+      }: {
+        urlRequest: string;
+        urlShop: string;
+        expectedValue: boolean;
+      }) => {
+        (window as Window).location = urlShop;
+        const result = isRequestAllowed(urlRequest);
+
+        expect(result).toBe(expectedValue);
+      }
+    );
+  });
+});

--- a/_dev/tests/api/ShopRequestsGuard.test.ts
+++ b/_dev/tests/api/ShopRequestsGuard.test.ts
@@ -40,6 +40,12 @@ describe('ShopRequestsGuard', () => {
         urlShop:
           'http://localhost:8001/admin-dev/?controller=AdminSelfUpgrade&token=&route=restore-page-post-restore',
         expectedValue: true
+      },
+      {
+        urlRequest: 'https://api.prestashop-project.org/prestashop/stable',
+        urlShop:
+          'http://localhost:8001/admin-dev/?controller=AdminSelfUpgrade&token=&route=restore-page-post-restore',
+        expectedValue: true
       }
     ];
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Updates are reported to fail randomly. This is caused by the ajax request that check regularly if new notifications should be displayed on the top of the back office. This PR introduces a guard that prevents all ajax requests to reach the shop if they are not related to Update Assistant. This fixes the parallel generation of the cache at a moment we try to empty it.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/39509
| Sponsor company   | @PrestaShopCorp
| How to test?      | As reported on the video below, the browser console will now display when the guard is toggled on and off. You can manually send ajax requests by clicking on the bell at the top of the back office page. On the `dev` branch, you can trigger it when you want and this makes the update fail if called at the end of the update database, while on this PR no ajax request will appear on the network tab.

**Note:** If requests are sent to the shop from other sources (API, probably front end as well...), Update Assistant won't be able to block them.

https://github.com/user-attachments/assets/1baae177-be50-4f75-b118-966350045fec


