### PR TITLE
Make `quantity` and `quantity_per_user` nullable in `cart_rule` table

### DIFF
--- a/upgrade/sql/9.1.0.sql
+++ b/upgrade/sql/9.1.0.sql
@@ -114,3 +114,8 @@ INSERT INTO `PREFIX_cart_rule_type` (`id_cart_rule_type`, `discount_type`, `is_c
 ON DUPLICATE KEY UPDATE `discount_type` = VALUES(`discount_type`), `is_core` = VALUES(`is_core`), `active` = VALUES(`active`);
 
 /* PHP:ps_910_init_cart_rule_type_lang_translations(); */;
+
+/* Make quantity and quantity_per_user nullable in cart_rule table */
+/* https://github.com/PrestaShop/PrestaShop/pull/40330 */
+/* PHP:add_column('cart_rule', 'quantity', 'int(10) unsigned DEFAULT \'0\''); */;
+/* PHP:add_column('cart_rule', 'quantity_per_user', 'int(10) unsigned DEFAULT \'0\''); */;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Make `quantity` and `quantity_per_user` nullable in `cart_rule` table. Related to https://github.com/PrestaShop/PrestaShop/pull/40330
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Sponsor company   | PrestaShop SA
| How to test?      | ~
