### PR TITLE
Add stack trace when possible in error report modal

### DIFF
--- a/_dev/src/ts/appUI/dialogs/SendErrorReportDialog.ts
+++ b/_dev/src/ts/appUI/dialogs/SendErrorReportDialog.ts
@@ -44,7 +44,12 @@ export default class SendErrorReportDialog extends DialogAbstract {
 
   get #errorMessagePanelContents(): string {
     if (this.#responseContents) {
-      return `${this.#lastErrorMessage}\n\n${JSON.parse(this.#responseContents)?.nextQuickInfo?.join('\n\n')}`;
+      try {
+        return `${this.#lastErrorMessage}\n\n${JSON.parse(this.#responseContents)?.nextQuickInfo?.join('\n\n')}`;
+      } catch {
+        // Sometimes we can get a response from the server that is not a JSON. In that case:
+        // Do nothing
+      }
     }
 
     return this.#lastErrorMessage;
@@ -60,8 +65,11 @@ export default class SendErrorReportDialog extends DialogAbstract {
     return latestError;
   }
 
-  get #responseContents(): string | undefined {
-    return document.getElementById(ErrorPageBuilder.externalAdditionalContentsPanelId)?.textContent;
+  get #responseContents(): string | null {
+    return (
+      document.getElementById(ErrorPageBuilder.externalAdditionalContentsPanelId)?.textContent ||
+      null
+    );
   }
 
   onSubmit = async (event: SubmitEvent) => {

--- a/_dev/src/ts/appUI/dialogs/SendErrorReportDialog.ts
+++ b/_dev/src/ts/appUI/dialogs/SendErrorReportDialog.ts
@@ -30,7 +30,7 @@ export default class SendErrorReportDialog extends DialogAbstract {
     this.form.addEventListener('submit', this.onSubmit);
 
     const errorMessageArea: HTMLTextAreaElement = this.form.querySelector('#errorMessage')!;
-    errorMessageArea.value = this.#lastErrorMessage;
+    errorMessageArea.value = this.#errorMessagePanelContents;
   };
 
   get form(): HTMLFormElement {
@@ -40,6 +40,14 @@ export default class SendErrorReportDialog extends DialogAbstract {
     }
 
     return form;
+  }
+
+  get #errorMessagePanelContents(): string {
+    if (this.#responseContents) {
+      return `${this.#lastErrorMessage}\n\n${JSON.parse(this.#responseContents)?.nextQuickInfo?.join('\n\n')}`;
+    }
+
+    return this.#lastErrorMessage;
   }
 
   get #lastErrorMessage(): string {
@@ -52,6 +60,10 @@ export default class SendErrorReportDialog extends DialogAbstract {
     return latestError;
   }
 
+  get #responseContents(): string | undefined {
+    return document.getElementById(ErrorPageBuilder.externalAdditionalContentsPanelId)?.textContent;
+  }
+
   onSubmit = async (event: SubmitEvent) => {
     event.preventDefault();
 
@@ -59,9 +71,7 @@ export default class SendErrorReportDialog extends DialogAbstract {
       logs: this.#getLogs(),
       other: new Map<string, string>()
     };
-    const responseContents = document.getElementById(
-      ErrorPageBuilder.externalAdditionalContentsPanelId
-    )?.textContent;
+    const responseContents = this.#responseContents;
     if (responseContents) {
       attachments.other.set('response_raw.txt', responseContents);
     }

--- a/_dev/src/ts/appUI/dialogs/SendErrorReportDialog.ts
+++ b/_dev/src/ts/appUI/dialogs/SendErrorReportDialog.ts
@@ -45,7 +45,8 @@ export default class SendErrorReportDialog extends DialogAbstract {
   get #errorMessagePanelContents(): string {
     if (this.#responseContents) {
       try {
-        return `${this.#lastErrorMessage}\n\n${JSON.parse(this.#responseContents)?.nextQuickInfo?.join('\n\n')}`;
+        const loggedErrors = JSON.parse(this.#responseContents)?.nextQuickInfo?.join('\n\n');
+        return `${this.#lastErrorMessage}\n\n${loggedErrors}`;
       } catch {
         // Sometimes we can get a response from the server that is not a JSON. In that case:
         // Do nothing

--- a/_dev/tests/dialogs/SendErrorReportDialog.test.ts
+++ b/_dev/tests/dialogs/SendErrorReportDialog.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+import SendErrorReportDialog from '../../src/ts/appUI/dialogs/SendErrorReportDialog';
+import { logStore } from '../../src/ts/appUI/store/LogStore';
+import { FeedbackFields } from '../../src/ts/appUI/types/sentryApi';
+
+// Mock ScriptHandler to prevent side effects
+jest.mock('../../src/ts/appUI/routing/ScriptHandler', () => {
+  return jest.fn().mockImplementation(() => ({
+    loadScript: jest.fn()
+  }));
+});
+
+// Mock the logStore
+jest.mock('../../src/ts/appUI/store/LogStore', () => ({
+  logStore: {
+    getErrors: jest.fn(),
+    getLogs: jest.fn(),
+    getWarnings: jest.fn()
+  }
+}));
+
+// Mock the sentryApi
+jest.mock('../../src/ts/appUI/api/sentryApi', () => ({
+  sendUserFeedback: jest.fn()
+}));
+
+describe('SendErrorReportDialog', () => {
+  let dialog: SendErrorReportDialog;
+
+  const lastErrorMessage =
+    'HTTP request failed. Route update-page-version-choice - Type: ERR_BAD_RESPONSE - HTTP Code 500';
+
+  const initTemplateAndDialogWithResponse = (response: string) => {
+    document.body.innerHTML = `
+      <html>
+        <body>
+          <form id="form-error-feedback">
+            <textarea id="errorMessage"></textarea>
+            <input name="${FeedbackFields.EMAIL}" value="john.doe@example.com" />
+            <textarea name="${FeedbackFields.COMMENTS}">This is a test comment.</textarea>
+          </form>
+          <div id="log-additional-contents">${response}</div>
+        </body>
+      </html>
+    `;
+
+    (logStore.getErrors as jest.Mock).mockReturnValue([{ message: lastErrorMessage }]);
+
+    dialog = new SendErrorReportDialog();
+    dialog.mount();
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should display the error returned in the JSON', () => {
+    const responseContent = {
+      nextQuickInfo: [
+        'CRITICAL - /var/www/html/modules/autoupgrade/classes/Services/DistributionApiService.php line 70 - PrestaShop\\Module\\AutoUpgrade\\Exceptions\\DistributionApiException: Error when retrieving data from Distribution API'
+      ],
+      error: true,
+      next: 'error'
+    };
+    initTemplateAndDialogWithResponse(JSON.stringify(responseContent));
+
+    const errorMessageArea: HTMLTextAreaElement | null = document.querySelector('#errorMessage');
+    expect(errorMessageArea).not.toBeNull();
+    const expectedValue = `HTTP request failed. Route update-page-version-choice - Type: ERR_BAD_RESPONSE - HTTP Code 500
+
+CRITICAL - /var/www/html/modules/autoupgrade/classes/Services/DistributionApiService.php line 70 - PrestaShop\\Module\\AutoUpgrade\\Exceptions\\DistributionApiException: Error when retrieving data from Distribution API`;
+    expect(errorMessageArea?.value).toBe(expectedValue);
+  });
+
+  it('should display several errors returned in the JSON', () => {
+    const responseContent = {
+      nextQuickInfo: [
+        'WARNING - /var/www/html/modules/autoupgrade/classes/Services/DistributionApiService.php line 67 - file_get_contents(): https:// wrapper is disabled in the server configuration by allow_url_fopen=0',
+        'WARNING - /var/www/html/modules/autoupgrade/classes/Services/DistributionApiService.php line 67 - file_get_contents(https://api.prestashop-project.org/prestashop): Failed to open stream: no suitable wrapper could be found',
+        'CRITICAL - /var/www/html/modules/autoupgrade/classes/Services/DistributionApiService.php line 70 - PrestaShop\\Module\\AutoUpgrade\\Exceptions\\DistributionApiException: Error when retrieving data from Distribution API'
+      ],
+      error: true,
+      next: 'error'
+    };
+    initTemplateAndDialogWithResponse(JSON.stringify(responseContent));
+
+    const errorMessageArea: HTMLTextAreaElement | null = document.querySelector('#errorMessage');
+    expect(errorMessageArea).not.toBeNull();
+    const expectedValue = `HTTP request failed. Route update-page-version-choice - Type: ERR_BAD_RESPONSE - HTTP Code 500
+
+WARNING - /var/www/html/modules/autoupgrade/classes/Services/DistributionApiService.php line 67 - file_get_contents(): https:// wrapper is disabled in the server configuration by allow_url_fopen=0
+
+WARNING - /var/www/html/modules/autoupgrade/classes/Services/DistributionApiService.php line 67 - file_get_contents(https://api.prestashop-project.org/prestashop): Failed to open stream: no suitable wrapper could be found
+
+CRITICAL - /var/www/html/modules/autoupgrade/classes/Services/DistributionApiService.php line 70 - PrestaShop\\Module\\AutoUpgrade\\Exceptions\\DistributionApiException: Error when retrieving data from Distribution API`;
+    expect(errorMessageArea?.value).toBe(expectedValue);
+  });
+
+  it('should only display the summary if there is no JSON to parse', () => {
+    const responseContent =
+      'Oops, something went wrong\n\nTry to refresh this page or feel free to contact us if the problem persists.';
+    initTemplateAndDialogWithResponse(responseContent);
+
+    const errorMessageArea: HTMLTextAreaElement | null = document.querySelector('#errorMessage');
+    expect(errorMessageArea).not.toBeNull();
+    const expectedValue =
+      'HTTP request failed. Route update-page-version-choice - Type: ERR_BAD_RESPONSE - HTTP Code 500';
+    expect(errorMessageArea?.value).toBe(expectedValue);
+  });
+});

--- a/views/templates/dialogs/dialog-error-report.html.twig
+++ b/views/templates/dialogs/dialog-error-report.html.twig
@@ -50,7 +50,7 @@
         id="errorMessage"
         name="error"
         placeholder=""
-        rows="3"
+        rows="6"
       ></textarea>
     </div>
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Display the technical details of an issue that occurs on the module, when posible on the error report modal.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/autoupgrade/issues/1555
| Sponsor company   | @PrestaShopCorp
| How to test?      | Modify your PHP config to add this key: `allow_url_fopen=0`, then start the update configuration process. You'll get an error and you will be able to see the details.

<img width="1054" height="794" alt="Capture d’écran du 2026-01-16 17-22-20" src="https://github.com/user-attachments/assets/6c4044eb-316d-4644-a57c-5c3e795f8197" />
