### PR TITLE
Show technical error details before generic error message

### DIFF
--- a/classes/Task/AbstractTask.php
+++ b/classes/Task/AbstractTask.php
@@ -165,6 +165,10 @@ abstract class AbstractTask
 
     protected function handleException(ProcessException $e): void
     {
+        foreach ($e->getQuickInfos() as $log) {
+            $this->logger->warning($log);
+        }
+
         if ($e->getSeverity() === ProcessException::SEVERITY_ERROR) {
             $this->next = TaskName::TASK_ERROR;
             $this->setErrorFlag();
@@ -173,10 +177,6 @@ abstract class AbstractTask
         if ($e->getSeverity() === ProcessException::SEVERITY_WARNING) {
             $this->logger->warning($e->getMessage());
             $this->container->getUpdateState()->setWarningDetected(true);
-        }
-
-        foreach ($e->getQuickInfos() as $log) {
-            $this->logger->warning($log);
         }
     }
 


### PR DESCRIPTION

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Show technical error details before generic error message to make logs easier to read (see images for before/after)
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | /
| Sponsor company   | @prestashopCorp
| How to test?      | Update from 1.7.8.9 to 8.2.4, PHP version 7.2.34
<img width="1066" height="338" alt="update-warning-error-before" src="https://github.com/user-attachments/assets/f5225679-096d-40fd-91d9-9394a4405078" title="Before" />

<img width="1057" height="331" alt="update-warning-error-after" src="https://github.com/user-attachments/assets/d586efce-83d5-4f35-b08b-79fbf46269dc" title="After" />

