### PR TITLE
Update command update:check-modules to display lists of incompatible and uncertain modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ The requirements can be reviewed to confirm the store is safe to update:
 $ php bin/console update:check-requirements <your-admin-dir>
 ```
 
+Modules that require an action before or during the update are listed with:
+
+```
+$ php bin/console update:check-modules <your-admin-dir>
+```
+
 To see which new versions are available for your installation use:
 
 ```
@@ -176,7 +182,7 @@ For more information on using commands, please refer to the [PrestaShop develope
 
 ## Check Modules Compatibility
 
-A command is available to verify module compatibility and detect available updates before performing a store update.
+A command helps you review module compatibility before launching an update, giving you clearer visibility on the actions needed or planned.
 
 Run the command from the root directory of the module:
 
@@ -184,7 +190,7 @@ Run the command from the root directory of the module:
 php bin/console update:check-modules <your-admin-dir>
 ```
 
-This command helps you review module compatibility before launching an update, giving you clearer visibility on potential issues or available updates.
+Running as verbose shows the compatibility details based on the Marketplace API.
 
 ## Channels
 

--- a/classes/Commands/CheckModulesCommand.php
+++ b/classes/Commands/CheckModulesCommand.php
@@ -22,7 +22,7 @@
 namespace PrestaShop\Module\AutoUpgrade\Commands;
 
 use Exception;
-use PrestaShop\Module\AutoUpgrade\Exceptions\MarketplaceApiException;
+use PrestaShop\Module\AutoUpgrade\Models\Module\Marketplace\ModuleUpgradeCompatibility;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\Task\ExitCode;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
@@ -117,59 +117,90 @@ class CheckModulesCommand extends AbstractCommand
             }
 
             $modulesInstalled = $this->upgradeContainer->getModuleAdapter()->listModulesPresentInFolderAndInstalled();
-            $marketplaceService = $this->upgradeContainer->getMarketplaceService();
+            $updateSelfCheck = $this->upgradeContainer->getUpgradeSelfCheck();
 
             if (!empty($modulesInstalled)) {
                 $progressIndicator = new ProgressIndicator($output);
                 $output->writeln(sprintf('Prestashop version: %s', $targetPsVersion));
+
                 $progressIndicator->start('Retrieving modules informations, please wait...');
+                $checkResults = $updateSelfCheck->getModulesRequiringAttention();
+                $progressIndicator->finish('Retrieving modules informations: Done.');
 
-                $table = new Table($output);
-                $table->setHeaders([
-                    'Module',
-                    'Compatible',
-                    'Update available',
-                    'Local version',
-                    'Update version available',
-                ]);
-
-                foreach ($modulesInstalled as $localModule) {
-                    $progressIndicator->advance();
-                    $localModuleName = $localModule['name'];
-                    $localVersion = $localModule['currentVersion'];
-
-                    try {
-                        $moduleDetails = $marketplaceService->getModuleDetail($localModuleName);
-                    } catch (MarketplaceApiException $e) {
-                        $table->addRow([
-                        $localModuleName,
-                        '<error>✗ Unable to retrieve module information</error>',
-                    ]);
-                        continue;
-                    }
-
-                    $moduleCompatibility = $marketplaceService->findCompatibleModuleUpgrade(
-                        $moduleDetails,
-                        $targetPsVersion,
-                        $localVersion
-                    );
-
-                    $table->addRow([
-                        $localModuleName,
-                        $moduleCompatibility->isCompatible() ? '✓ Yes' : '✗ No',
-                        $moduleCompatibility->hasUpdateAvailable() ? '✓ Yes' : '✗ No',
-                        $localVersion,
-                        $moduleCompatibility->isCompatible() ? $moduleCompatibility->getCompatibleRelease()->productVersion : '-',
-                    ]);
+                if ($output->isVerbose()) {
+                    $this->renderDetailedTable($output, $modulesInstalled, $checkResults);
                 }
-                $progressIndicator->finish('Result:');
-                $table->render();
+                $this->renderLists($output, $checkResults, $targetPsVersion);
             }
 
             return ExitCode::SUCCESS;
         } catch (Exception $e) {
             $this->logger->error("An error occurred during the check process:\n" . $e);
             throw $e;
+        }
+    }
+
+    /**
+     * @param array<array{name: string, currentVersion: string}> $modulesInstalled
+     * @param array{incompatible_modules: string[], uncertain_modules: string[], compatibility: array<string, ?ModuleUpgradeCompatibility>} $checkResults
+     */
+    private function renderDetailedTable(OutputInterface $output, array $modulesInstalled, array $checkResults): void
+    {
+        $output->writeln('Result:');
+
+        $table = new Table($output);
+        $table->setHeaders([
+            'Module',
+            'Compatible',
+            'Update available',
+            'Local version',
+            'Update version available',
+        ]);
+
+        foreach ($modulesInstalled as $localModule) {
+            $localModuleName = $localModule['name'];
+            $localVersion = $localModule['currentVersion'];
+
+            $moduleCompatibility = $checkResults['compatibility'][$localModuleName];
+
+            if (!$moduleCompatibility) {
+                $table->addRow([
+                    $localModuleName,
+                    '<error>✗ Unable to retrieve module information</error>',
+                ]);
+                continue;
+            }
+
+            $table->addRow([
+                $localModuleName,
+                $moduleCompatibility->isCompatible() ? '✓ Yes' : '✗ No',
+                $moduleCompatibility->hasUpdateAvailable() ? '✓ Yes' : '✗ No',
+                $localVersion,
+                $moduleCompatibility->isCompatible() ? $moduleCompatibility->getCompatibleRelease()->productVersion : '-',
+            ]);
+        }
+        $table->render();
+    }
+
+    /**
+     * @param array{incompatible_modules: string[], uncertain_modules: string[], compatibility: array<string, ?ModuleUpgradeCompatibility>} $checkResults
+     */
+    private function renderLists(OutputInterface $output, array $checkResults, string $targetPsVersion): void
+    {
+        if (!empty($checkResults['incompatible_modules'])) {
+            $output->writeln("\t<error>✘</error> " . count($checkResults['incompatible_modules']) . ' incompatible modules');
+            $output->writeln("\t  These modules are known to be incompatible with PrestaShop $targetPsVersion. They will be uninstalled before updating the store:");
+            foreach ($checkResults['incompatible_modules'] as $module) {
+                $output->writeln("\t\t" . $module);
+            }
+        }
+
+        if (!empty($checkResults['uncertain_modules'])) {
+            $output->writeln("\t<warning>⚠</warning> " . count($checkResults['uncertain_modules']) . ' uncertain modules');
+            $output->writeln("\t  The compatibility of the following modules with the destination version of PrestaShop cannot be checked. It could be because they are homemade or have been unlisted from the Marketplace. Please review them via the Module Manager:");
+            foreach ($checkResults['uncertain_modules'] as $module) {
+                $output->writeln("\t\t" . $module);
+            }
         }
     }
 }

--- a/classes/Commands/CheckModulesCommand.php
+++ b/classes/Commands/CheckModulesCommand.php
@@ -24,6 +24,7 @@ namespace PrestaShop\Module\AutoUpgrade\Commands;
 use Exception;
 use PrestaShop\Module\AutoUpgrade\Models\Module\Marketplace\ModuleUpgradeCompatibility;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
+use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeFileNames;
 use PrestaShop\Module\AutoUpgrade\Task\ExitCode;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 use Symfony\Component\Console\Helper\ProgressIndicator;
@@ -42,6 +43,7 @@ class CheckModulesCommand extends AbstractCommand
     {
         $this
             ->setDescription('Check module compatibility and updates.')
+            ->addOption('config-file-path', null, InputOption::VALUE_REQUIRED, 'Configuration file location for update.')
             ->addOption(
                 'channel',
                 null,
@@ -49,6 +51,7 @@ class CheckModulesCommand extends AbstractCommand
                 "Select which update channel to use ('" . UpgradeConfiguration::CHANNEL_LOCAL . "' / '" . UpgradeConfiguration::CHANNEL_ONLINE_RECOMMENDED . "' / '" . UpgradeConfiguration::CHANNEL_ONLINE . "')"
             )
             ->addOption('zip', null, InputOption::VALUE_REQUIRED, 'Sets the archive zip file for a local channel.')
+            ->addOption('xml', null, InputOption::VALUE_REQUIRED, 'Sets the archive xml file for a local update.')
             ->setHelp('This command checks the installed modules for compatibility with the target PrestaShop version and lists available updates.')
             ->addArgument(
                 'admin-dir',
@@ -61,39 +64,36 @@ class CheckModulesCommand extends AbstractCommand
     {
         try {
             $this->setupEnvironment($input, $output);
+            $this->upgradeContainer->getFileStorage()->clean(UpgradeFileNames::UPDATE_CONFIG_FILENAME);
 
-            $zip = $input->getOption('zip');
-            $channel = $input->getOption('channel');
-
-            if (!$channel) {
-                if ($zip) {
-                    $config[UpgradeConfiguration::CHANNEL] = UpgradeConfiguration::CHANNEL_LOCAL;
-                } else {
-                    $config[UpgradeConfiguration::CHANNEL] = UpgradeConfiguration::CHANNEL_ONLINE_RECOMMENDED;
+            $options = [
+                UpgradeConfiguration::ARCHIVE_ZIP => 'zip',
+                UpgradeConfiguration::ARCHIVE_XML => 'xml',
+                UpgradeConfiguration::CHANNEL => 'channel',
+            ];
+            foreach ($options as $configKey => $optionName) {
+                $optionValue = $input->getOption($optionName);
+                if ($optionValue !== null) {
+                    $this->consoleInputConfiguration[$configKey] = $optionValue;
                 }
-            } else {
-                $config[UpgradeConfiguration::CHANNEL] = $channel;
             }
 
-            if ($zip) {
-                $config[UpgradeConfiguration::ARCHIVE_ZIP] = $zip;
+            $configPath = $input->getOption('config-file-path');
+            $exitCode = $this->loadConfiguration($configPath);
+            if ($exitCode !== ExitCode::SUCCESS) {
+                return $exitCode;
             }
-
-            $errors = $this->upgradeContainer->getConfigurationValidator()->validate($config);
-
-            if (!empty($errors)) {
-                $output->writeln('<error> ✗ ' . reset($errors)['message'] . '</error>');
-
-                return ExitCode::FAIL;
-            }
+            $this->logger->debug('Configuration loaded successfully.');
 
             $this->upgradeContainer->initPrestaShopAutoloader();
             $this->upgradeContainer->initPrestaShopCore();
-            $channel = $config[UpgradeConfiguration::CHANNEL];
+            $config = $this->upgradeContainer->getUpdateConfiguration();
+            $channel = $config->getChannelOrDefault();
 
             if ($channel === UpgradeConfiguration::CHANNEL_ONLINE_RECOMMENDED || $channel === UpgradeConfiguration::CHANNEL_ONLINE) {
                 $targetPsVersion = $this->upgradeContainer->getUpgrader()->getOnlineDestinationVersionForChannel($channel);
             } else {
+                $zip = $config->getChannelZip();
                 if (empty($zip)) {
                     $output->writeln('<error> ✗ Please specify the destination zip file using the zip option..</error>');
 

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -29,6 +29,7 @@ use PrestaShop\Module\AutoUpgrade\Commands\CheckModulesCommand;
 use PrestaShop\Module\AutoUpgrade\Exceptions\DistributionApiException;
 use PrestaShop\Module\AutoUpgrade\Exceptions\MarketplaceApiException;
 use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
+use PrestaShop\Module\AutoUpgrade\Models\Module\Marketplace\ModuleUpgradeCompatibility;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\Router\Routes;
 use PrestaShop\Module\AutoUpgrade\Services\MarketplaceService;
@@ -786,19 +787,21 @@ class UpgradeSelfCheck
     /**
      * @param self::*_SEARCH $mode
      *
-     * @return array{incompatible_modules: string[], uncertain_modules: string[]}
+     * @return array{incompatible_modules: string[], uncertain_modules: string[], compatibility: array<string, ?ModuleUpgradeCompatibility>}
      */
     public function getModulesRequiringAttention($mode = self::COMPLETE_SEARCH): array
     {
         $result = [
             'incompatible_modules' => [],
             'uncertain_modules' => [],
+            'compatibility_details' => [],
         ];
         $modulesInstalled = $this->moduleAdapter->listModulesPresentInFolderAndInstalled();
 
         foreach ($modulesInstalled as $localModule) {
             $localModuleName = $localModule['name'];
             $localVersion = $localModule['currentVersion'];
+            $result['compatibility'][$localModuleName] = null;
 
             try {
                 $moduleDetails = $this->marketplaceService->getModuleDetail($localModuleName);
@@ -815,6 +818,8 @@ class UpgradeSelfCheck
                 $this->destinationVersion,
                 $localVersion
             );
+
+            $result['compatibility'][$localModuleName] = $moduleCompatibility;
 
             if (!$moduleCompatibility->isCompatible()) {
                 $result['incompatible_modules'][] = $localModule['name'];


### PR DESCRIPTION
~:warning: This PR requires #1699 to be merged first.~

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The command `update:check-modules` introduced on Update Assistant 7.5 shows raw data about module updates found on the Marketplace. The existing table is now visible in verbose mode, while the command now focuses to show what are the incompatible and/or modules with uncertain compatibility. This aligns the feature with the requirements update in #1699 
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Data displayed on the web is the same as the CLI command, and is updated accordingly to the destination version of PrestaShop.

### Result in regular mode

```
bin/console update:check-modules admin-dev
Prestashop version: 8.2.4
 - Retrieving modules informations, please wait...WARNING - /var/www/html/modules/autoupgrade/classes/Services/MarketplaceService.php line 51 - file_get_contents(https://api.addons.prestashop.com/v2/products/test_module_40410): Failed to open stream: HTTP request failed! HTTP/1.1 400 Bad Request

 - Retrieving modules informations: Done.
	✘ 4 incompatible modules
	  These modules are known to be incompatible with PrestaShop 8.2.4. They will be uninstalled before updating the store:
		contactform
		psgdpr
		ps_themecusto
		statsdata
	⚠ 1 uncertain modules
	  The compatibility of the following modules with the destination version of PrestaShop cannot be checked. It could be because they are homemade or have been unlisted from the Marketplace. Please review them via the Module Manager:
		test_module_40410

```

### Result with verbose mode

```
www-data@cfe59af7a3a9:~/html/modules/autoupgrade$ bin/console -v update:check-modules admin-dev
DEBUG - Production root directory: /var/www/html/modules/autoupgrade/bin/../../..
DEBUG - Admin directory: /var/www/html/modules/autoupgrade/bin/../../../admin-dev
DEBUG - Update container initialized.
DEBUG - Logger initialized: PrestaShop\Module\AutoUpgrade\Log\CliLogger
DEBUG - Error handler enabled.
Prestashop version: 8.2.4
 - Retrieving modules informations, please wait... (< 1 sec)WARNING - /var/www/html/modules/autoupgrade/classes/Services/MarketplaceService.php line 51 - file_get_contents(https://api.addons.prestashop.com/v2/products/test_module_40410): Failed to open stream: HTTP request failed! HTTP/1.1 400 Bad Request

 - Retrieving modules informations: Done. (13 secs)
Result:
+--------------------------+-----------------------------------------+------------------+---------------+--------------------------+
| Module                   | Compatible                              | Update available | Local version | Update version available |
+--------------------------+-----------------------------------------+------------------+---------------+--------------------------+
| blockreassurance         | ✓ Yes                                   | ✓ Yes            | 5.1.2         | 5.1.4                    |
| blockwishlist            | ✓ Yes                                   | ✓ Yes            | 2.1.2         | 3.0.2                    |
| contactform              | ✗ No                                    | ✗ No             | 4.4.1         | -                        |
| dashactivity             | ✓ Yes                                   | ✓ Yes            | 2.1.0         | 2.1.1                    |
| dashgoals                | ✓ Yes                                   | ✓ Yes            | 2.0.3         | 2.0.4                    |
| dashproducts             | ✓ Yes                                   | ✓ Yes            | 2.1.3         | 2.2.1                    |
| dashtrends               | ✓ Yes                                   | ✓ Yes            | 2.1.0         | 2.1.3                    |
| graphnvd3                | ✓ Yes                                   | ✗ No             | 2.0.3         | 2.0.3                    |
| gridhtml                 | ✓ Yes                                   | ✗ No             | 2.0.3         | 2.0.3                    |
| gsitemap                 | ✓ Yes                                   | ✓ Yes            | 4.2.1         | 5.0.0                    |
| pagesnotfound            | ✓ Yes                                   | ✓ Yes            | 2.0.2         | 3.0.0                    |
| productcomments          | ✓ Yes                                   | ✓ Yes            | 5.0.3         | 6.0.2                    |
| psgdpr                   | ✗ No                                    | ✗ No             | 1.4.3         | -                        |
| ps_banner                | ✓ Yes                                   | ✗ No             | 2.1.2         | 2.1.2                    |
| ps_bestsellers           | ✓ Yes                                   | ✓ Yes            | 1.0.6         | 1.0.7                    |
| ps_brandlist             | ✓ Yes                                   | ✗ No             | 1.0.3         | 1.0.3                    |
| ps_cashondelivery        | ✓ Yes                                   | ✗ No             | 2.0.1         | 2.0.1                    |
| ps_categoryproducts      | ✓ Yes                                   | ✓ Yes            | 1.0.7         | 1.0.8                    |
| ps_categorytree          | ✓ Yes                                   | ✓ Yes            | 2.0.2         | 3.0.2                    |
| ps_checkpayment          | ✓ Yes                                   | ✓ Yes            | 2.0.6         | 2.1.0                    |
| ps_contactinfo           | ✓ Yes                                   | ✓ Yes            | 3.3.2         | 3.3.3                    |
| ps_crossselling          | ✓ Yes                                   | ✓ Yes            | 2.0.2         | 2.0.3                    |
| ps_currencyselector      | ✓ Yes                                   | ✗ No             | 2.1.1         | 2.1.1                    |
| ps_customeraccountlinks  | ✓ Yes                                   | ✗ No             | 3.2.0         | 3.2.0                    |
| ps_customersignin        | ✓ Yes                                   | ✗ No             | 2.0.5         | 2.0.5                    |
| ps_customtext            | ✓ Yes                                   | ✓ Yes            | 4.2.1         | 4.2.2                    |
| ps_dataprivacy           | ✓ Yes                                   | ✗ No             | 2.1.1         | 2.1.1                    |
| ps_distributionapiclient | ✓ Yes                                   | ✓ Yes            | 1.1.0         | 2.1.0                    |
| ps_emailalerts           | ✓ Yes                                   | ✓ Yes            | 2.3.3         | 3.0.1                    |
| ps_emailsubscription     | ✓ Yes                                   | ✓ Yes            | 2.7.1         | 2.8.3                    |
| ps_facetedsearch         | ✓ Yes                                   | ✓ Yes            | 3.12.1        | 4.0.1                    |
| ps_faviconnotificationbo | ✓ Yes                                   | ✗ No             | 2.1.3         | 2.1.3                    |
| ps_featuredproducts      | ✓ Yes                                   | ✓ Yes            | 2.1.4         | 2.1.6                    |
| ps_googleanalytics       | ✓ Yes                                   | ✓ Yes            | 4.2.1         | 5.0.3                    |
| ps_imageslider           | ✓ Yes                                   | ✓ Yes            | 3.1.2         | 3.2.2                    |
| ps_languageselector      | ✓ Yes                                   | ✗ No             | 2.1.3         | 2.1.3                    |
| ps_linklist              | ✓ Yes                                   | ✓ Yes            | 5.0.5         | 7.0.1                    |
| ps_mainmenu              | ✓ Yes                                   | ✓ Yes            | 2.3.2         | 2.3.6                    |
| ps_newproducts           | ✓ Yes                                   | ✓ Yes            | 1.0.4         | 1.0.5                    |
| ps_searchbar             | ✓ Yes                                   | ✓ Yes            | 2.1.3         | 2.1.4                    |
| ps_sharebuttons          | ✓ Yes                                   | ✓ Yes            | 2.1.2         | 2.1.3                    |
| ps_shoppingcart          | ✓ Yes                                   | ✓ Yes            | 2.0.7         | 3.0.0                    |
| ps_socialfollow          | ✓ Yes                                   | ✓ Yes            | 2.3.0         | 2.3.3                    |
| ps_specials              | ✓ Yes                                   | ✓ Yes            | 1.0.2         | 1.0.3                    |
| ps_supplierlist          | ✓ Yes                                   | ✗ No             | 1.0.6         | 1.0.6                    |
| ps_themecusto            | ✗ No                                    | ✗ No             | 1.2.2         | -                        |
| ps_viewedproduct         | ✓ Yes                                   | ✓ Yes            | 1.2.4         | 1.2.5                    |
| ps_wirepayment           | ✓ Yes                                   | ✓ Yes            | 2.1.3         | 2.2.1                    |
| statsbestcategories      | ✓ Yes                                   | ✓ Yes            | 2.0.1         | 2.1.0                    |
| statsbestcustomers       | ✓ Yes                                   | ✓ Yes            | 2.0.4         | 2.1.0                    |
| statsbestmanufacturers   | ✓ Yes                                   | ✓ Yes            | 2.0.3         | 2.0.4                    |
| statsbestproducts        | ✓ Yes                                   | ✗ No             | 2.0.1         | 2.0.1                    |
| statsbestsuppliers       | ✓ Yes                                   | ✗ No             | 2.0.2         | 2.0.2                    |
| statsbestvouchers        | ✓ Yes                                   | ✗ No             | 2.0.1         | 2.0.1                    |
| statscarrier             | ✓ Yes                                   | ✗ No             | 2.0.1         | 2.0.1                    |
| statscatalog             | ✓ Yes                                   | ✓ Yes            | 2.0.3         | 2.0.4                    |
| statscheckup             | ✓ Yes                                   | ✓ Yes            | 2.0.2         | 2.0.3                    |
| statsdata                | ✗ No                                    | ✗ No             | 2.1.1         | -                        |
| statsforecast            | ✓ Yes                                   | ✗ No             | 2.0.4         | 2.0.4                    |
| statsnewsletter          | ✓ Yes                                   | ✗ No             | 2.0.3         | 2.0.3                    |
| statspersonalinfos       | ✓ Yes                                   | ✗ No             | 2.0.4         | 2.0.4                    |
| statsproduct             | ✓ Yes                                   | ✓ Yes            | 2.1.1         | 2.1.3                    |
| statsregistrations       | ✓ Yes                                   | ✗ No             | 2.0.1         | 2.0.1                    |
| statssales               | ✓ Yes                                   | ✗ No             | 2.1.0         | 2.1.0                    |
| statssearch              | ✓ Yes                                   | ✗ No             | 2.0.2         | 2.0.2                    |
| statsstock               | ✓ Yes                                   | ✗ No             | 2.0.1         | 2.0.1                    |
| test_module_40410        | ✗ Unable to retrieve module information |                  |               |                          |
+--------------------------+-----------------------------------------+------------------+---------------+--------------------------+
	✘ 4 incompatible modules
	  These modules are known to be incompatible with PrestaShop 8.2.4. They will be uninstalled before updating the store:
		contactform
		psgdpr
		ps_themecusto
		statsdata
	⚠ 1 uncertain modules
	  The compatibility of the following modules with the destination version of PrestaShop cannot be checked. It could be because they are homemade or have been unlisted from the Marketplace. Please review them via the Module Manager:
		test_module_40410
```