### PR TITLE
Fix underline issue on v9

### DIFF
--- a/_dev/src/scss/appUI/components/_privacy.scss
+++ b/_dev/src/scss/appUI/components/_privacy.scss
@@ -33,7 +33,9 @@ $e: ".privacy-link";
     font-size: 1rem;
     line-height: 1.4;
     color: var(--#{$ua-prefix}privacy-link-color);
-    text-decoration: none;
+    // Disable text decoration for the link to maintain v9 compatibility
+    // stylelint-disable-next-line
+    text-decoration: none !important;
     transition: border-color 0.15s;
 
     &:hover {

--- a/_dev/src/scss/appUI/components/_radio-card.scss
+++ b/_dev/src/scss/appUI/components/_radio-card.scss
@@ -192,7 +192,9 @@ $e: ".radio-card";
       font-size: 0.875rem;
       line-height: 1.4;
       color: var(--#{$ua-prefix}radio-card-release-color);
-      text-decoration: none;
+      // Disable text decoration for the link to maintain v9 compatibility
+      // stylelint-disable-next-line
+      text-decoration: none !important;
       transition: border-color 0.15s;
 
       &:hover {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | PrestaShop v9 BO introduces an underline on links, which degrades the UI. A fix has been added to restore the original link appearance.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | --
| Sponsor company   | @PrestaShopCorp
| How to test?      | Check whether the "Release note" and "Privacy policy" links display correctly without a double underline.
