### PR TITLE
Fix error about missing files in admin-api/ during requirements check

### DIFF
--- a/classes/Xml/ChecksumCompare.php
+++ b/classes/Xml/ChecksumCompare.php
@@ -226,7 +226,13 @@ class ChecksumCompare
                 $fullPath = str_replace('ps_root_dir', $this->prodPath, $fullPath);
 
                 // replace default admin dir by current one
-                $fullPath = str_replace($this->prodPath . DIRECTORY_SEPARATOR . 'admin', $this->adminPath, $fullPath);
+                // Add directory separator to ensure we only match the exact admin directory
+                // and not directories like admin-api, etc. (fixes #40035)
+                $fullPath = str_replace(
+                    $this->prodPath . DIRECTORY_SEPARATOR . 'admin' . DIRECTORY_SEPARATOR,
+                    $this->adminPath . DIRECTORY_SEPARATOR,
+                    $fullPath
+                );
 
                 if (!file_exists($fullPath) && !str_contains($fullPath, 'install' . DIRECTORY_SEPARATOR)) {
                     $this->addFileDifferences($relative_path, true);

--- a/tests/fixtures/checksum-compare/9.0.0.xml
+++ b/tests/fixtures/checksum-compare/9.0.0.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<checksum_list>
+	<ps_root_dir version="9.0.0">
+		<dir name="admin">
+			<md5file name="index.php">283b4dff1c55cbcfb624ca5a10cb808f</md5file>
+		</dir>
+		<dir name="admin-api">
+			<md5file name="index.php">96b9bb217e71f7dfa0b0cf1704860d25</md5file>
+			<md5file name=".htaccess">0a98f8777dddfd8cd380a1f4a66ae537</md5file>
+		</dir>
+	</ps_root_dir>
+</checksum_list>

--- a/tests/fixtures/checksum-compare/9.0.0/admin-api/.htaccess
+++ b/tests/fixtures/checksum-compare/9.0.0/admin-api/.htaccess
@@ -1,0 +1,2 @@
+# Admin API htaccess
+Deny from all

--- a/tests/fixtures/checksum-compare/9.0.0/admin-api/index.php
+++ b/tests/fixtures/checksum-compare/9.0.0/admin-api/index.php
@@ -1,0 +1,2 @@
+<?php
+// Admin API index file

--- a/tests/fixtures/checksum-compare/9.0.0/admin120df7jyx6dk20p2ehq/index.php
+++ b/tests/fixtures/checksum-compare/9.0.0/admin120df7jyx6dk20p2ehq/index.php
@@ -1,0 +1,2 @@
+<?php
+// Admin index file

--- a/tests/unit/Xml/ChecksumCompareTest.php
+++ b/tests/unit/Xml/ChecksumCompareTest.php
@@ -102,4 +102,41 @@ class ChecksumCompareTest extends TestCase
 
         $this->assertEquals($expected, $tamperedFiles);
     }
+
+    /**
+     * Test that admin-api files are not incorrectly reported as missing
+     * when admin folder has been renamed (bug from issue #40035)
+     */
+    public function testAdminApiFilesNotReportedAsMissingWithCustomAdminFolder()
+    {
+        $fileSystemAdapter = $this->getMockBuilder(FilesystemAdapter::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $fileLoader = $this->getMockBuilder(FileLoader::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getXmlMd5File'])
+            ->getMock();
+
+        $xmlFile = @simplexml_load_file(__DIR__ . '/../../fixtures/checksum-compare/9.0.0.xml');
+
+        $fileLoader->method('getXmlMd5File')
+            ->willReturn($xmlFile);
+
+        // Use custom admin folder name to simulate real PrestaShop setup
+        $checksumCompare = new ChecksumCompare(
+            $fileLoader,
+            $fileSystemAdapter,
+            __DIR__ . '/../../fixtures/checksum-compare/9.0.0',
+            __DIR__ . '/../../fixtures/checksum-compare/9.0.0/admin120df7jyx6dk20p2ehq'
+        );
+        $tamperedFiles = $checksumCompare->getTamperedFilesOnShop('9.0.0');
+
+        // admin-api files should NOT be reported as missing
+        // The bug was that str_replace would match "admin" in "admin-api"
+        // and create incorrect paths like "admin120df7jyx6dk20p2ehq-api"
+        $missingFiles = $tamperedFiles[ChecksumCompare::CATEGORY_CORE][ChecksumCompare::FILE_MISSING];
+        $this->assertNotContains('admin-api/index.php', $missingFiles, 'admin-api files should not be reported as missing when admin folder is renamed');
+        $this->assertNotContains('admin-api/.htaccess', $missingFiles, 'admin-api files should not be reported as missing when admin folder is renamed');
+    }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix reported missing files about admin-api. 
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/40035
| Sponsor company   | @PrestaShopCorp
| How to test?      | On fresh installations of PrestaShop 9, the contents of the folder admin-api is not anymore reported as missing

This fix has been found with the help of AI.