### PR TITLE
Speed up execution of files updates by moving files instead of copying them

### DIFF
--- a/classes/Task/Update/UpdateFiles.php
+++ b/classes/Task/Update/UpdateFiles.php
@@ -182,7 +182,7 @@ class UpdateFiles extends AbstractTask
             // upgrade exception were above. This part now process all files that have to be upgraded (means to modify or to remove)
             // delete before updating (and this will also remove deprecated files)
             try {
-                $this->container->getFileSystem()->copy($orig, $dest, true);
+                $this->container->getFileSystem()->rename($orig, $dest, true);
                 $this->logger->debug($this->translator->trans('Copied %1$s.', [$file]));
 
                 return true;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | During the update of files, move them instead of copying them which is a really fast operation when the source and destination are on the same disk partition.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Check the time needed to run the updates, especially until the end of the update of files. You should expect the time taken to be cut in half.
