### PR TITLE
Change how we get the Request object

### DIFF
--- a/autoupgrade.php
+++ b/autoupgrade.php
@@ -204,7 +204,10 @@ class Autoupgrade extends Module
             return '';
         }
 
-        return (new \PrestaShop\Module\AutoUpgrade\Hooks\DisplayBackOfficeHeader($this->getUpgradeContainer()))->renderUpdateNotification();
+        return (new \PrestaShop\Module\AutoUpgrade\Hooks\DisplayBackOfficeHeader(
+            $this->getUpgradeContainer(),
+            $this->getCurrentRequest()
+        ))->renderUpdateNotification();
     }
 
     /**
@@ -267,5 +270,27 @@ class Autoupgrade extends Module
         }
 
         return $this->container;
+    }
+
+    /**
+     * @return \Symfony\Component\HttpFoundation\Request
+     */
+    public function getCurrentRequest()
+    {
+        // When possible, retrieve an existing instance of Request to avoid issues on pages with uploaded files.
+        // We are compatible with PS 1.7.0 BUT:
+        //  - Module::get() exists since PS 1.7.3.
+        //  - Service "request_stack" is found from PS 8.
+        if (version_compare(_PS_VERSION_, '8.0.0', '>=')) {
+            /** @var \Symfony\Component\HttpFoundation\RequestStack $requestStack */
+            $requestStack = $this->get('request_stack');
+            $request = $requestStack->getCurrentRequest();
+
+            if ($request) {
+                return $request;
+            }
+        }
+
+        return \Symfony\Component\HttpFoundation\Request::createFromGlobals();
     }
 }

--- a/classes/Hooks/DisplayBackOfficeHeader.php
+++ b/classes/Hooks/DisplayBackOfficeHeader.php
@@ -56,6 +56,11 @@ class DisplayBackOfficeHeader
     private $container;
 
     /**
+     * @var Request
+     */
+    private $request;
+
+    /**
      * @var Upgrader
      */
     private $upgrader;
@@ -93,9 +98,10 @@ class DisplayBackOfficeHeader
     /**
      * @throws Exception
      */
-    public function __construct(UpgradeContainer $container)
+    public function __construct(UpgradeContainer $container, Request $request)
     {
         $this->container = $container;
+        $this->request = $request;
         $this->upgrader = $this->container->getUpgrader();
         $this->updateNotificationService = $this->container->getUpdateNotificationService();
         $this->updateNotificationConfiguration = $this->updateNotificationService->getUpdateNotificationConfiguration();
@@ -129,8 +135,7 @@ class DisplayBackOfficeHeader
 
         $this->addScriptsVariables();
 
-        $request = Request::createFromGlobals();
-        $this->addUIAssets($request);
+        $this->addUIAssets($this->request);
 
         if (!$this->isEmployeeDefaultController()) {
             return $this->content;

--- a/controllers/admin/AdminSelfUpgradeController.php
+++ b/controllers/admin/AdminSelfUpgradeController.php
@@ -271,7 +271,7 @@ class AdminSelfUpgradeController extends ModuleAdminController
         $this->content = $this->upgradeContainer->getTwig()->render('@ModuleAutoUpgrade/module-script-variables.html.twig', [
             'autoupgrade_variables' => $this->getScriptsVariables(),
         ]);
-        $request = Request::createFromGlobals();
+        $request = $this->module->getCurrentRequest();
         $this->addUIAssets($request);
 
         $response = (new Router($this->upgradeContainer))->handle($request);

--- a/tests/phpstan/phpstan-1.7.2.5.neon
+++ b/tests/phpstan/phpstan-1.7.2.5.neon
@@ -28,6 +28,10 @@ parameters:
 		- '#Parameter \$params of method Autoupgrade::hookDisplayBackOfficeEmployeeMenu\(\) has invalid type PrestaShop\\PrestaShop\\Core\\Action\\ActionsBarButtonsCollection.#'
 		- '#Parameter \#1 \$kernel of class Symfony\\Bundle\\FrameworkBundle\\Console\\Application constructor expects Symfony\\Component\\HttpKernel\\KernelInterface, AdminKernel\|AppKernel given.$#'
 		-
+			message: '#Call to an undefined method Autoupgrade::get\(\)\.#'
+			path: ./../../autoupgrade.php
+			count: 1
+		-
 			identifier: booleanAnd.rightAlwaysTrue
 			path: ./../../classes/UpgradeSelfCheck.php
 			count: 1


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Update Assistant breaks the BO when a module is uploaded and handled in the request. This PR tends to use the existing request from Symfony when possible. There are some limitations though:<ul><li>It appears the service "request_stack" may be non-existing on PS 1.7 because of the limited integration of Symfony on these versions, especially on legacy pages</li><li>The request stack may have no requests in their list.</li></ul>In these cases, we still rely on the use of `Request::createFromGlobals()` with the risk of failures on pages where a file is uploaded. The issue is not completely fixed but mitigated.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/autoupgrade/issues/1586, Fixes https://github.com/PrestaShop/autoupgrade/issues/1578, Fixes https://github.com/PrestaShop/PrestaShop/issues/39239
| Sponsor company   | @PrestaShopCorp
| How to test?      | Use the module [test_module_40410.zip](https://github.com/user-attachments/files/24477569/test_module_40410.zip), configure it with Update Assistant installed. On the configuration of this test module, select a file and upload it, you'll get the exception about a non-existing file that is fixed by this PR.