### PR TITLE
Init Symfony kernel during modules uninstallation

### DIFF
--- a/classes/Task/Update/UninstallModules.php
+++ b/classes/Task/Update/UninstallModules.php
@@ -99,6 +99,8 @@ class UninstallModules extends AbstractTask
     public function init(): void
     {
         $this->container->initPrestaShopCore();
+        // Container may be needed on uninstallation if the module loads services.
+        $this->container->getSymfonyAdapter()->initKernel();
     }
 
     /**

--- a/classes/UpgradeTools/SymfonyAdapter.php
+++ b/classes/UpgradeTools/SymfonyAdapter.php
@@ -59,6 +59,8 @@ class SymfonyAdapter
             }
 
             $kernel->boot();
+            // Starting from PrestaShop 9, some parts of the new context are defined by event listeners on kernel.request.
+            // We may have to trigger it with dummy data in the future.
         }
 
         return $kernel;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Some module try to load Symfony services while they're being uninstalled. This PR loads Symfony and the necessary components of the Core
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Update from 9.0.3 to PrestaShop 9.2.0, all modules will be uninstalled. Some of them will trigger an issue.
