### PR TITLE
Persist current product route when upgrading to 9.0.0

### DIFF
--- a/upgrade/php/add_product_routes.php
+++ b/upgrade/php/add_product_routes.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+/**
+ * In Prestashop 9.0.0 the default product routes have been modified by removing
+ * category and EAN from the URL.
+ *
+ * If the merchant kept the original routes the former urls won't be reachable any
+ * more and SEO will be lost. So we force a custom rule matching the former format.
+ *
+ * If the route was customized, no need to do anything. We don't change anything for
+ * multi shop either since it will be used it the merchant has already changed them.
+ */
+function add_product_routes()
+{
+    Configuration::loadConfiguration();
+
+    if (!Configuration::get('PS_ROUTE_product_rule', null, 0, 0)) {
+        Configuration::updateGlobalValue('PS_ROUTE_product_rule', '{category:/}{id}{-:id_product_attribute}-{rewrite}{-:ean13}.html');
+    }
+}

--- a/upgrade/php/ps_900_set_previous_product_route_as_custom.php
+++ b/upgrade/php/ps_900_set_previous_product_route_as_custom.php
@@ -28,10 +28,8 @@
  * If the route was customized, no need to do anything. We don't change anything for
  * multi shop either since it will be used it the merchant has already changed them.
  */
-function add_product_routes()
+function ps_900_set_previous_product_route_as_custom()
 {
-    Configuration::loadConfiguration();
-
     if (!Configuration::get('PS_ROUTE_product_rule', null, 0, 0)) {
         Configuration::updateGlobalValue('PS_ROUTE_product_rule', '{category:/}{id}{-:id_product_attribute}-{rewrite}{-:ean13}.html');
     }

--- a/upgrade/sql/9.0.0.sql
+++ b/upgrade/sql/9.0.0.sql
@@ -3,7 +3,7 @@ SET NAMES 'utf8mb4';
 
 /* Persist current product routes to avoid SEO issues after changing default routes in 9.0.0 */
 /* See https://github.com/PrestaShop/PrestaShop/pull/37467 */
-/* PHP:add_product_routes(); */;
+/* PHP:ps_900_set_previous_product_route_as_custom(); */;
 
 /* Add a file separator input to the sql manager settings - https://github.com/PrestaShop/PrestaShop/pull/35843 */
 /* Allow configuring maximum word difference - https://github.com/PrestaShop/PrestaShop/pull/37261 */

--- a/upgrade/sql/9.0.0.sql
+++ b/upgrade/sql/9.0.0.sql
@@ -1,6 +1,10 @@
 SET SESSION sql_mode='';
 SET NAMES 'utf8mb4';
 
+/* Persist current product routes to avoid SEO issues after changing default routes in 9.0.0 */
+/* See https://github.com/PrestaShop/PrestaShop/pull/37467 */
+/* PHP:add_product_routes(); */;
+
 /* Add a file separator input to the sql manager settings - https://github.com/PrestaShop/PrestaShop/pull/35843 */
 /* Allow configuring maximum word difference - https://github.com/PrestaShop/PrestaShop/pull/37261 */
 /* PHP:add_configuration_if_not_exists('PS_DEBUG_COOKIE_NAME', ''); */;


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | If routes have not been modified, they are not in ps_configration. If you upgrade to 9.0.0, your product URLs change and you completely RUIN YOUR SEO. Caused by https://github.com/PrestaShop/PrestaShop/pull/37467.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/40063#issuecomment-3564109485
| Sponsor company   | TRENDO s.r.o.
| How to test?      | Upgrade from 8.2.3 to 9.0.0 and check that your product rewrite rule in SEO settings is the same.
