### PR TITLE
Rename UpgradeException to ProcessException

### DIFF
--- a/autoupgrade.php
+++ b/autoupgrade.php
@@ -191,7 +191,7 @@ class Autoupgrade extends Module
      * @return string
      *
      * @throws \PrestaShop\Module\AutoUpgrade\Exceptions\DistributionApiException
-     * @throws \PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException
+     * @throws \PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException
      * @throws \Twig\Error\LoaderError
      * @throws \Twig\Error\RuntimeError
      * @throws \Twig\Error\SyntaxError

--- a/classes/Commands/CheckNewVersionCommand.php
+++ b/classes/Commands/CheckNewVersionCommand.php
@@ -23,7 +23,7 @@ namespace PrestaShop\Module\AutoUpgrade\Commands;
 
 use Exception;
 use PrestaShop\Module\AutoUpgrade\Exceptions\DistributionApiException;
-use PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException;
+use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\Services\LocalVersionFilesService;
 use PrestaShop\Module\AutoUpgrade\Task\ExitCode;
@@ -49,7 +49,7 @@ class CheckNewVersionCommand extends AbstractCommand
 
     /**
      * @throws DistributionApiException
-     * @throws UpgradeException
+     * @throws ProcessException
      */
     protected function execute(InputInterface $input, OutputInterface $output): ?int
     {

--- a/classes/Commands/CheckRequirementsCommand.php
+++ b/classes/Commands/CheckRequirementsCommand.php
@@ -23,7 +23,7 @@ namespace PrestaShop\Module\AutoUpgrade\Commands;
 
 use Exception;
 use PrestaShop\Module\AutoUpgrade\Exceptions\DistributionApiException;
-use PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException;
+use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\Task\ExitCode;
 use PrestaShop\Module\AutoUpgrade\UpgradeSelfCheck;
@@ -116,7 +116,7 @@ class CheckRequirementsCommand extends AbstractCommand
 
     /**
      * @throws DistributionApiException
-     * @throws UpgradeException
+     * @throws ProcessException
      */
     private function processRequirementWarnings(): void
     {

--- a/classes/Commands/UpdateCommand.php
+++ b/classes/Commands/UpdateCommand.php
@@ -25,7 +25,7 @@ use Exception;
 use InvalidArgumentException;
 use PrestaShop\Module\AutoUpgrade\DocumentationLinks;
 use PrestaShop\Module\AutoUpgrade\Exceptions\DistributionApiException;
-use PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException;
+use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeFileNames;
 use PrestaShop\Module\AutoUpgrade\Task\ExitCode;
@@ -182,7 +182,7 @@ class UpdateCommand extends AbstractCommand
 
     /**
      * @throws DistributionApiException
-     * @throws UpgradeException
+     * @throws ProcessException
      * @throws Exception
      */
     private function calculateUpdateTypeAfterConfigLoad(): void

--- a/classes/Exceptions/ProcessException.php
+++ b/classes/Exceptions/ProcessException.php
@@ -23,7 +23,7 @@ namespace PrestaShop\Module\AutoUpgrade\Exceptions;
 
 use Exception;
 
-class UpgradeException extends Exception
+class ProcessException extends Exception
 {
     const SEVERITY_ERROR = 1;
     const SEVERITY_WARNING = 2;
@@ -58,7 +58,7 @@ class UpgradeException extends Exception
         return $this->severity;
     }
 
-    public function addQuickInfo(string $quickInfo): UpgradeException
+    public function addQuickInfo(string $quickInfo): ProcessException
     {
         $this->quickInfos[] = $quickInfo;
 
@@ -70,14 +70,14 @@ class UpgradeException extends Exception
      *
      * @return $this
      */
-    public function setQuickInfos(array $quickInfos): UpgradeException
+    public function setQuickInfos(array $quickInfos): ProcessException
     {
         $this->quickInfos = $quickInfos;
 
         return $this;
     }
 
-    public function setSeverity(int $severity): UpgradeException
+    public function setSeverity(int $severity): ProcessException
     {
         $this->severity = $severity;
 

--- a/classes/Hooks/DisplayBackOfficeHeader.php
+++ b/classes/Hooks/DisplayBackOfficeHeader.php
@@ -26,7 +26,7 @@ use Exception;
 use PrestaShop\Module\AutoUpgrade\DocumentationLinks;
 use PrestaShop\Module\AutoUpgrade\Environment;
 use PrestaShop\Module\AutoUpgrade\Exceptions\DistributionApiException;
-use PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException;
+use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
 use PrestaShop\Module\AutoUpgrade\Models\UpdateNotificationConfiguration;
 use PrestaShop\Module\AutoUpgrade\Services\UpdateNotificationService;
 use PrestaShop\Module\AutoUpgrade\Twig\PageSelectors;
@@ -115,7 +115,7 @@ class DisplayBackOfficeHeader
      * @return string
      *
      * @throws DistributionApiException
-     * @throws UpgradeException
+     * @throws ProcessException
      * @throws LoaderError
      * @throws RuntimeError
      * @throws SyntaxError
@@ -229,7 +229,7 @@ class DisplayBackOfficeHeader
 
     /**
      * @throws DistributionApiException
-     * @throws UpgradeException
+     * @throws ProcessException
      */
     private function checkNewerVersion(): void
     {
@@ -255,7 +255,7 @@ class DisplayBackOfficeHeader
     /**
      * @return array<string, mixed>
      *
-     * @throws UpgradeException
+     * @throws ProcessException
      */
     private function getParams(): array
     {

--- a/classes/Services/DownloadService.php
+++ b/classes/Services/DownloadService.php
@@ -21,7 +21,7 @@
 
 namespace PrestaShop\Module\AutoUpgrade\Services;
 
-use PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException;
+use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
 use PrestaShop\Module\AutoUpgrade\Log\Logger;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator;
 use Symfony\Component\Filesystem\Exception\IOException;
@@ -44,7 +44,7 @@ class DownloadService
     }
 
     /**
-     * @throws UpgradeException
+     * @throws ProcessException
      */
     public function downloadWithRetry(string $downloadUrl, string $destinationPath, int $retryCount = self::MAX_DOWNLOAD_TRY, int $delayInSeconds = self::WAIT_BETWEEN_RETRY_IN_SECONDS): void
     {
@@ -66,7 +66,7 @@ class DownloadService
             }
         }
 
-        throw new UpgradeException($this->translator->trans('All download attempts have failed.'));
+        throw new ProcessException($this->translator->trans('All download attempts have failed.'));
     }
 
     public function download(string $downloadUrl, string $destinationPath): void

--- a/classes/Task/AbstractTask.php
+++ b/classes/Task/AbstractTask.php
@@ -24,7 +24,7 @@ namespace PrestaShop\Module\AutoUpgrade\Task;
 use Exception;
 use PrestaShop\Module\AutoUpgrade\AjaxResponse;
 use PrestaShop\Module\AutoUpgrade\Analytics;
-use PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException;
+use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
 use PrestaShop\Module\AutoUpgrade\Log\Logger;
 use PrestaShop\Module\AutoUpgrade\Task\Runner\ChainedTasks;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
@@ -161,14 +161,14 @@ abstract class AbstractTask
 
     abstract public function run(): int;
 
-    protected function handleException(UpgradeException $e): void
+    protected function handleException(ProcessException $e): void
     {
-        if ($e->getSeverity() === UpgradeException::SEVERITY_ERROR) {
+        if ($e->getSeverity() === ProcessException::SEVERITY_ERROR) {
             $this->next = TaskName::TASK_ERROR;
             $this->setErrorFlag();
             $this->logger->error($e->getMessage());
         }
-        if ($e->getSeverity() === UpgradeException::SEVERITY_WARNING) {
+        if ($e->getSeverity() === ProcessException::SEVERITY_WARNING) {
             $this->logger->warning($e->getMessage());
             $this->container->getUpdateState()->setWarningDetected(true);
         }

--- a/classes/Task/Backup/BackupDatabase.php
+++ b/classes/Task/Backup/BackupDatabase.php
@@ -24,7 +24,7 @@ namespace PrestaShop\Module\AutoUpgrade\Task\Backup;
 use Exception;
 use PDO;
 use PrestaShop\Module\AutoUpgrade\Database\TableFilter;
-use PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException;
+use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeFileNames;
 use PrestaShop\Module\AutoUpgrade\Progress\Backlog;
 use PrestaShop\Module\AutoUpgrade\Task\AbstractTask;
@@ -292,7 +292,7 @@ class BackupDatabase extends AbstractTask
         );
 
         if (empty($listOfTables)) {
-            throw (new UpgradeException($this->translator->trans('No valid tables were found to back up. Backup of database canceled.')))->setSeverity(UpgradeException::SEVERITY_ERROR);
+            throw (new ProcessException($this->translator->trans('No valid tables were found to back up. Backup of database canceled.')))->setSeverity(ProcessException::SEVERITY_ERROR);
         }
 
         $tablesToBackup = new Backlog($listOfTables, count($listOfTables));
@@ -337,7 +337,7 @@ class BackupDatabase extends AbstractTask
     {
         // Figure out what compression is available and open the file
         if ($this->container->getFileSystem()->exists($backupfile)) {
-            throw (new UpgradeException($this->translator->trans('Backup file %s already exists. Operation aborted.', [$backupfile])))->setSeverity(UpgradeException::SEVERITY_ERROR);
+            throw (new ProcessException($this->translator->trans('Backup file %s already exists. Operation aborted.', [$backupfile])))->setSeverity(ProcessException::SEVERITY_ERROR);
         }
 
         if (function_exists('bzopen')) {
@@ -351,7 +351,7 @@ class BackupDatabase extends AbstractTask
         }
 
         if ($fp === false) {
-            throw (new UpgradeException($this->translator->trans('Unable to create backup database file %s.', [addslashes($backupfile)])))->setSeverity(UpgradeException::SEVERITY_ERROR);
+            throw (new ProcessException($this->translator->trans('Unable to create backup database file %s.', [addslashes($backupfile)])))->setSeverity(ProcessException::SEVERITY_ERROR);
         }
 
         return $fp;

--- a/classes/Task/Update/Download.php
+++ b/classes/Task/Update/Download.php
@@ -23,7 +23,7 @@ namespace PrestaShop\Module\AutoUpgrade\Task\Update;
 
 use Exception;
 use PrestaShop\Module\AutoUpgrade\Exceptions\DistributionApiException;
-use PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException;
+use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
 use PrestaShop\Module\AutoUpgrade\Task\AbstractTask;
 use PrestaShop\Module\AutoUpgrade\Task\ExitCode;
 use PrestaShop\Module\AutoUpgrade\Task\TaskName;
@@ -83,7 +83,7 @@ class Download extends AbstractTask
 
     /**
      * @throws DistributionApiException
-     * @throws UpgradeException
+     * @throws ProcessException
      * @throws Exception
      */
     public function downloadArchive(): void
@@ -102,7 +102,7 @@ class Download extends AbstractTask
                 $this->logger->error($this->translator->trans('Download complete but MD5 sum does not match (%s).', [$md5file]));
                 $this->next = TaskName::TASK_ERROR;
             }
-        } catch (UpgradeException $e) {
+        } catch (ProcessException $e) {
             $this->logger->error($this->translator->trans('The .zip archive could not be downloaded. The update is currently impossible. Please try again later.'));
             $this->next = TaskName::TASK_ERROR;
         }

--- a/classes/Task/Update/DownloadModules.php
+++ b/classes/Task/Update/DownloadModules.php
@@ -22,7 +22,7 @@
 namespace PrestaShop\Module\AutoUpgrade\Task\Update;
 
 use Exception;
-use PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException;
+use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeFileNames;
 use PrestaShop\Module\AutoUpgrade\Progress\Backlog;
 use PrestaShop\Module\AutoUpgrade\Task\AbstractTask;
@@ -82,9 +82,9 @@ class DownloadModules extends AbstractTask
                         UpgradeFileNames::MODULES_TO_UPGRADE_LIST
                     );
                 }
-            } catch (UpgradeException $e) {
+            } catch (ProcessException $e) {
                 $this->handleException($e);
-                if ($e->getSeverity() === UpgradeException::SEVERITY_ERROR) {
+                if ($e->getSeverity() === ProcessException::SEVERITY_ERROR) {
                     return ExitCode::FAIL;
                 }
             }
@@ -141,7 +141,7 @@ class DownloadModules extends AbstractTask
                 (new Backlog([], 0))->dump(),
                 UpgradeFileNames::MODULES_TO_UPGRADE_LIST
             );
-        } catch (UpgradeException $e) {
+        } catch (ProcessException $e) {
             $this->handleException($e);
 
             return ExitCode::FAIL;

--- a/classes/Task/Update/UpdateDatabase.php
+++ b/classes/Task/Update/UpdateDatabase.php
@@ -22,7 +22,7 @@
 namespace PrestaShop\Module\AutoUpgrade\Task\Update;
 
 use Exception;
-use PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException;
+use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeFileNames;
 use PrestaShop\Module\AutoUpgrade\Progress\Backlog;
 use PrestaShop\Module\AutoUpgrade\Task\AbstractTask;
@@ -71,7 +71,7 @@ class UpdateDatabase extends AbstractTask
             }
             $this->container->getFileStorage()->clean(UpgradeFileNames::SQL_TO_EXECUTE_LIST);
             $this->getCoreUpgrader()->finalizeCoreUpdate();
-        } catch (UpgradeException $e) {
+        } catch (ProcessException $e) {
             $this->next = TaskName::TASK_ERROR;
             $this->setErrorFlag();
             foreach ($e->getQuickInfos() as $log) {
@@ -118,7 +118,7 @@ class UpdateDatabase extends AbstractTask
     }
 
     /**
-     * @throws UpgradeException
+     * @throws ProcessException
      * @throws Exception
      */
     protected function warmUp(): int
@@ -156,7 +156,7 @@ class UpdateDatabase extends AbstractTask
     }
 
     /**
-     * @throws UpgradeException
+     * @throws ProcessException
      */
     protected function checkVersionIsNewer(): void
     {
@@ -166,9 +166,9 @@ class UpdateDatabase extends AbstractTask
         $versionCompare = version_compare($destinationVersion, $currentVersion);
 
         if ($versionCompare === -1) {
-            throw new UpgradeException($this->container->getTranslator()->trans('Version to install is too old. Current version: %oldversion%. Version to install: %newversion%.', ['%oldversion%' => $currentVersion, '%newversion%' => $destinationVersion]));
+            throw new ProcessException($this->container->getTranslator()->trans('Version to install is too old. Current version: %oldversion%. Version to install: %newversion%.', ['%oldversion%' => $currentVersion, '%newversion%' => $destinationVersion]));
         } elseif ($versionCompare === 0) {
-            throw new UpgradeException($this->container->getTranslator()->trans('You already have the %s version.', [$destinationVersion]));
+            throw new ProcessException($this->container->getTranslator()->trans('You already have the %s version.', [$destinationVersion]));
         }
     }
 

--- a/classes/Task/Update/UpdateModules.php
+++ b/classes/Task/Update/UpdateModules.php
@@ -22,7 +22,7 @@
 namespace PrestaShop\Module\AutoUpgrade\Task\Update;
 
 use Exception;
-use PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException;
+use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeFileNames;
 use PrestaShop\Module\AutoUpgrade\Progress\Backlog;
 use PrestaShop\Module\AutoUpgrade\Task\AbstractTask;
@@ -72,7 +72,7 @@ class UpdateModules extends AbstractTask
                 $module = \Module::getInstanceByName($moduleInfos['name']);
 
                 if (!($module instanceof \Module)) {
-                    throw (new UpgradeException($this->translator->trans('Retrieving the module instance of %s failed.', [$moduleInfos['name']])))->setSeverity(UpgradeException::SEVERITY_WARNING);
+                    throw (new ProcessException($this->translator->trans('Retrieving the module instance of %s failed.', [$moduleInfos['name']])))->setSeverity(ProcessException::SEVERITY_WARNING);
                 }
 
                 $moduleMigrationContext = new ModuleMigrationContext($module, $dbVersion);
@@ -86,9 +86,9 @@ class UpdateModules extends AbstractTask
                     $moduleMigration->runMigration($moduleMigrationContext);
                 }
                 $moduleMigration->saveVersionInDb($moduleMigrationContext);
-            } catch (UpgradeException $e) {
+            } catch (ProcessException $e) {
                 $this->handleException($e);
-                if ($e->getSeverity() === UpgradeException::SEVERITY_ERROR) {
+                if ($e->getSeverity() === ProcessException::SEVERITY_ERROR) {
                     return ExitCode::FAIL;
                 }
             } finally {

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -26,7 +26,7 @@ use ConfigurationTest;
 use Context;
 use Exception;
 use PrestaShop\Module\AutoUpgrade\Exceptions\DistributionApiException;
-use PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException;
+use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\Services\PhpVersionResolverService;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator;
@@ -179,7 +179,7 @@ class UpgradeSelfCheck
     /**
      * @return array<int, bool>
      *
-     * @throws UpgradeException
+     * @throws ProcessException
      */
     public function getWarnings(): array
     {
@@ -215,7 +215,7 @@ class UpgradeSelfCheck
      *
      * @return array{'message': string, 'list'?: array<string>}
      *
-     * @throws UpgradeException
+     * @throws ProcessException
      * @throws DistributionApiException
      */
     public function getRequirementWording(int $requirement, bool $isWebVersion = false): array
@@ -564,7 +564,7 @@ class UpgradeSelfCheck
     }
 
     /**
-     * @throws UpgradeException
+     * @throws ProcessException
      */
     public function isModuleVersionLatest(): bool
     {
@@ -785,7 +785,7 @@ class UpgradeSelfCheck
     }
 
     /**
-     * @throws UpgradeException
+     * @throws ProcessException
      */
     private function checkModuleVersionIsLastest(): bool
     {

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -28,7 +28,7 @@ use Language;
 use ParseError;
 use PrestaShop\Module\AutoUpgrade\Database\MysqlErrorCode;
 use PrestaShop\Module\AutoUpgrade\Exceptions\UpdateDatabaseException;
-use PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException;
+use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
 use PrestaShop\Module\AutoUpgrade\Log\LoggerInterface;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
@@ -105,7 +105,7 @@ abstract class CoreUpgrader
     }
 
     /**
-     * @throws UpgradeException
+     * @throws ProcessException
      * @throws Exception
      */
     public function setupUpdateEnvironment(): void
@@ -115,7 +115,7 @@ abstract class CoreUpgrader
     }
 
     /**
-     * @throws UpgradeException
+     * @throws ProcessException
      */
     public function finalizeCoreUpdate(): void
     {
@@ -262,14 +262,14 @@ abstract class CoreUpgrader
     }
 
     /**
-     * @throws UpgradeException
-     *
      * @return array<string, string>
+     *@throws ProcessException
+     *
      */
     protected function getUpgradeSqlFilesListToApply(string $upgrade_dir_sql, string $oldversion): array
     {
         if (!$this->fileSystem->exists($upgrade_dir_sql)) {
-            throw new UpgradeException($this->container->getTranslator()->trans('Unable to find upgrade directory in the installation path.'));
+            throw new ProcessException($this->container->getTranslator()->trans('Unable to find upgrade directory in the installation path.'));
         }
 
         $upgradeFiles = $neededUpgradeFiles = [];
@@ -279,14 +279,14 @@ abstract class CoreUpgrader
                     continue;
                 }
                 if (!is_readable($upgrade_dir_sql . $file)) {
-                    throw new UpgradeException($this->container->getTranslator()->trans('Error while loading SQL upgrade file "%s".', [$file]));
+                    throw new ProcessException($this->container->getTranslator()->trans('Error while loading SQL upgrade file "%s".', [$file]));
                 }
                 $upgradeFiles[] = str_replace('.sql', '', $file);
             }
             closedir($handle);
         }
         if (empty($upgradeFiles)) {
-            throw new UpgradeException($this->container->getTranslator()->trans('Cannot find the SQL upgrade files. Please check that the %s folder is not empty.', [$upgrade_dir_sql]));
+            throw new ProcessException($this->container->getTranslator()->trans('Cannot find the SQL upgrade files. Please check that the %s folder is not empty.', [$upgrade_dir_sql]));
         }
         natcasesort($upgradeFiles);
 
@@ -300,9 +300,9 @@ abstract class CoreUpgrader
     }
 
     /**
-     * @throws UpgradeException
-     *
      * @return array<array{'version':string,'query':string}>
+     *@throws ProcessException
+     *
      */
     public function getSqlContentList(string $originVersion): array
     {
@@ -734,7 +734,7 @@ abstract class CoreUpgrader
     }
 
     /**
-     * @throws UpgradeException
+     * @throws ProcessException
      * @throws Exception
      */
     protected function updateTheme(): void
@@ -744,7 +744,7 @@ abstract class CoreUpgrader
     }
 
     /**
-     * @throws UpgradeException
+     * @throws ProcessException
      * @throws \Exception
      */
     protected function switchToDefaultTheme(): void
@@ -766,7 +766,7 @@ abstract class CoreUpgrader
         );
 
         if ($themeErrors !== true) {
-            throw new UpgradeException($themeErrors);
+            throw new ProcessException($themeErrors);
         }
     }
 
@@ -870,7 +870,7 @@ abstract class CoreUpgrader
         exec($command, $output, $resultCode);
 
         if ($resultCode !== 0) {
-            throw new UpgradeException($this->container->getTranslator()->trans("An error was raised when warming up the core cache: \n %s", [implode("\n", $output)]));
+            throw new ProcessException($this->container->getTranslator()->trans("An error was raised when warming up the core cache: \n %s", [implode("\n", $output)]));
         }
         $this->logger->debug($this->container->getTranslator()->trans('Core cache has been generated to avoid dependency conflicts.'));
     }
@@ -906,7 +906,7 @@ abstract class CoreUpgrader
         ]), $output);
 
         if ($errorCode !== 0) {
-            throw new UpgradeException($this->container->getTranslator()->trans("A code %d was returned while installing assets: \n %s", [$errorCode, $output->fetch()]));
+            throw new ProcessException($this->container->getTranslator()->trans("A code %d was returned while installing assets: \n %s", [$errorCode, $output->fetch()]));
         }
     }
 }

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -27,8 +27,8 @@ use InvalidArgumentException;
 use Language;
 use ParseError;
 use PrestaShop\Module\AutoUpgrade\Database\MysqlErrorCode;
-use PrestaShop\Module\AutoUpgrade\Exceptions\UpdateDatabaseException;
 use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
+use PrestaShop\Module\AutoUpgrade\Exceptions\UpdateDatabaseException;
 use PrestaShop\Module\AutoUpgrade\Log\LoggerInterface;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
@@ -263,8 +263,8 @@ abstract class CoreUpgrader
 
     /**
      * @return array<string, string>
-     *@throws ProcessException
      *
+     *@throws ProcessException
      */
     protected function getUpgradeSqlFilesListToApply(string $upgrade_dir_sql, string $oldversion): array
     {
@@ -301,8 +301,8 @@ abstract class CoreUpgrader
 
     /**
      * @return array<array{'version':string,'query':string}>
-     *@throws ProcessException
      *
+     *@throws ProcessException
      */
     public function getSqlContentList(string $originVersion): array
     {

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -264,7 +264,7 @@ abstract class CoreUpgrader
     /**
      * @return array<string, string>
      *
-     *@throws ProcessException
+     * @throws ProcessException
      */
     protected function getUpgradeSqlFilesListToApply(string $upgrade_dir_sql, string $oldversion): array
     {
@@ -302,7 +302,7 @@ abstract class CoreUpgrader
     /**
      * @return array<array{'version':string,'query':string}>
      *
-     *@throws ProcessException
+     * @throws ProcessException
      */
     public function getSqlContentList(string $originVersion): array
     {

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader17.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader17.php
@@ -21,7 +21,7 @@
 
 namespace PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader;
 
-use PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException;
+use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
 
 /**
  * Class used to modify the core of PrestaShop, on the files are copied on the filesystem.
@@ -38,7 +38,7 @@ class CoreUpgrader17 extends CoreUpgrader
     }
 
     /**
-     * @throws UpgradeException
+     * @throws ProcessException
      * @throws \Exception
      */
     protected function upgradeLanguage($lang): void
@@ -53,7 +53,7 @@ class CoreUpgrader17 extends CoreUpgrader
         $errorsLanguage = [];
 
         if (!\Language::downloadLanguagePack($isoCode, _PS_VERSION_, $errorsLanguage)) {
-            throw new UpgradeException($this->container->getTranslator()->trans('Download of the language pack %lang% failed. %details%', ['%lang%' => $isoCode, '%details%' => implode('; ', $errorsLanguage)]));
+            throw new ProcessException($this->container->getTranslator()->trans('Download of the language pack %lang% failed. %details%', ['%lang%' => $isoCode, '%details%' => implode('; ', $errorsLanguage)]));
         }
 
         $lang_pack = \Language::getLangDetails($isoCode);
@@ -64,7 +64,7 @@ class CoreUpgrader17 extends CoreUpgrader
         }
 
         if (!empty($errorsLanguage)) {
-            throw new UpgradeException($this->container->getTranslator()->trans('Error while updating translations for the language pack %lang%. %details%', ['%lang%' => $isoCode, '%details%' => implode('; ', $errorsLanguage)]));
+            throw new ProcessException($this->container->getTranslator()->trans('Error while updating translations for the language pack %lang%. %details%', ['%lang%' => $isoCode, '%details%' => implode('; ', $errorsLanguage)]));
         }
         \Language::loadLanguages();
 

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
@@ -57,8 +57,8 @@ class CoreUpgrader80 extends CoreUpgrader
 
     /**
      * @param array<string, mixed> $lang
-     *@throws Exception
      *
+     * @throws Exception
      * @throws ProcessException
      */
     protected function upgradeLanguage($lang): void

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 namespace PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader;
 
 use Exception;
-use PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException;
+use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
 use PrestaShop\PrestaShop\Adapter\Module\Repository\ModuleRepository;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Domain\MailTemplate\Command\GenerateThemeMailTemplatesCommand;
@@ -56,10 +56,10 @@ class CoreUpgrader80 extends CoreUpgrader
     }
 
     /**
-     * @throws UpgradeException
-     * @throws Exception
-     *
      * @param array<string, mixed> $lang
+     *@throws Exception
+     *
+     * @throws ProcessException
      */
     protected function upgradeLanguage($lang): void
     {
@@ -74,7 +74,7 @@ class CoreUpgrader80 extends CoreUpgrader
 
         $this->logger->debug($this->container->getTranslator()->trans('Downloading language pack for %lang%', ['%lang%' => $isoCode]));
         if (!\Language::downloadLanguagePack($isoCode, _PS_VERSION_, $errorsLanguage)) {
-            throw new UpgradeException($this->container->getTranslator()->trans('Download of the language pack %lang% failed. %details%', ['%lang%' => $isoCode, '%details%' => implode('; ', $errorsLanguage)]));
+            throw new ProcessException($this->container->getTranslator()->trans('Download of the language pack %lang% failed. %details%', ['%lang%' => $isoCode, '%details%' => implode('; ', $errorsLanguage)]));
         }
 
         $this->logger->debug($this->container->getTranslator()->trans('Installing %lang% language pack', ['%lang%' => $isoCode]));
@@ -102,12 +102,12 @@ class CoreUpgrader80 extends CoreUpgrader
             try {
                 $commandBus->handle($generateCommand);
             } catch (CoreException $e) {
-                throw new UpgradeException($this->container->getTranslator()->trans('Cannot generate email templates: %s.', [$e->getMessage()]));
+                throw new ProcessException($this->container->getTranslator()->trans('Cannot generate email templates: %s.', [$e->getMessage()]));
             }
         }
 
         if (!empty($errorsLanguage)) {
-            throw new UpgradeException($this->container->getTranslator()->trans('Error while updating translations for the language pack %lang%. %details%', ['%lang%' => $isoCode, '%details%' => implode('; ', $errorsLanguage)]));
+            throw new ProcessException($this->container->getTranslator()->trans('Error while updating translations for the language pack %lang%. %details%', ['%lang%' => $isoCode, '%details%' => implode('; ', $errorsLanguage)]));
         }
         \Language::loadLanguages();
 

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader81.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader81.php
@@ -22,13 +22,13 @@ declare(strict_types=1);
 
 namespace PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader;
 
-use PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException;
+use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 
 class CoreUpgrader81 extends CoreUpgrader80
 {
     /**
-     * @throws UpgradeException
+     * @throws ProcessException
      */
     public function writeNewSettings(): void
     {
@@ -50,7 +50,7 @@ class CoreUpgrader81 extends CoreUpgrader80
             $parametersContent = sprintf('<?php return %s;', var_export($parameters, true));
             $this->logger->debug($this->container->getTranslator()->trans('Updating parameters file'));
             if (!file_put_contents($parametersPath, $parametersContent)) {
-                throw new UpgradeException($this->container->getTranslator()->trans('Unable to migrate parameters'));
+                throw new ProcessException($this->container->getTranslator()->trans('Unable to migrate parameters'));
             }
 
             if (function_exists('opcache_invalidate')) {

--- a/classes/UpgradeTools/Module/ModuleAdapter.php
+++ b/classes/UpgradeTools/Module/ModuleAdapter.php
@@ -21,7 +21,7 @@
 
 namespace PrestaShop\Module\AutoUpgrade\UpgradeTools\Module;
 
-use PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException;
+use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\SymfonyAdapter;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator;
 use PrestaShop\PrestaShop\Adapter\Module\Repository\ModuleRepository;
@@ -108,7 +108,7 @@ class ModuleAdapter
      *
      * @return array<array{name:string, currentVersion:string}> Module available on the local filesystem and installed
      *
-     * @throws UpgradeException
+     * @throws ProcessException
      */
     public function listModulesPresentInFolderAndInstalled(): array
     {
@@ -116,7 +116,7 @@ class ModuleAdapter
         $dir = $this->modulesPath;
 
         if (!is_dir($dir)) {
-            throw (new UpgradeException($this->translator->trans('%dir% does not exist or is not a directory.', ['%dir%' => $dir])))->addQuickInfo($this->translator->trans('%s does not exist or is not a directory.', [$dir]))->setSeverity(UpgradeException::SEVERITY_ERROR);
+            throw (new ProcessException($this->translator->trans('%dir% does not exist or is not a directory.', ['%dir%' => $dir])))->addQuickInfo($this->translator->trans('%s does not exist or is not a directory.', [$dir]))->setSeverity(ProcessException::SEVERITY_ERROR);
         }
 
         foreach ($this->getInstalledVersionOfModules() as $moduleInstalled) {

--- a/classes/UpgradeTools/Module/ModuleDownloader.php
+++ b/classes/UpgradeTools/Module/ModuleDownloader.php
@@ -22,7 +22,7 @@ namespace PrestaShop\Module\AutoUpgrade\UpgradeTools\Module;
 
 use Exception;
 use LogicException;
-use PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException;
+use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
 use PrestaShop\Module\AutoUpgrade\Log\Logger;
 use PrestaShop\Module\AutoUpgrade\Services\DownloadService;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator;
@@ -51,7 +51,7 @@ class ModuleDownloader
     }
 
     /**
-     * @throws UpgradeException
+     * @throws ProcessException
      */
     public function downloadModule(ModuleDownloaderContext $moduleDownloaderContext): void
     {
@@ -73,12 +73,12 @@ class ModuleDownloader
 
         if (!$downloadSuccessful) {
             $message = $this->translator->trans('All download attempts have failed. The module %s has been disabled. You can try to update it manually afterwards.', [$moduleDownloaderContext->getModuleName()]);
-            throw (new UpgradeException($message))->setSeverity(UpgradeException::SEVERITY_WARNING);
+            throw (new ProcessException($message))->setSeverity(ProcessException::SEVERITY_WARNING);
         }
     }
 
     /**
-     * @throws UpgradeException
+     * @throws ProcessException
      */
     private function attemptDownload(ModuleDownloaderContext $moduleDownloaderContext, int $index): void
     {
@@ -108,19 +108,19 @@ class ModuleDownloader
     }
 
     /**
-     * @throws UpgradeException If download content is invalid
+     * @throws ProcessException If download content is invalid
      */
     private function assertDownloadedContentsIsValid(string $destinationPath): void
     {
         if (is_file($destinationPath)) {
             // Arbitrary size value checking the zip file has at least a file in it.
             if (filesize($destinationPath) <= 300) {
-                throw (new UpgradeException($this->translator->trans('The received module archive is empty.')))->setSeverity(UpgradeException::SEVERITY_WARNING);
+                throw (new ProcessException($this->translator->trans('The received module archive is empty.')))->setSeverity(ProcessException::SEVERITY_WARNING);
             }
 
             $downloadedFile = fopen($destinationPath, 'r');
             if (!$downloadedFile || fread($downloadedFile, 5) == '<?xml') {
-                throw (new UpgradeException($this->translator->trans('Invalid contents from provider (Got an XML file).')))->setSeverity(UpgradeException::SEVERITY_WARNING);
+                throw (new ProcessException($this->translator->trans('Invalid contents from provider (Got an XML file).')))->setSeverity(ProcessException::SEVERITY_WARNING);
             }
             fclose($downloadedFile);
         }

--- a/classes/UpgradeTools/Module/ModuleMigration.php
+++ b/classes/UpgradeTools/Module/ModuleMigration.php
@@ -22,7 +22,7 @@
 namespace PrestaShop\Module\AutoUpgrade\UpgradeTools\Module;
 
 use LogicException;
-use PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException;
+use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
 use PrestaShop\Module\AutoUpgrade\Log\Logger;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator;
 use Symfony\Component\Filesystem\Exception\IOException;
@@ -92,7 +92,7 @@ class ModuleMigration
 
     /**
      * @throws LogicException
-     * @throws UpgradeException
+     * @throws ProcessException
      */
     public function runMigration(ModuleMigrationContext $moduleMigrationContext): void
     {
@@ -107,25 +107,25 @@ class ModuleMigration
 
             try {
                 if (!$this->loadAndCallFunction($migrationFilePath, $methodName, $moduleMigrationContext)) {
-                    throw (new UpgradeException($this->translator->trans('Migration failed while running the file %s. Module %s disabled.', [basename($migrationFilePath), $moduleMigrationContext->getModuleName()])))->setSeverity(UpgradeException::SEVERITY_WARNING);
+                    throw (new ProcessException($this->translator->trans('Migration failed while running the file %s. Module %s disabled.', [basename($migrationFilePath), $moduleMigrationContext->getModuleName()])))->setSeverity(ProcessException::SEVERITY_WARNING);
                 }
-            } catch (UpgradeException $e) {
+            } catch (ProcessException $e) {
                 $moduleMigrationContext->getModuleInstance()->disable();
                 throw $e;
             } catch (Throwable $t) {
                 $moduleMigrationContext->getModuleInstance()->disable();
-                throw (new UpgradeException($this->translator->trans('Unexpected issue when trying to upgrade module %s. Module %s disabled.', [$moduleMigrationContext->getModuleName(), $moduleMigrationContext->getModuleName()]), 0, $t))->setSeverity(UpgradeException::SEVERITY_WARNING);
+                throw (new ProcessException($this->translator->trans('Unexpected issue when trying to upgrade module %s. Module %s disabled.', [$moduleMigrationContext->getModuleName(), $moduleMigrationContext->getModuleName()]), 0, $t))->setSeverity(ProcessException::SEVERITY_WARNING);
             }
         }
     }
 
     /**
-     * @throws UpgradeException
+     * @throws ProcessException
      */
     public function saveVersionInDb(ModuleMigrationContext $moduleMigrationContext): void
     {
         if (!\Module::upgradeModuleVersion($moduleMigrationContext->getModuleName(), $moduleMigrationContext->getLocalVersion())) {
-            throw (new UpgradeException($this->translator->trans('Module %s version could not be updated. Database might be unavailable.', [$moduleMigrationContext->getModuleName()]), 0))->setSeverity(UpgradeException::SEVERITY_WARNING);
+            throw (new ProcessException($this->translator->trans('Module %s version could not be updated. Database might be unavailable.', [$moduleMigrationContext->getModuleName()]), 0))->setSeverity(ProcessException::SEVERITY_WARNING);
         }
     }
 
@@ -143,7 +143,7 @@ class ModuleMigration
     /**
      * Loads the migration file and calls the specified method using eval.
      *
-     * @throws UpgradeException
+     * @throws ProcessException
      */
     private function loadAndCallFunction(string $filePath, string $methodName, ModuleMigrationContext $moduleMigrationContext): bool
     {
@@ -158,12 +158,12 @@ class ModuleMigration
 
             require_once $sandboxedFilePath;
             if (!function_exists($uniqueMethodName)) {
-                throw (new UpgradeException($this->translator->trans('Method %s does not exist. Module %s disabled.', [$uniqueMethodName, $moduleMigrationContext->getModuleName()])))->setSeverity(UpgradeException::SEVERITY_WARNING);
+                throw (new ProcessException($this->translator->trans('Method %s does not exist. Module %s disabled.', [$uniqueMethodName, $moduleMigrationContext->getModuleName()])))->setSeverity(ProcessException::SEVERITY_WARNING);
             }
 
             return call_user_func($uniqueMethodName, $moduleMigrationContext->getModuleInstance());
         } catch (IOException $e) {
-            throw (new UpgradeException($this->translator->trans('Could not write temporary file %s.', [$sandboxedFilePath])))->setSeverity(UpgradeException::SEVERITY_WARNING);
+            throw (new ProcessException($this->translator->trans('Could not write temporary file %s.', [$sandboxedFilePath])))->setSeverity(ProcessException::SEVERITY_WARNING);
         } finally {
             $this->filesystem->remove($sandboxedFilePath);
             // If the module echoed during the migration, we catch it in the logger.

--- a/classes/UpgradeTools/Module/ModuleUnzipper.php
+++ b/classes/UpgradeTools/Module/ModuleUnzipper.php
@@ -21,7 +21,7 @@
 namespace PrestaShop\Module\AutoUpgrade\UpgradeTools\Module;
 
 use LogicException;
-use PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException;
+use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator;
 use PrestaShop\Module\AutoUpgrade\ZipAction;
 use Symfony\Component\Filesystem\Filesystem;
@@ -45,14 +45,14 @@ class ModuleUnzipper
     }
 
     /**
-     * @throws LogicException|UpgradeException
+     * @throws LogicException|ProcessException
      */
     public function unzipModule(ModuleUnzipperContext $moduleUnzipperContext): void
     {
         $updatedModulePath = $moduleUnzipperContext->getDestinationFilePath();
 
         if (is_file($updatedModulePath) && !$this->zipAction->extract($updatedModulePath, $this->modulesFolder)) {
-            throw (new UpgradeException($this->translator->trans('Error when trying to extract module %s.', [$moduleUnzipperContext->getModuleName()])))->setSeverity(UpgradeException::SEVERITY_WARNING);
+            throw (new ProcessException($this->translator->trans('Error when trying to extract module %s.', [$moduleUnzipperContext->getModuleName()])))->setSeverity(ProcessException::SEVERITY_WARNING);
         }
 
         // Module is already unzipped, we make the actual move in the modules folder.

--- a/classes/Upgrader.php
+++ b/classes/Upgrader.php
@@ -22,7 +22,7 @@
 namespace PrestaShop\Module\AutoUpgrade;
 
 use PrestaShop\Module\AutoUpgrade\Exceptions\DistributionApiException;
-use PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException;
+use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
 use PrestaShop\Module\AutoUpgrade\Models\PrestashopRelease;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\Services\DistributionApiService;
@@ -72,7 +72,7 @@ class Upgrader
 
     /**
      * @throws DistributionApiException
-     * @throws UpgradeException
+     * @throws ProcessException
      */
     public function isLastVersion(): bool
     {
@@ -121,7 +121,7 @@ class Upgrader
 
     /**
      * @throws DistributionApiException
-     * @throws UpgradeException
+     * @throws ProcessException
      */
     public function getOnlineDestinationRelease(): ?PrestaShopRelease
     {
@@ -160,7 +160,7 @@ class Upgrader
      * @return ?string Prestashop destination version or null if no compatible version found
      *
      * @throws DistributionApiException
-     * @throws UpgradeException
+     * @throws ProcessException
      */
     public function getDestinationVersion(): ?string
     {
@@ -178,7 +178,7 @@ class Upgrader
     }
 
     /**
-     * @throws UpgradeException
+     * @throws ProcessException
      */
     public function getOnlineDestinationVersionForChannel(string $channel): ?string
     {
@@ -188,19 +188,19 @@ class Upgrader
             return $this->getOnlineRecommendedDestinationRelease() ? $this->getOnlineRecommendedDestinationRelease()->getVersion() : null;
         }
 
-        throw new UpgradeException(sprintf('Channel accepted: %s, %s', UpgradeConfiguration::CHANNEL_ONLINE, UpgradeConfiguration::CHANNEL_ONLINE_RECOMMENDED));
+        throw new ProcessException(sprintf('Channel accepted: %s, %s', UpgradeConfiguration::CHANNEL_ONLINE, UpgradeConfiguration::CHANNEL_ONLINE_RECOMMENDED));
     }
 
     /**
      * @throws DistributionApiException
-     * @throws UpgradeException
+     * @throws ProcessException
      */
     public function getLatestCompatibleModuleVersion(): string
     {
         $autoupgradeReleases = $this->distributionApiService->getAutoupgradeCompatibilities();
 
         if (empty($autoupgradeReleases)) {
-            throw new UpgradeException($this->translator->trans('Unable to retrieve the recommended releases of Update Assistant.'));
+            throw new ProcessException($this->translator->trans('Unable to retrieve the recommended releases of Update Assistant.'));
         }
 
         $destinationVersion = $this->getDestinationVersion();

--- a/classes/VersionUtils.php
+++ b/classes/VersionUtils.php
@@ -22,7 +22,7 @@
 namespace PrestaShop\Module\AutoUpgrade;
 
 use InvalidArgumentException;
-use PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException;
+use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
 
 class VersionUtils
 {
@@ -113,7 +113,7 @@ class VersionUtils
     /**
      * @return 'major'|'minor'|'patch'
      *
-     * @throws UpgradeException
+     * @throws ProcessException
      */
     public static function getUpdateType(string $originVersion, string $destinationVersion)
     {
@@ -128,7 +128,7 @@ class VersionUtils
             return 'patch';
         }
 
-        throw new UpgradeException('Versions are identical');
+        throw new ProcessException('Versions are identical');
     }
 
     /**

--- a/tests/unit/Services/PhpVersionResolverServiceTest.php
+++ b/tests/unit/Services/PhpVersionResolverServiceTest.php
@@ -23,7 +23,7 @@ namespace unit\Services;
 use LogicException;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\Module\AutoUpgrade\Exceptions\DistributionApiException;
-use PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException;
+use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
 use PrestaShop\Module\AutoUpgrade\Models\PrestashopRelease;
 use PrestaShop\Module\AutoUpgrade\Services\DistributionApiService;
 use PrestaShop\Module\AutoUpgrade\Services\PhpVersionResolverService;
@@ -118,7 +118,7 @@ class PhpVersionResolverServiceTest extends TestCase
     }
 
     /**
-     * @throws UpgradeException
+     * @throws ProcessException
      * @throws DistributionApiException
      * @throws LogicException
      */
@@ -131,7 +131,7 @@ class PhpVersionResolverServiceTest extends TestCase
     }
 
     /**
-     * @throws UpgradeException
+     * @throws ProcessException
      * @throws DistributionApiException
      * @throws LogicException
      */
@@ -147,7 +147,7 @@ class PhpVersionResolverServiceTest extends TestCase
     }
 
     /**
-     * @throws UpgradeException
+     * @throws ProcessException
      * @throws DistributionApiException
      * @throws LogicException
      */
@@ -285,7 +285,7 @@ class PhpVersionResolverServiceTest extends TestCase
     }
 
     /**
-     * @throws UpgradeException
+     * @throws ProcessException
      * @throws DistributionApiException
      * @throws LogicException
      *
@@ -303,7 +303,7 @@ class PhpVersionResolverServiceTest extends TestCase
     }
 
     /**
-     * @throws UpgradeException
+     * @throws ProcessException
      * @throws DistributionApiException
      * @throws LogicException
      */
@@ -344,7 +344,7 @@ class PhpVersionResolverServiceTest extends TestCase
     }
 
     /**
-     * @throws UpgradeException
+     * @throws ProcessException
      * @throws DistributionApiException
      * @throws LogicException
      */
@@ -362,7 +362,7 @@ class PhpVersionResolverServiceTest extends TestCase
     }
 
     /**
-     * @throws UpgradeException
+     * @throws ProcessException
      * @throws DistributionApiException
      * @throws LogicException
      */

--- a/tests/unit/UpgradeTools/Module/ModuleAdapterTest.php
+++ b/tests/unit/UpgradeTools/Module/ModuleAdapterTest.php
@@ -19,7 +19,7 @@
  */
 
 use PHPUnit\Framework\TestCase;
-use PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException;
+use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\ModuleAdapter;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\SymfonyAdapter;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator;
@@ -221,7 +221,7 @@ class ModuleAdapterTest extends TestCase
             }
         };
 
-        $this->expectException(UpgradeException::class);
+        $this->expectException(ProcessException::class);
         $this->expectExceptionMessage('does not exist or is not a directory');
 
         $moduleAdapter->listModulesPresentInFolderAndInstalled();

--- a/tests/unit/UpgradeTools/Module/ModuleDownloaderTest.php
+++ b/tests/unit/UpgradeTools/Module/ModuleDownloaderTest.php
@@ -19,7 +19,7 @@
  */
 
 use PHPUnit\Framework\TestCase;
-use PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException;
+use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
 use PrestaShop\Module\AutoUpgrade\Log\Logger;
 use PrestaShop\Module\AutoUpgrade\Services\DownloadService;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\ModuleDownloader;
@@ -175,7 +175,7 @@ class ModuleDownloaderTest extends TestCase
 
         $this->downloadService
             ->method('downloadWithRetry')
-            ->willThrowException(new UpgradeException('Invalid contents from provider (Got an XML file).'));
+            ->willThrowException(new ProcessException('Invalid contents from provider (Got an XML file).'));
 
         $this->moduleDownloader->downloadModule($moduleContext);
     }

--- a/tests/unit/UpgradeTools/Module/ModuleMigrationTest.php
+++ b/tests/unit/UpgradeTools/Module/ModuleMigrationTest.php
@@ -198,7 +198,7 @@ class ModuleMigrationTest extends TestCase
 
         $this->moduleMigration->needMigration($moduleMigrationContext);
 
-        $this->expectException(\PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException::class);
+        $this->expectException(\PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException::class);
         $this->expectExceptionMessage('Method mymodule_upgrade_module_1_2_0 does not exist. Module mymodule disabled.');
 
         $this->moduleMigration->runMigration($moduleMigrationContext);
@@ -214,7 +214,7 @@ class ModuleMigrationTest extends TestCase
 
         $this->moduleMigration->needMigration($moduleMigrationContext);
 
-        $this->expectException(\PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException::class);
+        $this->expectException(\PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException::class);
         $this->expectExceptionMessage('Migration failed while running the file upgrade-1.2.1.php. Module mymodule disabled.');
 
         $this->moduleMigration->runMigration($moduleMigrationContext);
@@ -230,7 +230,7 @@ class ModuleMigrationTest extends TestCase
 
         $this->moduleMigration->needMigration($moduleMigrationContext);
 
-        $this->expectException(\PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException::class);
+        $this->expectException(\PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException::class);
         $this->expectExceptionMessage('Unexpected issue when trying to upgrade module mymodule. Module mymodule disabled.');
 
         $this->moduleMigration->runMigration($moduleMigrationContext);
@@ -256,7 +256,7 @@ class ModuleMigrationTest extends TestCase
 
         $moduleMigrationContext = new ModuleMigrationContext($mymodule, $dbVersion);
 
-        $this->expectException(\PrestaShop\Module\AutoUpgrade\Exceptions\UpgradeException::class);
+        $this->expectException(\PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException::class);
         $this->expectExceptionMessage('Module mymodule version could not be updated. Database might be unavailable.');
 
         $this->assertNull($this->moduleMigration->saveVersionInDb($moduleMigrationContext));


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Rename `UpgradeException` to `ProcessException` because he is not only used in update task and he is only for process (like `update`, `restore`, etc...)
| Type?             | refactor
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | @PrestaShopCorp
| How to test?      | Try everything run as excepted (errors too)
