### PR TITLE
Fix opening of modals in requirements

### DIFF
--- a/_dev/src/ts/appUI/pages/RestorePageBackupSelection.ts
+++ b/_dev/src/ts/appUI/pages/RestorePageBackupSelection.ts
@@ -28,12 +28,12 @@ export default class RestorePageBackupSelection extends StepPage {
 
   public mount = () => {
     this.initStepper();
-    this.#form.addEventListener('change', this.#saveForm.bind(this));
+    this.#form.addEventListener('change', this.#saveForm);
     this.#form.addEventListener('submit', this.#handleSubmit);
   };
 
   public beforeDestroy = () => {
-    this.#form.removeEventListener('change', this.#saveForm.bind(this));
+    this.#form.removeEventListener('change', this.#saveForm);
     this.#form.removeEventListener('submit', this.#handleSubmit);
   };
 

--- a/_dev/src/ts/appUI/pages/UpdatePageVersionChoice.ts
+++ b/_dev/src/ts/appUI/pages/UpdatePageVersionChoice.ts
@@ -33,8 +33,9 @@ export default class UpdatePageVersionChoice extends StepPage {
     this.initStepper();
     if (!this.#form) return;
 
-    this.#form.addEventListener('change', this.#saveForm.bind(this));
+    this.#form.addEventListener('change', this.#saveForm);
     this.#form.addEventListener('submit', this.#handleSubmit);
+    this.#form.addEventListener('click', this.#onFormClick);
 
     this.#form.dispatchEvent(new Event('change'));
 
@@ -46,29 +47,20 @@ export default class UpdatePageVersionChoice extends StepPage {
     this.#localCardParent?.addEventListener(Hydration.hydrationEventName, this.#handleHydrate);
 
     this.#toggleNextButton();
-    this.#addListenerToCheckRequirementsAgainButtons();
   };
 
   public beforeDestroy = () => {
     if (!this.#form) return;
     this.#form.removeEventListener('change', this.#saveForm);
     this.#form.removeEventListener('submit', this.#handleSubmit);
-    this.#onlineCardParent?.removeEventListener(
-      Hydration.hydrationEventName,
-      this.#toggleNextButton
-    );
+    this.#form.removeEventListener('click', this.#onFormClick);
+
+    this.#onlineCardParent?.removeEventListener(Hydration.hydrationEventName, this.#handleHydrate);
     this.#onlineRecommendedCardParent?.removeEventListener(
       Hydration.hydrationEventName,
-      this.#toggleNextButton
+      this.#handleHydrate
     );
-    this.#localCardParent?.removeEventListener(
-      Hydration.hydrationEventName,
-      this.#toggleNextButton
-    );
-    this.#checkRequirementsAgainButtons?.forEach((element) => {
-      element.removeEventListener('click', this.#saveForm);
-    });
-    this.#requirementsListContainer?.removeEventListener('click', this.#onClickDialogLink);
+    this.#localCardParent?.removeEventListener(Hydration.hydrationEventName, this.#handleHydrate);
   };
 
   #sendForm = async (routeToSend: string) => {
@@ -76,16 +68,20 @@ export default class UpdatePageVersionChoice extends StepPage {
     await api.post(routeToSend, formData);
   };
 
-  #addListenerToCheckRequirementsAgainButtons = () => {
-    if (this.#checkRequirementsAgainButtons?.length) {
-      this.#checkRequirementsAgainButtons.forEach((element) => {
-        element.addEventListener('click', this.#saveForm);
-      });
-    }
-  };
+  readonly #onFormClick = (event: MouseEvent) => {
+    const target = event.target as HTMLElement;
 
-  #addListenerToRequirementsLinks = () => {
-    this.#requirementsListContainer?.addEventListener('click', this.#onClickDialogLink);
+    // Delegate links with additional contents to display
+    if (target.tagName === 'A' && (target as HTMLAnchorElement).hash) {
+      this.#onClickDialogLink(event);
+      return;
+    }
+
+    // Delegate "Check requirements again" button
+    const button = target.closest('button[data-action="check-requirements-again"]');
+    if (button) {
+      this.#saveForm();
+    }
   };
 
   #onClickDialogLink = async (event: MouseEvent) => {
@@ -104,8 +100,6 @@ export default class UpdatePageVersionChoice extends StepPage {
 
   #handleHydrate = () => {
     this.#toggleNextButton();
-    this.#addListenerToCheckRequirementsAgainButtons();
-    this.#addListenerToRequirementsLinks();
   };
 
   #toggleNextButton = () => {
@@ -190,20 +184,6 @@ export default class UpdatePageVersionChoice extends StepPage {
       return this.#localInputElement!.dataset.requirementsAreOk === '1';
     }
     return false;
-  }
-
-  get #requirementsListContainer(): HTMLDivElement | null | undefined {
-    return this.#form?.querySelector('[data-slot-component="requirements"]');
-  }
-
-  get #checkRequirementsAgainButtons(): HTMLButtonElement[] | undefined {
-    return this.#form
-      ? (Array.from(this.#form.elements).filter(
-          (element): element is HTMLButtonElement =>
-            element instanceof HTMLButtonElement &&
-            element.dataset.action === 'check-requirements-again'
-        ) as HTMLButtonElement[])
-      : undefined;
   }
 
   // online option


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix opening of modals that were not working in some cases.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | See below

**How to reproduce:**
1. Use a PrestaShop installation where multiple versions are available in the "Version choice" step (e.g., PrestaShop 8.0.3 showing 8.2.4 and 9.0.3).
2. Go to the "Version choice" step.
3. Select the first version option (e.g., 8.2.4).
4. Refresh the browser page.
5. Select the second version option (e.g., 9.0.3).
6. Click on the link "See the list of changes" within the update requirements report.

**Non-regression tests:**
* Form of the selection of backups in the backup process