### PR TITLE
Display a link to the GitHub discussions

### DIFF
--- a/_dev/src/scss/appUI/components/_radio-card.scss
+++ b/_dev/src/scss/appUI/components/_radio-card.scss
@@ -85,6 +85,9 @@ $e: ".radio-card";
       #{$e}__check-requirements {
         display: none;
       }
+      #{$e}__message-bottom {
+        display: none;
+      }
     }
 
     &__loader-wrapper {
@@ -181,6 +184,10 @@ $e: ".radio-card";
       color: var(--#{$ua-prefix}radio-card-message-color);
       word-break: break-word;
       word-wrap: break-word;
+    }
+
+    &__message-bottom {
+      margin-top: 0.75rem;
     }
 
     &__release-note {

--- a/classes/DocumentationLinks.php
+++ b/classes/DocumentationLinks.php
@@ -24,69 +24,73 @@ class DocumentationLinks
 {
     public const DEV_DOC_BASE_VERSION = '8';
 
-    /** @return string */
-    public static function getDevDocUrl(string $prestashopVersion = self::DEV_DOC_BASE_VERSION)
+    public static function getDevDocUrl(string $prestashopVersion = self::DEV_DOC_BASE_VERSION): string
     {
         return "https://devdocs.prestashop-project.org/{$prestashopVersion}";
     }
 
-    /** @return string */
-    public static function getDevDocUpToDateUrl(string $prestashopVersion = self::DEV_DOC_BASE_VERSION)
+    public static function getDevDocUpToDateUrl(string $prestashopVersion = self::DEV_DOC_BASE_VERSION): string
     {
         return self::getDevDocUrl($prestashopVersion) . '/basics/keeping-up-to-date';
     }
 
-    /** @return string */
-    public static function getDevDocUpdateAssistantUrl(string $prestashopVersion = self::DEV_DOC_BASE_VERSION)
+    public static function getDevDocUpdateAssistantUrl(string $prestashopVersion = self::DEV_DOC_BASE_VERSION): string
     {
         return self::getDevDocUpToDateUrl($prestashopVersion) . '/update';
     }
 
-    /** @return string */
-    public static function getDevDocUpdateAssistantCliUrl(string $prestashopVersion = self::DEV_DOC_BASE_VERSION)
+    public static function getDevDocUpdateAssistantCliUrl(string $prestashopVersion = self::DEV_DOC_BASE_VERSION): string
     {
         return self::getDevDocUpdateAssistantUrl($prestashopVersion) . '/update-from-the-cli';
     }
 
-    /** @return string */
-    public static function getDevDocUpdateAssistantWebUrl(string $prestashopVersion = self::DEV_DOC_BASE_VERSION)
+    public static function getDevDocUpdateAssistantWebUrl(string $prestashopVersion = self::DEV_DOC_BASE_VERSION): string
     {
         return self::getDevDocUpdateAssistantUrl($prestashopVersion) . '/update-from-the-back-office';
     }
 
-    /** @return string */
-    public static function getDevDocUpdateAssistantPostUpdateUrl(string $prestashopVersion = self::DEV_DOC_BASE_VERSION)
+    public static function getDevDocUpdateAssistantPostUpdateUrl(string $prestashopVersion = self::DEV_DOC_BASE_VERSION): string
     {
         return self::getDevDocUpdateAssistantUrl($prestashopVersion) . '/post-update-checklist';
     }
 
-    /** @return string */
-    public static function getDevDocUpdateAssistantPostRestoreUrl(string $prestashopVersion = self::DEV_DOC_BASE_VERSION)
+    public static function getDevDocUpdateAssistantPostRestoreUrl(string $prestashopVersion = self::DEV_DOC_BASE_VERSION): string
     {
         return self::getDevDocUpdateAssistantUrl($prestashopVersion) . '/post-restore-checklist';
     }
 
-    /** @return string */
-    public static function getPrestashopProjectUrl()
+    public static function getPrestashopProjectUrl(): string
     {
         return 'https://www.prestashop-project.org';
     }
 
-    /** @return string */
-    public static function getPrestashopProjectDataTransparencyUrl()
+    public static function getPrestashopProjectDataTransparencyUrl(): string
     {
         return self::getPrestashopProjectUrl() . '/data-transparency';
     }
 
-    /** @return string */
-    public static function getFindSupportUrl()
+    public static function getFindSupportUrl(): string
     {
         return 'https://www.prestashop-project.org/support/';
     }
 
-    /** @return string */
-    public static function getPrestashopReleasesUrl()
+    public static function getPrestashopReleasesUrl(): string
     {
         return 'https://build.prestashop-project.org/tag/releases/';
+    }
+
+    public static function getRepositoryUrl(): string
+    {
+        return 'https://github.com/PrestaShop/autoupgrade';
+    }
+
+    public static function getDiscussionsAboutKnownIssuesUrl(?string $impactedVersion = null): string
+    {
+        $discussionsQuery = ['is:open'];
+        if ($impactedVersion) {
+            $discussionsQuery[] = 'label:"Impacts: ' . $impactedVersion . '"';
+        }
+
+        return self::getRepositoryUrl() . '/discussions/categories/known-issues?' . http_build_query(['discussions_q' => implode(' ', $discussionsQuery)]);
     }
 }

--- a/controllers/admin/self-managed/UpdatePageVersionChoiceController.php
+++ b/controllers/admin/self-managed/UpdatePageVersionChoiceController.php
@@ -117,6 +117,7 @@ class UpdatePageVersionChoiceController extends AbstractPageWithStepController
         $noLocalArchive = empty($localVersions['zip']) && empty($localVersions['xml']);
         $currentPsVersion = $this->upgradeContainer->getProperty(UpgradeContainer::PS_VERSION);
         $currentMajorVersion = VersionUtils::splitPrestaShopVersion($currentPsVersion)['major'];
+        $currentUpdateAssistantMinorVersion = VersionUtils::splitPrestaShopVersion($this->upgradeContainer->getPrestaShopConfiguration()->getModuleVersion())['minor'];
 
         return array_merge(
             $updateSteps->getStepParams($this::CURRENT_STEP),
@@ -128,6 +129,7 @@ class UpdatePageVersionChoiceController extends AbstractPageWithStepController
                 'assets_base_path' => $this->upgradeContainer->getAssetsEnvironment()->getAssetsBaseUrl($this->request),
                 'current_prestashop_version' => $this->getPsVersion(),
                 'current_php_version' => VersionUtils::getHumanReadableVersionOf(PHP_VERSION_ID),
+                'known_issues_discussions_url' => DocumentationLinks::getDiscussionsAboutKnownIssuesUrl($currentUpdateAssistantMinorVersion),
                 'local_archives' => [
                     'zip' => $localVersions['zip'],
                     'xml' => $localVersions['xml'],

--- a/views/templates/components/radio-card.html.twig
+++ b/views/templates/components/radio-card.html.twig
@@ -91,6 +91,12 @@
           {% include "@ModuleAutoUpgrade/components/check-requirements.html.twig" %}
         </div>
       {% endif %}
-    {% endif %}
+        <p class="radio-card__message-bottom">
+          {{ "Need a hand? Check [1]Update Assistant GitHub repository[/1]."|trans({
+            '[1]' : '<a class="link" href="' ~ known_issues_discussions_url ~ '" target="_blank">',
+            '[/1]' : '</a>',
+          })|raw }}
+        </p>
+      {% endif %}
   </div>
 </label>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR adds a link to the discussions of the project. This allow us to post messages about details to take care about after a version is released.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | On the version selection page, a new link to https://github.com/PrestaShop/autoupgrade/discussions is displayed. It must target open discussions with a label impacting the current minor version of the module.

<img width="1398" height="721" alt="image" src="https://github.com/user-attachments/assets/450505f0-7610-4b4e-ba33-3ffe47898a0d" />
