### PR TITLE
Fix column wrongly declared as NOT NULL instead of DEFAULT NULL

### DIFF
--- a/upgrade/sql/9.0.2.sql
+++ b/upgrade/sql/9.0.2.sql
@@ -3,7 +3,7 @@ SET NAMES 'utf8mb4';
 
 -- https://github.com/PrestaShop/PrestaShop/pull/39606
 ALTER TABLE `PREFIX_customer_message`
-    MODIFY `user_agent` varchar(255) NOT NULL;
+    MODIFY `user_agent` varchar(255) DEFAULT NULL;
 
 -- https://github.com/PrestaShop/PrestaShop/pull/39914
 INSERT IGNORE INTO `PREFIX_authorization_role` (`slug`) VALUES


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix an error in the column type from https://github.com/PrestaShop/autoupgrade/pull/1471
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | When describing the table `customer_message` after an update to PS 9.0.2, the type of the column must be `user_agent varchar(255) DEFAULT NULL`
