### PR TITLE
Allow copy of errors in report modal

### DIFF
--- a/_dev/src/scss/appUI/components/_button-copy.scss
+++ b/_dev/src/scss/appUI/components/_button-copy.scss
@@ -16,22 +16,45 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */
-// Global
-@use "typography";
+@use "../../variables" as *;
 
-// Specific
-@use "alert";
-@use "button";
-@use "button-copy";
-@use "check-requirements";
-@use "content";
-@use "dialog";
-@use "form";
-@use "local-archive";
-@use "logs";
-@use "privacy";
-@use "progress";
-@use "radio-card";
-@use "scrollable-list";
-@use "skeletons";
-@use "stepper";
+$e: ".copy-wrapper";
+
+#{$ua-id} {
+  #{$e} {
+    position: relative;
+
+    pre {
+      --#{$ua-prefix}contents-height: calc(5lh + (6 * 0.5rem));
+      max-height: var(--#{$ua-prefix}contents-height);
+      word-wrap: break-word;
+      white-space: pre-wrap;
+    }
+
+    &:hover {
+      .copy-button {
+        visibility: visible;
+      }
+    }
+
+    .copy-button {
+      position: absolute;
+      right: 0;
+      visibility: hidden;
+
+      .copied {
+        display: none;
+      }
+
+      &--copied {
+        .copy {
+          display: none;
+        }
+
+        .copied {
+          display: inline;
+        }
+      }
+    }
+  }
+}

--- a/_dev/src/scss/appUI/components/_button-copy.scss
+++ b/_dev/src/scss/appUI/components/_button-copy.scss
@@ -39,7 +39,11 @@ $e: ".copy-wrapper";
 
     .copy-button {
       position: absolute;
-      right: 0;
+      top: 2px;
+      right: 2px;
+      padding: 8px 10px;
+      background-color: rgb(245 245 245 / 0.5);
+      backdrop-filter: blur(2px);
       visibility: hidden;
 
       .copied {
@@ -53,6 +57,7 @@ $e: ".copy-wrapper";
 
         .copied {
           display: inline;
+          color: var(--#{$ua-prefix}green-500);
         }
       }
     }

--- a/_dev/src/scss/appUI/components/_index.scss
+++ b/_dev/src/scss/appUI/components/_index.scss
@@ -22,7 +22,7 @@
 // Specific
 @use "alert";
 @use "button";
-@use "button-copy";
+@use "wrapper-copy";
 @use "check-requirements";
 @use "content";
 @use "dialog";

--- a/_dev/src/scss/appUI/components/_wrapper-copy.scss
+++ b/_dev/src/scss/appUI/components/_wrapper-copy.scss
@@ -18,26 +18,26 @@
  */
 @use "../../variables" as *;
 
-$e: ".copy-wrapper";
+$e: ".wrapper-copy";
 
 #{$ua-id} {
   #{$e} {
     position: relative;
 
-    pre {
+    &:hover {
+      #{$e}__button {
+        visibility: visible;
+      }
+    }
+
+    &__content {
       --#{$ua-prefix}contents-height: calc(5lh + (6 * 0.5rem));
       max-height: var(--#{$ua-prefix}contents-height);
       word-wrap: break-word;
       white-space: pre-wrap;
     }
 
-    &:hover {
-      .copy-button {
-        visibility: visible;
-      }
-    }
-
-    .copy-button {
+    &__button {
       position: absolute;
       top: 2px;
       right: 2px;

--- a/_dev/src/scss/appUI/components/_wrapper-copy.scss
+++ b/_dev/src/scss/appUI/components/_wrapper-copy.scss
@@ -30,20 +30,31 @@ $e: ".wrapper-copy";
       }
     }
 
-    &__content {
+    &__pre {
       --#{$ua-prefix}contents-height: calc(5lh + (6 * 0.5rem));
       max-height: var(--#{$ua-prefix}contents-height);
-      word-wrap: break-word;
-      white-space: pre-wrap;
+      padding-block-start: 0;
+      white-space: inherit;
+    }
+
+    &__button-wrapper {
+      position: sticky;
+      top: 0.125rem;
+      display: flex;
+      align-items: flex-start;
+      justify-content: flex-end;
+      height: 1rem;
+    }
+
+    &__content {
+      display: block;
     }
 
     &__button {
-      position: absolute;
-      top: 0.125rem;
-      right: 0.125rem;
-      padding: 0.5rem 0.625px;
+      padding: 0.5rem 0.625rem;
       background-color: rgb(245 245 245 / 0.5);
       backdrop-filter: blur(0.125rem);
+      border-radius: 0.25rem;
       visibility: hidden;
 
       .copied {

--- a/_dev/src/scss/appUI/components/_wrapper-copy.scss
+++ b/_dev/src/scss/appUI/components/_wrapper-copy.scss
@@ -39,11 +39,11 @@ $e: ".wrapper-copy";
 
     &__button {
       position: absolute;
-      top: 2px;
-      right: 2px;
-      padding: 8px 10px;
+      top: 0.125rem;
+      right: 0.125rem;
+      padding: 0.5rem 0.625px;
       background-color: rgb(245 245 245 / 0.5);
-      backdrop-filter: blur(2px);
+      backdrop-filter: blur(0.125rem);
       visibility: hidden;
 
       .copied {

--- a/_dev/src/ts/appUI/components/WrapperCopy.ts
+++ b/_dev/src/ts/appUI/components/WrapperCopy.ts
@@ -38,6 +38,7 @@ export default class WrapperCopy implements DomLifecycle {
     }
 
     target.classList.add(this.#elementClassWhenCopied);
+    target.blur();
     setTimeout(() => {
       target.classList.remove(this.#elementClassWhenCopied);
     }, 1500);

--- a/_dev/src/ts/appUI/components/WrapperCopy.ts
+++ b/_dev/src/ts/appUI/components/WrapperCopy.ts
@@ -19,8 +19,8 @@
 import DomLifecycle from '../../types/DomLifecycle';
 
 export default class WrapperCopy implements DomLifecycle {
-  readonly #elementClassToWatch = 'copy-button';
-  readonly #elementClassWhenCopied = 'copy-button--copied';
+  readonly #elementClassToWatch = 'wrapper-copy__button';
+  readonly #elementClassWhenCopied = 'wrapper-copy__button--copied';
   readonly #dataAttribute: string = 'targetId';
   public mount = () => {
     document.addEventListener('click', this.#onClick);

--- a/_dev/src/ts/appUI/components/WrapperCopy.ts
+++ b/_dev/src/ts/appUI/components/WrapperCopy.ts
@@ -23,14 +23,14 @@ export default class WrapperCopy implements DomLifecycle {
   readonly #elementClassWhenCopied = 'copy-button--copied';
   readonly #dataAttribute: string = 'targetId';
   public mount = () => {
-    document.addEventListener('click', (ev) => this.#onClick(ev));
+    document.addEventListener('click', this.#onClick);
   };
 
   public beforeDestroy = () => {
-    document.removeEventListener('click', (ev) => this.#onClick(ev));
+    document.removeEventListener('click', this.#onClick);
   };
 
-  async #onClick(ev: Event): Promise<void> {
+  readonly #onClick = async (ev: Event): Promise<void> => {
     const target = this.#getEventTargetIfCopyButton(ev);
 
     if (!target) {
@@ -45,10 +45,13 @@ export default class WrapperCopy implements DomLifecycle {
 
     const contentsTarget = document.getElementById(this.#getTargetIdOfCopyButton(target));
 
-    if (contentsTarget) {
-      await navigator.clipboard.writeText((contentsTarget as HTMLPreElement).innerText);
+    if (!contentsTarget) {
+      throw new Error(
+        `Target from ID #${this.#getTargetIdOfCopyButton(target)} cannot be found in the DOM.`
+      );
     }
-  }
+    await navigator.clipboard.writeText((contentsTarget as HTMLPreElement).innerText);
+  };
 
   #getEventTargetIfCopyButton(ev: Event): HTMLElement | null {
     const target = ev.target ? (ev.target as HTMLElement) : null;

--- a/_dev/src/ts/appUI/components/WrapperCopy.ts
+++ b/_dev/src/ts/appUI/components/WrapperCopy.ts
@@ -1,0 +1,73 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+import DomLifecycle from '../../types/DomLifecycle';
+
+export default class WrapperCopy implements DomLifecycle {
+  readonly #elementClassToWatch = 'copy-button';
+  readonly #elementClassWhenCopied = 'copy-button--copied';
+  readonly #dataAttribute: string = 'targetId';
+  public mount = () => {
+    document.addEventListener('click', (ev) => this.#onClick(ev));
+  };
+
+  public beforeDestroy = () => {
+    document.removeEventListener('click', (ev) => this.#onClick(ev));
+  };
+
+  async #onClick(ev: Event): Promise<void> {
+    const target = this.#getEventTargetIfCopyButton(ev);
+
+    if (!target) {
+      return;
+    }
+
+    target.classList.add(this.#elementClassWhenCopied);
+    setTimeout(() => {
+      target.classList.remove(this.#elementClassWhenCopied);
+    }, 1500);
+
+    const contentsTarget = document.getElementById(this.#getTargetIdOfCopyButton(target));
+
+    if (contentsTarget) {
+      await navigator.clipboard.writeText((contentsTarget as HTMLPreElement).innerText);
+    }
+  }
+
+  #getEventTargetIfCopyButton(ev: Event): HTMLElement | null {
+    const target = ev.target ? (ev.target as HTMLElement) : null;
+
+    if (!target) {
+      return null;
+    }
+
+    if (target.classList.contains(this.#elementClassToWatch)) {
+      return target;
+    }
+
+    return target.closest(`.${this.#elementClassToWatch}`);
+  }
+
+  #getTargetIdOfCopyButton(element: HTMLElement): string {
+    if (!element.dataset[this.#dataAttribute]) {
+      throw new Error(`Missing data ${this.#dataAttribute} from dataset.`);
+    }
+
+    return element.dataset[this.#dataAttribute]!;
+  }
+}

--- a/_dev/src/ts/appUI/dialogs/SendErrorReportDialog.ts
+++ b/_dev/src/ts/appUI/dialogs/SendErrorReportDialog.ts
@@ -22,15 +22,28 @@ import { logStore } from '../store/LogStore';
 import { formatLogsMessages } from '../utils/logsUtils';
 import DialogAbstract from './DialogAbstract';
 import ErrorPageBuilder from '../components/ErrorPageBuilder';
+import WrapperCopy from '../components/WrapperCopy';
 
 export default class SendErrorReportDialog extends DialogAbstract {
   protected readonly formId = 'form-error-feedback';
+  #wrapperCopy: WrapperCopy;
+
+  constructor() {
+    super();
+    this.#wrapperCopy = new WrapperCopy();
+  }
 
   public mount = (): void => {
     this.form.addEventListener('submit', this.onSubmit);
 
     const errorMessageArea: HTMLTextAreaElement = this.form.querySelector('#errorMessage')!;
-    errorMessageArea.value = this.#errorMessagePanelContents;
+    errorMessageArea.innerText = this.#errorMessagePanelContents;
+
+    this.#wrapperCopy.mount();
+  };
+
+  public beforeDestroy = (): void => {
+    this.#wrapperCopy.beforeDestroy();
   };
 
   get form(): HTMLFormElement {

--- a/_dev/tests/components/WrapperCopy.test.ts
+++ b/_dev/tests/components/WrapperCopy.test.ts
@@ -29,7 +29,7 @@ describe('WrapperCopy', () => {
 
   const createCopyButton = (targetId?: string): HTMLButtonElement => {
     const button = document.createElement('button');
-    button.className = 'copy-button';
+    button.className = 'wrapper-copy__button';
 
     if (targetId) {
       button.dataset.targetId = targetId;
@@ -111,7 +111,7 @@ describe('WrapperCopy', () => {
       button.click();
       await Promise.resolve();
 
-      expect(button.classList.contains('copy-button--copied')).toBe(true);
+      expect(button.classList.contains('wrapper-copy__button--copied')).toBe(true);
       expect(blurSpy).toHaveBeenCalled();
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith('hello world');
     });
@@ -123,11 +123,11 @@ describe('WrapperCopy', () => {
       button.click();
       await Promise.resolve();
 
-      expect(button.classList.contains('copy-button--copied')).toBe(true);
+      expect(button.classList.contains('wrapper-copy__button--copied')).toBe(true);
 
       jest.advanceTimersByTime(1500);
 
-      expect(button.classList.contains('copy-button--copied')).toBe(false);
+      expect(button.classList.contains('wrapper-copy__button--copied')).toBe(false);
     });
 
     it('handles clicks on child elements via closest()', async () => {

--- a/_dev/tests/components/WrapperCopy.test.ts
+++ b/_dev/tests/components/WrapperCopy.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+import WrapperCopy from '../../src/ts/appUI/components/WrapperCopy';
+
+describe('WrapperCopy', () => {
+  const mockClipboard = () => {
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: jest.fn().mockResolvedValue(undefined)
+      }
+    });
+  };
+
+  const createCopyButton = (targetId?: string): HTMLButtonElement => {
+    const button = document.createElement('button');
+    button.className = 'copy-button';
+
+    if (targetId) {
+      button.dataset.targetId = targetId;
+    }
+
+    document.body.appendChild(button);
+    return button;
+  };
+
+  const createPreWithContents = (id: string, text: string): HTMLElement => {
+    const pre = document.createElement('pre');
+    pre.id = id;
+    pre.innerText = text;
+    document.body.appendChild(pre);
+    return pre;
+  };
+
+  describe('Lifecycle', () => {
+    let wrapper: WrapperCopy;
+
+    beforeEach(() => {
+      wrapper = new WrapperCopy();
+      document.body.innerHTML = '';
+      jest.clearAllMocks();
+    });
+
+    it('attempts to remove click listener on beforeDestroy()', () => {
+      const spy = jest.spyOn(document, 'removeEventListener');
+
+      wrapper.mount();
+      wrapper.beforeDestroy();
+
+      expect(spy).toHaveBeenCalledWith('click', expect.any(Function));
+    });
+
+    it('not reacts to clicks after beforeDestroy()', async () => {
+      mockClipboard();
+      wrapper.mount();
+      wrapper.beforeDestroy();
+
+      createPreWithContents('foo', 'copied text');
+      const button = createCopyButton('foo');
+
+      button.click();
+
+      await Promise.resolve();
+
+      expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Click handling', () => {
+    let wrapper: WrapperCopy;
+    jest.useFakeTimers();
+
+    beforeEach(() => {
+      wrapper = new WrapperCopy();
+      document.body.innerHTML = '';
+      jest.clearAllMocks();
+      mockClipboard();
+      wrapper.mount();
+    });
+
+    it('does nothing when clicking outside a copy button', () => {
+      const div = document.createElement('div');
+      document.body.appendChild(div);
+
+      div.click();
+
+      expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+    });
+
+    it('copies text when clicking directly on a copy button', async () => {
+      createPreWithContents('foo', 'hello world');
+      const button = createCopyButton('foo');
+
+      const blurSpy = jest.spyOn(button, 'blur');
+
+      button.click();
+      await Promise.resolve();
+
+      expect(button.classList.contains('copy-button--copied')).toBe(true);
+      expect(blurSpy).toHaveBeenCalled();
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('hello world');
+    });
+
+    it('removes copied class after 1500ms', async () => {
+      createPreWithContents('foo', 'hello');
+      const button = createCopyButton('foo');
+
+      button.click();
+      await Promise.resolve();
+
+      expect(button.classList.contains('copy-button--copied')).toBe(true);
+
+      jest.advanceTimersByTime(1500);
+
+      expect(button.classList.contains('copy-button--copied')).toBe(false);
+    });
+
+    it('handles clicks on child elements via closest()', async () => {
+      createPreWithContents('foo', 'nested copy');
+      const button = createCopyButton('foo');
+
+      const span = document.createElement('span');
+      button.appendChild(span);
+
+      span.click();
+      await Promise.resolve();
+
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('nested copy');
+    });
+  });
+});

--- a/_dev/tests/dialogs/SendErrorReportDialog.test.ts
+++ b/_dev/tests/dialogs/SendErrorReportDialog.test.ts
@@ -81,12 +81,12 @@ describe('SendErrorReportDialog', () => {
     };
     initTemplateAndDialogWithResponse(JSON.stringify(responseContent));
 
-    const errorMessageArea: HTMLTextAreaElement | null = document.querySelector('#errorMessage');
+    const errorMessageArea: HTMLPreElement | null = document.querySelector('#errorMessage');
     expect(errorMessageArea).not.toBeNull();
     const expectedValue = `HTTP request failed. Route update-page-version-choice - Type: ERR_BAD_RESPONSE - HTTP Code 500
 
 CRITICAL - /var/www/html/modules/autoupgrade/classes/Services/DistributionApiService.php line 70 - PrestaShop\\Module\\AutoUpgrade\\Exceptions\\DistributionApiException: Error when retrieving data from Distribution API`;
-    expect(errorMessageArea?.value).toBe(expectedValue);
+    expect(errorMessageArea?.innerText).toBe(expectedValue);
   });
 
   it('should display several errors returned in the JSON', () => {
@@ -101,7 +101,7 @@ CRITICAL - /var/www/html/modules/autoupgrade/classes/Services/DistributionApiSer
     };
     initTemplateAndDialogWithResponse(JSON.stringify(responseContent));
 
-    const errorMessageArea: HTMLTextAreaElement | null = document.querySelector('#errorMessage');
+    const errorMessageArea: HTMLPreElement | null = document.querySelector('#errorMessage');
     expect(errorMessageArea).not.toBeNull();
     const expectedValue = `HTTP request failed. Route update-page-version-choice - Type: ERR_BAD_RESPONSE - HTTP Code 500
 
@@ -110,7 +110,7 @@ WARNING - /var/www/html/modules/autoupgrade/classes/Services/DistributionApiServ
 WARNING - /var/www/html/modules/autoupgrade/classes/Services/DistributionApiService.php line 67 - file_get_contents(https://api.prestashop-project.org/prestashop): Failed to open stream: no suitable wrapper could be found
 
 CRITICAL - /var/www/html/modules/autoupgrade/classes/Services/DistributionApiService.php line 70 - PrestaShop\\Module\\AutoUpgrade\\Exceptions\\DistributionApiException: Error when retrieving data from Distribution API`;
-    expect(errorMessageArea?.value).toBe(expectedValue);
+    expect(errorMessageArea?.innerText).toBe(expectedValue);
   });
 
   it('should only display the summary if there is no JSON to parse', () => {
@@ -118,10 +118,10 @@ CRITICAL - /var/www/html/modules/autoupgrade/classes/Services/DistributionApiSer
       'Oops, something went wrong\n\nTry to refresh this page or feel free to contact us if the problem persists.';
     initTemplateAndDialogWithResponse(responseContent);
 
-    const errorMessageArea: HTMLTextAreaElement | null = document.querySelector('#errorMessage');
+    const errorMessageArea: HTMLPreElement | null = document.querySelector('#errorMessage');
     expect(errorMessageArea).not.toBeNull();
     const expectedValue =
       'HTTP request failed. Route update-page-version-choice - Type: ERR_BAD_RESPONSE - HTTP Code 500';
-    expect(errorMessageArea?.value).toBe(expectedValue);
+    expect(errorMessageArea?.innerText).toBe(expectedValue);
   });
 });

--- a/views/templates/components/wrapper-copy.html.twig
+++ b/views/templates/components/wrapper-copy.html.twig
@@ -16,10 +16,10 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  *#}
-<div class="copy-wrapper">
-  <button class="btn btn-link copy-button" type="button" data-target-id="{{ id }}">
+<div class="wrapper-copy">
+  <button class="btn btn-link wrapper-copy__button" type="button" data-target-id="{{ id }}">
     <span class="copy"><i class="material-icons">content_copy</i></span>
     <span class="copied"><i class="material-icons">check</i></span>
   </button>
-  <pre id="{{ id }}"></pre>
+  <pre class="wrapper-copy__content" id="{{ id }}"></pre>
 </div>

--- a/views/templates/components/wrapper-copy.html.twig
+++ b/views/templates/components/wrapper-copy.html.twig
@@ -17,9 +17,14 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  *#}
 <div class="wrapper-copy">
-  <button class="btn btn-link wrapper-copy__button" type="button" data-target-id="{{ id }}">
-    <span class="copy"><i class="material-icons">content_copy</i></span>
-    <span class="copied"><i class="material-icons">check</i></span>
-  </button>
-  <pre class="wrapper-copy__content" id="{{ id }}"></pre>
+  <pre class="wrapper-copy__pre">
+    <div class="wrapper-copy__button-wrapper">
+      <button class="btn btn-link wrapper-copy__button" type="button" data-target-id="{{ id }}">
+        <span class="copy"><i class="material-icons">content_copy</i></span>
+        <span class="copied"><i class="material-icons">check</i></span>
+      </button>
+    </div>
+
+    <code class="wrapper-copy__content" id="{{ id }}"></code>
+  </pre>
 </div>

--- a/views/templates/components/wrapper-copy.html.twig
+++ b/views/templates/components/wrapper-copy.html.twig
@@ -1,4 +1,4 @@
-/**
+{#**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -15,23 +15,11 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
- */
-// Global
-@use "typography";
-
-// Specific
-@use "alert";
-@use "button";
-@use "button-copy";
-@use "check-requirements";
-@use "content";
-@use "dialog";
-@use "form";
-@use "local-archive";
-@use "logs";
-@use "privacy";
-@use "progress";
-@use "radio-card";
-@use "scrollable-list";
-@use "skeletons";
-@use "stepper";
+ *#}
+<div class="copy-wrapper">
+  <button class="btn btn-link copy-button" type="button" data-target-id="{{ id }}">
+    <span class="copy">{{ 'Copy'|trans({}) }}</span>
+    <span class="copied">{{ 'Copied!'|trans({}) }}</span>
+  </button>
+  <pre id="{{ id }}"></pre>
+</div>

--- a/views/templates/components/wrapper-copy.html.twig
+++ b/views/templates/components/wrapper-copy.html.twig
@@ -18,8 +18,8 @@
  *#}
 <div class="copy-wrapper">
   <button class="btn btn-link copy-button" type="button" data-target-id="{{ id }}">
-    <span class="copy">{{ 'Copy'|trans({}) }}</span>
-    <span class="copied">{{ 'Copied!'|trans({}) }}</span>
+    <span class="copy"><i class="material-icons">content_copy</i></span>
+    <span class="copied"><i class="material-icons">check</i></span>
   </button>
   <pre id="{{ id }}"></pre>
 </div>

--- a/views/templates/dialogs/dialog-error-report.html.twig
+++ b/views/templates/dialogs/dialog-error-report.html.twig
@@ -44,14 +44,7 @@
       <label for="errorMessage">
         {{ 'Error details'|trans({}) }}
       </label>
-      <textarea
-        disabled
-        class="form-control"
-        id="errorMessage"
-        name="error"
-        placeholder=""
-        rows="6"
-      ></textarea>
+      {% include "@ModuleAutoUpgrade/components/wrapper-copy.html.twig" with {'id': 'errorMessage'} %}
     </div>
 
     <div class="form-group">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | In the error report modal, this PR adds a button to copy the contents of the panel. This helps to report the issues on other platforms.
| Type?             | new feature
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Trigger any error to get access to the modal "Error report". When hovering the error details, a button "Copy" will now appear. Click on it to immediately get he contents in the device clipboard.
