### PR TITLE
Fix loading of container on very old versions of PS

### DIFF
--- a/autoupgrade.php
+++ b/autoupgrade.php
@@ -131,8 +131,10 @@ class Autoupgrade extends Module
             $ajaxTab->delete();
         }
 
-        // Remove the 'autoupgrade' admin directory except backups
-        $this->getUpgradeContainer()->getFilesystemAdapter()->clearDirectory(_PS_ADMIN_DIR_ . DIRECTORY_SEPARATOR . 'autoupgrade', ['backup']);
+        if ($this->initAutoloaderIfCompliant()) {
+            // Remove the 'autoupgrade' admin directory except backups
+            $this->getUpgradeContainer()->getFilesystemAdapter()->clearDirectory(_PS_ADMIN_DIR_ . DIRECTORY_SEPARATOR . 'autoupgrade', ['backup']);
+        }
 
         return parent::uninstall();
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | While manipulating the module before running UI tests, it appeared we have an issue when uninstalling it. 
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Uninstalling the module on PS 1.7.2.1 works.

## Reported error
<img width="1024" height="1327" alt="Capture d’écran du 2026-01-28 14-31-28" src="https://github.com/user-attachments/assets/9739b3fd-16d8-4e5e-85a0-289e4f074154" />

