### PR TITLE
Prepare release of Update Assistant 7.4.4 for PrestaShop 9.0.2

### DIFF
--- a/autoupgrade.php
+++ b/autoupgrade.php
@@ -35,7 +35,7 @@ class Autoupgrade extends Module
         $this->name = 'autoupgrade';
         $this->tab = 'administration';
         $this->author = 'PrestaShop';
-        $this->version = '7.4.3';
+        $this->version = '7.4.4';
         $this->need_instance = 1;
         $this->module_key = '926bc3e16738b7b834f37fc63d59dcf8';
 

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>autoupgrade</name>
     <displayName><![CDATA[Update Assistant]]></displayName>
-    <version><![CDATA[7.4.3]]></version>
+    <version><![CDATA[7.4.4]]></version>
     <description><![CDATA[The Update Assistant module helps you backup, update and restore your PrestaShop store. With just a few clicks, you can move to the latest version of PrestaShop with confidence.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[administration]]></tab>

--- a/upgrade/php/deactivate_custom_modules.php
+++ b/upgrade/php/deactivate_custom_modules.php
@@ -100,6 +100,10 @@ function deactivate_custom_modules80($moduleRepository): bool
 {
     $nonNativeModulesList = $moduleRepository->getNonNativeModules();
 
+    if (empty($nonNativeModulesList)) {
+        return true;
+    }
+
     $return = DbWrapper::execute(
         'UPDATE `' . _DB_PREFIX_ . 'module` SET `active` = 0 WHERE `name` IN (' . implode(',', array_map('add_quotes', $nonNativeModulesList)) . ')'
     );

--- a/upgrade/php/ps_900_set_previous_product_route_as_custom.php
+++ b/upgrade/php/ps_900_set_previous_product_route_as_custom.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+/**
+ * In Prestashop 9.0.0 the default product routes have been modified by removing
+ * category and EAN from the URL.
+ *
+ * If the merchant kept the original routes the former urls won't be reachable any
+ * more and SEO will be lost. So we force a custom rule matching the former format.
+ *
+ * If the route was customized, no need to do anything. We don't change anything for
+ * multi shop either since it will be used it the merchant has already changed them.
+ */
+function ps_900_set_previous_product_route_as_custom()
+{
+    if (!Configuration::get('PS_ROUTE_product_rule', null, 0, 0)) {
+        Configuration::updateGlobalValue('PS_ROUTE_product_rule', '{category:/}{id}{-:id_product_attribute}-{rewrite}{-:ean13}.html');
+    }
+}

--- a/upgrade/sql/9.0.0.sql
+++ b/upgrade/sql/9.0.0.sql
@@ -1,6 +1,10 @@
 SET SESSION sql_mode='';
 SET NAMES 'utf8mb4';
 
+/* Persist current product routes to avoid SEO issues after changing default routes in 9.0.0 */
+/* See https://github.com/PrestaShop/PrestaShop/pull/37467 */
+/* PHP:ps_900_set_previous_product_route_as_custom(); */;
+
 /* Add a file separator input to the sql manager settings - https://github.com/PrestaShop/PrestaShop/pull/35843 */
 /* Allow configuring maximum word difference - https://github.com/PrestaShop/PrestaShop/pull/37261 */
 /* PHP:add_configuration_if_not_exists('PS_DEBUG_COOKIE_NAME', ''); */;

--- a/upgrade/sql/9.0.2.sql
+++ b/upgrade/sql/9.0.2.sql
@@ -1,0 +1,20 @@
+SET SESSION sql_mode='';
+SET NAMES 'utf8mb4';
+
+-- https://github.com/PrestaShop/PrestaShop/pull/39606
+ALTER TABLE `PREFIX_customer_message`
+    MODIFY `user_agent` varchar(255) DEFAULT NULL;
+
+-- https://github.com/PrestaShop/PrestaShop/pull/39914
+INSERT IGNORE INTO `PREFIX_authorization_role` (`slug`) VALUES
+  ('ROLE_MOD_TAB_DEFAULT_READ'),
+  ('ROLE_MOD_TAB_DEFAULT_CREATE'),
+  ('ROLE_MOD_TAB_DEFAULT_UPDATE'),
+  ('ROLE_MOD_TAB_DEFAULT_DELETE');
+
+INSERT INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES
+  -- https://github.com/PrestaShop/PrestaShop/pull/39913
+  (NULL, 'actionOverrideQuantityAvailableByProduct','Override available quantity by product','Allows modules to override the available quantity returned by StockAvailable::getQuantityAvailableByProduct().', '1'),
+  (NULL, 'actionCheckAttributeQuantity','Check product attribute quantity availability','Allows modules to validate or override the stock availability check for a specific product combination.', '1'),
+  (NULL, 'actionOverrideProductQuantity','Override product quantity calculation','Allows modules to override the final product quantity returned by Product::getQuantity(), including cart-aware calculations.', '1')
+ON DUPLICATE KEY UPDATE `title` = VALUES(`title`), `description` = VALUES(`description`);

--- a/upgrade/sql/9.1.0.sql
+++ b/upgrade/sql/9.1.0.sql
@@ -1,11 +1,16 @@
 SET SESSION sql_mode='';
 SET NAMES 'utf8mb4';
 
-/* Insert new feature flags introduced for the newly improved shipment system */
-/* https://github.com/PrestaShop/PrestaShop/pull/38040 */
+/* 
+  Insert new feature flags introduced for the newly improved shipment system
+  https://github.com/PrestaShop/PrestaShop/pull/38040
+  Insert new feature flags introduced for the migration of tag page
+  https://github.com/PrestaShop/PrestaShop/pull/39516
+*/
 INSERT INTO `PREFIX_feature_flag` (`name`, `type`, `label_wording`, `label_domain`, `description_wording`, `description_domain`, `state`, `stability`) VALUES
   ('improved_shipment', 'env,dotenv,db', 'Improved shipment', 'Admin.Advparameters.Feature', 'Enable / Disable the newly improved shipment system', 'Admin.Advparameters.Help', 0, 'beta'),
-  ('discount', 'env,dotenv,db', 'Discount', 'Admin.Advparameters.Feature', 'Enable / Disable the new discount system.', 'Admin.Advparameters.Help', 0, 'beta');
+  ('discount', 'env,dotenv,db', 'Discount', 'Admin.Advparameters.Feature', 'Enable / Disable the new discount system.', 'Admin.Advparameters.Help', 0, 'beta'),
+  ('tag', 'env,dotenv,db', 'Tag', 'Admin.Advparameters.Feature', 'Enable / Disable the tag page.', 'Admin.Advparameters.Help', 0, 'beta');
 
 /* Add a new field to cart_rule */
 /* https://github.com/PrestaShop/PrestaShop/pull/37911/ */
@@ -41,5 +46,7 @@ CREATE TABLE IF NOT EXISTS `PREFIX_shipment_product` (
 
 ALTER TABLE `PREFIX_cart_rule_product_rule` MODIFY COLUMN `type` ENUM(
     'products', 'categories', 'attributes',
-    'manufacturers', 'suppliers', 'combinations'
+    'manufacturers', 'suppliers', 'combinations', 'features'
 ) NOT NULL;
+
+/* PHP:add_column('cart_rule_product_rule_group', 'type', 'ENUM("at_least_one_product_rule", "all_product_rules") NOT NULL DEFAULT "at_least_one_product_rule"'); */;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | We are not quite ready to release Update Assistant 7.5. In order to be in sync with the release of PrestaShop 9.0.2, we prepare a patch release of the module that only contains the changes in the migration scripts.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Related to https://github.com/PrestaShop/PrestaShop/issues/40028
| Sponsor company   | @PrestaShopCorp
| How to test?      | Updates to 9.0.2 succeed and are in line with fresh installations.
