### PR TITLE
Fix the paths of the deleted files, which were absolute but invalid paths

### DIFF
--- a/classes/Task/Update/UpdateFiles.php
+++ b/classes/Task/Update/UpdateFiles.php
@@ -95,7 +95,8 @@ class UpdateFiles extends AbstractTask
     /**
      * upgradeThisFile.
      *
-     * @param mixed $orig The absolute path to the file from the upgrade archive
+     * @param mixed $orig The absolute path to the file in the temp extraction directory structure.
+     *                    For deleted files, this path may not physically exist.
      *
      * @throws Exception
      */
@@ -276,6 +277,7 @@ class UpdateFiles extends AbstractTask
         // Admin folder name in this deleted files list is standard /admin/.
         // We will need to change it to our own admin folder name.
         $admin_dir = trim(str_replace($this->container->getProperty(UpgradeContainer::PS_ROOT_PATH), '', $this->container->getProperty(UpgradeContainer::PS_ADMIN_PATH)), DIRECTORY_SEPARATOR);
+        $tmpFilesPath = $this->container->getProperty(UpgradeContainer::TMP_FILES_PATH);
         foreach ($diffFileList as $k => $path) {
             if (preg_match('#autoupgrade#', $path)) {
                 unset($diffFileList[$k]);
@@ -284,6 +286,10 @@ class UpdateFiles extends AbstractTask
                 // admin even in the middle of a path, not deleting some files as a result.
                 // Also, do not use DIRECTORY_SEPARATOR, keep forward slash, because the path come from the XML standardized.
                 $diffFileList[$k] = '/' . $admin_dir . substr($path, 6);
+            }
+            // Convert relative paths to absolute paths with the same structure as files from temp extraction directory
+            if (isset($diffFileList[$k])) {
+                $diffFileList[$k] = $tmpFilesPath . $diffFileList[$k];
             }
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix the build of the backlog of files updates, where the deleted files were not a valid absolute path to the unzipped archive of PrestaShop
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/autoupgrade/issues/1552
| Sponsor company   | @PrestaShopCorp
| How to test?      | Files to delete are not triggering anymore errors during an update. To reproduce this issue, the root path of the webserver files must be added to the basedir. For instance, this is `/var/www/html` on a Docker environment, so in the php.ini you would get:


```ini
open_basedir = "/var/www/html/:/tmp"
```