### PR TITLE
Remove non native module deactivation option for v9

### DIFF
--- a/classes/Commands/UpdateCommand.php
+++ b/classes/Commands/UpdateCommand.php
@@ -59,7 +59,7 @@ class UpdateCommand extends AbstractCommand
             ->addOption('channel', null, InputOption::VALUE_REQUIRED, "Selects what update to run ('" . UpgradeConfiguration::CHANNEL_LOCAL . "' / '" . UpgradeConfiguration::CHANNEL_ONLINE_RECOMMENDED . "' / '" . UpgradeConfiguration::CHANNEL_ONLINE . "')")
             ->addOption('zip', null, InputOption::VALUE_REQUIRED, 'Sets the archive zip file for a local update')
             ->addOption('xml', null, InputOption::VALUE_REQUIRED, 'Sets the archive xml file for a local update')
-            ->addOption('disable-non-native-modules', null, InputOption::VALUE_REQUIRED, 'Disable all modules installed after the store creation (1 for yes, 0 for no)')
+            ->addOption('disable-non-native-modules', null, InputOption::VALUE_REQUIRED, 'Disable all modules installed after the store creation (1 for yes, 0 for no). Ignored for destination versions >= 9.0.0')
             ->addOption('regenerate-email-templates', null, InputOption::VALUE_REQUIRED, "Regenerate email templates. If you've customized email templates, your changes will be lost if you activate this option (1 for yes, 0 for no)")
             ->addOption('disable-all-overrides', null, InputOption::VALUE_REQUIRED, 'Overriding is a way to replace business behaviors (class files and controller files) to target only one method or as many as you need. This option disables all classes & controllers overrides, allowing you to avoid conflicts during and after updates (1 for yes, 0 for no)')
             ->addOption('config-file-path', null, InputOption::VALUE_REQUIRED, 'Configuration file location for update.')

--- a/classes/Commands/UpdateCommand.php
+++ b/classes/Commands/UpdateCommand.php
@@ -59,7 +59,7 @@ class UpdateCommand extends AbstractCommand
             ->addOption('channel', null, InputOption::VALUE_REQUIRED, "Selects what update to run ('" . UpgradeConfiguration::CHANNEL_LOCAL . "' / '" . UpgradeConfiguration::CHANNEL_ONLINE_RECOMMENDED . "' / '" . UpgradeConfiguration::CHANNEL_ONLINE . "')")
             ->addOption('zip', null, InputOption::VALUE_REQUIRED, 'Sets the archive zip file for a local update')
             ->addOption('xml', null, InputOption::VALUE_REQUIRED, 'Sets the archive xml file for a local update')
-            ->addOption('disable-non-native-modules', null, InputOption::VALUE_REQUIRED, 'Disable all modules installed after the store creation (1 for yes, 0 for no). Ignored for destination versions >= 9.0.0')
+            ->addOption('disable-non-native-modules', null, InputOption::VALUE_REQUIRED, 'Disable all modules installed after the store creation (1 for yes, 0 for no). Ignored for PrestaShop v9 and above.')
             ->addOption('regenerate-email-templates', null, InputOption::VALUE_REQUIRED, "Regenerate email templates. If you've customized email templates, your changes will be lost if you activate this option (1 for yes, 0 for no)")
             ->addOption('disable-all-overrides', null, InputOption::VALUE_REQUIRED, 'Overriding is a way to replace business behaviors (class files and controller files) to target only one method or as many as you need. This option disables all classes & controllers overrides, allowing you to avoid conflicts during and after updates (1 for yes, 0 for no)')
             ->addOption('config-file-path', null, InputOption::VALUE_REQUIRED, 'Configuration file location for update.')

--- a/classes/Task/Update/UpdateDatabase.php
+++ b/classes/Task/Update/UpdateDatabase.php
@@ -129,6 +129,7 @@ class UpdateDatabase extends AbstractTask
             $this->container->getCompletionCalculator()->getBasePercentageOfTask(self::class)
         );
 
+        /** @see https://github.com/PrestaShop/PrestaShop/pull/35313 */
         if (version_compare('9.0.0', $this->container->getUpdateState()->getDestinationVersion(), '>')) {
             if ($this->container->getUpdateConfiguration()->shouldDeactivateCustomModules()) {
                 $this->logger->info($this->container->getTranslator()->trans('Disabling all non native modules'));

--- a/classes/Task/Update/UpdateDatabase.php
+++ b/classes/Task/Update/UpdateDatabase.php
@@ -138,7 +138,6 @@ class UpdateDatabase extends AbstractTask
             }
         }
 
-
         $this->container->getQuarantineZone()->addAll();
 
         $this->getCoreUpgrader()->writeNewSettings();

--- a/classes/Task/Update/UpdateDatabase.php
+++ b/classes/Task/Update/UpdateDatabase.php
@@ -129,7 +129,7 @@ class UpdateDatabase extends AbstractTask
             $this->container->getCompletionCalculator()->getBasePercentageOfTask(self::class)
         );
 
-        /** @see https://github.com/PrestaShop/PrestaShop/pull/35313 */
+        /* @see https://github.com/PrestaShop/PrestaShop/pull/35313 */
         if (version_compare('9.0.0', $this->container->getUpdateState()->getDestinationVersion(), '>')) {
             if ($this->container->getUpdateConfiguration()->shouldDeactivateCustomModules()) {
                 $this->logger->info($this->container->getTranslator()->trans('Disabling all non native modules'));

--- a/classes/Task/Update/UpdateDatabase.php
+++ b/classes/Task/Update/UpdateDatabase.php
@@ -129,12 +129,15 @@ class UpdateDatabase extends AbstractTask
             $this->container->getCompletionCalculator()->getBasePercentageOfTask(self::class)
         );
 
-        if ($this->container->getUpdateConfiguration()->shouldDeactivateCustomModules()) {
-            $this->logger->info($this->container->getTranslator()->trans('Disabling all non native modules'));
-            $this->getCoreUpgrader()->disableCustomModules();
-        } else {
-            $this->logger->info($this->container->getTranslator()->trans('Keeping non native modules enabled'));
+        if (version_compare('9.0.0', $this->container->getUpdateState()->getDestinationVersion(), '>')) {
+            if ($this->container->getUpdateConfiguration()->shouldDeactivateCustomModules()) {
+                $this->logger->info($this->container->getTranslator()->trans('Disabling all non native modules'));
+                $this->getCoreUpgrader()->disableCustomModules();
+            } else {
+                $this->logger->info($this->container->getTranslator()->trans('Keeping non native modules enabled'));
+            }
         }
+
 
         $this->container->getQuarantineZone()->addAll();
 

--- a/controllers/admin/self-managed/UpdatePageUpdateOptionsController.php
+++ b/controllers/admin/self-managed/UpdatePageUpdateOptionsController.php
@@ -105,7 +105,7 @@ class UpdatePageUpdateOptionsController extends AbstractPageWithStepController
                 'form_fields' => [
                     'deactive_non_native_modules' => [
                         // Starting from v9.0.0, this field has no effect. Services are now loaded regardless of the module's state, so this setting is no longer relevant.
-                        'enabled' => version_compare('9.0.0', $this->upgradeContainer->getUpgrader()->getDestinationVersion(), '>'),
+                        'visible' => version_compare('9.0.0', $this->upgradeContainer->getUpgrader()->getDestinationVersion(), '>'),
                         'field' => UpgradeConfiguration::PS_AUTOUP_CUSTOM_MOD_DESACT,
                         'value' => $updateConfiguration->shouldDeactivateCustomModules(),
                     ],

--- a/controllers/admin/self-managed/UpdatePageUpdateOptionsController.php
+++ b/controllers/admin/self-managed/UpdatePageUpdateOptionsController.php
@@ -104,6 +104,8 @@ class UpdatePageUpdateOptionsController extends AbstractPageWithStepController
 
                 'form_fields' => [
                     'deactive_non_native_modules' => [
+                        // Starting from v9.0.0, this field has no effect. Services are now loaded regardless of the module's state, so this setting is no longer relevant.
+                        'enabled' => version_compare('9.0.0', $this->upgradeContainer->getUpgrader()->getDestinationVersion(), '>'),
                         'field' => UpgradeConfiguration::PS_AUTOUP_CUSTOM_MOD_DESACT,
                         'value' => $updateConfiguration->shouldDeactivateCustomModules(),
                     ],

--- a/views/templates/steps/update-options.html.twig
+++ b/views/templates/steps/update-options.html.twig
@@ -33,7 +33,7 @@
     id="update-options-page-form"
     name="update-options-page-form"
   >
-    {% if form_fields.deactive_non_native_modules.enabled %}
+    {% if form_fields.deactive_non_native_modules.visible %}
       {% include "@ModuleAutoUpgrade/components/render-switch.html.twig" with {
         id: form_fields.deactive_non_native_modules.field,
         name: form_fields.deactive_non_native_modules.field,

--- a/views/templates/steps/update-options.html.twig
+++ b/views/templates/steps/update-options.html.twig
@@ -25,7 +25,7 @@
 {% endblock %}
 
 {% block content %}
-  <form 
+  <form
     class="update-options-page__field-list"
     action=""
     data-route-to-save="{{ form_route_to_save }}"
@@ -33,14 +33,16 @@
     id="update-options-page-form"
     name="update-options-page-form"
   >
-    {% include "@ModuleAutoUpgrade/components/render-switch.html.twig" with {
-      id: form_fields.deactive_non_native_modules.field,
-      name: form_fields.deactive_non_native_modules.field,
-      title: "Deactivate non-native modules"|trans({}),
-      description: "All the modules installed after creating your store are considered non-native modules. They might be incompatible with the new version of PrestaShop. We recommend deactivating them during the update."|trans({}),
-      value: form_fields.deactive_non_native_modules.value,
-      error_message: errors[form_fields.deactive_non_native_modules.field] is defined ? errors[form_fields.deactive_non_native_modules.field] : null,
-    } %}
+    {% if form_fields.deactive_non_native_modules.enabled %}
+      {% include "@ModuleAutoUpgrade/components/render-switch.html.twig" with {
+        id: form_fields.deactive_non_native_modules.field,
+        name: form_fields.deactive_non_native_modules.field,
+        title: "Deactivate non-native modules"|trans({}),
+        description: "All the modules installed after creating your store are considered non-native modules. They might be incompatible with the new version of PrestaShop. We recommend deactivating them during the update."|trans({}),
+        value: form_fields.deactive_non_native_modules.value,
+        error_message: errors[form_fields.deactive_non_native_modules.field] is defined ? errors[form_fields.deactive_non_native_modules.field] : null,
+      } %}
+    {% endif %}
 
     {% include "@ModuleAutoUpgrade/components/render-switch.html.twig" with {
       id: form_fields.regenerate_email_templates.field,


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Hide the "Deactivate non-native modules" option when running on PrestaShop 9.0 or higher. The behavior of disabled modules has changed in PrestaShop 9 (services are still loaded), rendering this option ineffective for preventing module interference during updates.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | @PrestaShopCorp
| How to test?      | Check internal ticket
