### PR TITLE
Fix all issues reported on Storybook from recent changes

### DIFF
--- a/storybook/stories/components/DialogTemperedFiles.stories.js
+++ b/storybook/stories/components/DialogTemperedFiles.stories.js
@@ -51,6 +51,8 @@ export const TemperedFiles = {
       "adminProjetX/themes/new-theme/public/meta.bundle.js",
       "adminProjetX/themes/new-theme/public/module.bundle.js",
     ],
+    container_id: 'tempered_files_container',
+    content_action: '#',
   },
   play: async () => {
     const dialog = document.querySelector(".dialog");

--- a/storybook/stories/components/RadioCard.stories.js
+++ b/storybook/stories/components/RadioCard.stories.js
@@ -58,6 +58,7 @@ export const Default = {
       update_value: "update",
       restore_value: "restore",
     },
+    recommended: false,
   },
 };
 

--- a/storybook/stories/components/RadioCardLocal.stories.js
+++ b/storybook/stories/components/RadioCardLocal.stories.js
@@ -37,6 +37,7 @@ export const Local = {
     releaseNote: "",
     form_options: {
       online_value: false,
+      online_recommended_value: false,
       local_value: false,
     },
     form_fields: {
@@ -53,10 +54,11 @@ export const Local = {
       zip: ["archive1.zip", "archive2.zip", "archive3.zip"],
       xml: ["archive1.xml", "archive2.xml", "archive3.xml"],
     },
-    local_requirements: {
+    requirements: {
       requirements_ok: true,
       errors: [],
       warnings: [],
     },
+    recommended: true,
   },
 };

--- a/storybook/stories/components/RadioCardOnlineRecommended.stories.js
+++ b/storybook/stories/components/RadioCardOnlineRecommended.stories.js
@@ -24,7 +24,7 @@ export default {
   title: "Components/Radio card",
 };
 
-export const Online = {
+export const OnlineRecommended = {
   args: {
     updateAssistantDocs:
       "https://devdocs.prestashop-project.org/8/basics/keeping-up-to-date/use-autoupgrade-module/",
@@ -32,7 +32,6 @@ export const Online = {
     disabledMessage: "",
     form_options: {
       online_value: false,
-      online_recommended_value: false,
       local_value: false,
     },
     form_fields: {
@@ -44,12 +43,12 @@ export const Online = {
       channel: "online",
     },
     next_release: {
-      badge_label: "Major version",
-      badge_status: "major",
+      badge_label: "Minor version",
+      badge_status: "minor",
       release_note: "https://github.com/PrestaShop/autoupgrade",
-      version: "9.0.0",
-      recommended: false,
-      message: 'The maximum version of PrestaShop to which you can update your store, based on its PHP version.',
+      version: "8.2.3",
+      recommended: true,
+      message: 'The recommended version of PrestaShop to which you can update your store, based on its PHP version.',
     },
     next_releases: {
       online: {

--- a/storybook/stories/pages/VersionChoice.stories.js
+++ b/storybook/stories/pages/VersionChoice.stories.js
@@ -22,6 +22,7 @@ import { Online } from "../components/RadioCardOnline.stories";
 import { Local } from "../components/RadioCardLocal.stories";
 import { NoLocalArchive } from "../components/Alert.stories";
 import { VersionChoice as Stepper } from "../components/Stepper.stories";
+import { OnlineRecommended } from "../components/RadioCardOnlineRecommended.stories";
 
 export default {
   component: VersionChoicePage,
@@ -45,12 +46,14 @@ export const VersionChoice = {
     stepper_parent_id: "stepper_content",
     radio_card_online_parent_id: "radio_card_online",
     radio_card_archive_parent_id: "radio_card_archive",
+    radio_card_online_recommended_parent_id: "radio_card_online_recommended",
     form_route_to_save: "update-step-version-choice-save-form",
     form_route_to_submit: "update-step-version-choice-submit-form",
     data_transparency_link:
       "https://www.prestashop-project.org/data-transparency",
     // Radio cards
     ...Online.args,
+    ...OnlineRecommended.args,
     ...Local.args,
     // Stepper
     ...Stepper.args,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | With Update Assistant 7.5, major changes have been brought to the update configuration. They are backported on the storybook as many stories were broken due to missing variables sent to the templates.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Run Storybook with by running these commands at the same time from `storybook/`: `php -S localhost:8003 -t public/` and `npm run storybook`. No story must display an error.