### PR TITLE
Avoid impacting statistics of succesfull updates with test cases

### DIFF
--- a/classes/Analytics.php
+++ b/classes/Analytics.php
@@ -153,7 +153,9 @@ class Analytics
 
     private function hasOptedOut(): bool
     {
-        return isset($_SERVER[self::URL_TRACKING_ENV_NAME])
-            && ((bool) $_SERVER[self::URL_TRACKING_ENV_NAME] === false || $_SERVER[self::URL_TRACKING_ENV_NAME] === 'false');
+        $trackingEnabled = getenv(self::URL_TRACKING_ENV_NAME);
+
+        return $trackingEnabled !== false
+            && ((bool) $trackingEnabled === false || $trackingEnabled === 'false');
     }
 }

--- a/tests/UI/docker-compose.yml
+++ b/tests/UI/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - DB_PASSWD=prestashop
       - DB_NAME=prestashop
       - DB_PREFIX=ps_
+      - PS_URL_TRACKING=0
     volumes:
       - type: bind
         # Local Path


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Do not send test cases to statistics, as we want to know how healthy are updates from actual shops.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | To check that UI tests do not send anymore events to Segment, make a `PS_VERSION=8.2.1 docker compose up -d` from the command line, then `docker exec -ti -u www-data prestashop php modules/autoupgrade/bin/console backup:create admin-dev`. Check Segment with and without the env var.