### PR TITLE
[FIX] PHP deprecation notices break JSON responses in AJAX endpoints

### DIFF
--- a/ajax-upgradetab.php
+++ b/ajax-upgradetab.php
@@ -23,12 +23,13 @@ use PrestaShop\Module\AutoUpgrade\Router\Router;
 use PrestaShop\Module\AutoUpgrade\Task\Runner\SingleTask;
 use Symfony\Component\HttpFoundation\Request;
 
-/**
+/*
  * This file is the entrypoint for all ajax requests during a upgrade, rollback or configuration.
  * In order to get the admin context, this file is copied to the admin/autoupgrade folder of your shop when the module configuration is reached.
  *
  * Calling it from the module/autoupgrade folder will have unwanted consequences on the upgrade and your shop.
  */
+
 ini_set('display_errors', '0');
 ob_start();
 

--- a/ajax-upgradetab.php
+++ b/ajax-upgradetab.php
@@ -29,6 +29,9 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * Calling it from the module/autoupgrade folder will have unwanted consequences on the upgrade and your shop.
  */
+ini_set('display_errors', '0');
+ob_start();
+
 require_once realpath(dirname(__FILE__) . '/../../modules/autoupgrade') . '/ajax-upgradetabconfig.php';
 
 autoupgrade_require_autoload(dirname(__FILE__));
@@ -56,9 +59,21 @@ if (!empty($action)) {
     $controller = new SingleTask($container);
     $controller->setOptions(['action' => $action]);
     $controller->run();
+
+    // Clear previous output to ensure the response is a valid JSON
+    if (ob_get_level() && ob_get_length() > 0) {
+        ob_clean();
+    }
+
     echo $controller->getJsonResponse();
 } else {
     $response = (new Router($container))->handle($request);
+
+    // Clear previous output to ensure the response is a valid JSON
+    if (ob_get_level() && ob_get_length() > 0) {
+        ob_clean();
+    }
+
     if ($response instanceof \Symfony\Component\HttpFoundation\Response) {
         $response->send();
     } else {

--- a/classes/ErrorHandler.php
+++ b/classes/ErrorHandler.php
@@ -87,6 +87,9 @@ class ErrorHandler
                 break;
             case E_NOTICE:
             case E_USER_NOTICE:
+            case E_DEPRECATED:
+            case E_USER_DEPRECATED:
+            case E_STRICT:
                 $type = Logger::NOTICE;
                 break;
             default:


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When running the autoupgrade module, PHP errors, warnings, and deprecation notices from vendor libraries or other sources are being output as HTML before JSON responses. This breaks the JSON parsing in JavaScript and causes operations to fail.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Internal issue
| Sponsor company   | @PrestaShopCorp
| How to test?      | 

To test use PS tag (for docker) = `9.0.0-8.4`
and for `.ini` file with 
```
display_errors = On
error_reporting = E_ALL
```
