### PR TITLE
Let the file_get_contents method throw warnings about the issues they encountered

### DIFF
--- a/classes/Services/DistributionApiService.php
+++ b/classes/Services/DistributionApiService.php
@@ -64,7 +64,7 @@ class DistributionApiService
      */
     public function getApiEndpoint(string $endPoint)
     {
-        $response = @file_get_contents(self::API_URL . '/' . $endPoint);
+        $response = file_get_contents(self::API_URL . '/' . $endPoint);
 
         if (!$response) {
             throw new DistributionApiException($this->translator->trans('Error when retrieving data from Distribution API'), DistributionApiException::API_NOT_CALLABLE_CODE);

--- a/classes/Services/MarketplaceService.php
+++ b/classes/Services/MarketplaceService.php
@@ -45,7 +45,7 @@ class MarketplaceService
      */
     public function getModuleDetail(string $module)
     {
-        $response = @file_get_contents(self::ADDONS_API_URL . '/v2/products/' . $module);
+        $response = file_get_contents(self::ADDONS_API_URL . '/v2/products/' . $module);
 
         if (!$response) {
             throw new MarketplaceApiException($this->translator->trans('Error when retrieving data from Distribution API'), MarketplaceApiException::API_NOT_CALLABLE_CODE);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Some issues may be occurring while the project is running, but the root cause is not seen because of a silencing `@` symbol before the method call.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/autoupgrade/issues/1562
| Sponsor company   | @PrestaShopCorp
| How to test?      | Modify your PHP config to add this key: allow_url_fopen=0, then start the update configuration process. You'll see the warning appearing now.

NOTE: When https://github.com/PrestaShop/autoupgrade/pull/1600 will be merged, the warning will be visible in the error report modal to make self debugging easier.