### PR TITLE
Fix prevent mass uninstallation while updating to unreleased versions of PrestaShop

### DIFF
--- a/classes/State/UpdateState.php
+++ b/classes/State/UpdateState.php
@@ -43,6 +43,11 @@ class UpdateState extends AbstractState
     protected $destinationVersion;
 
     /**
+     * @var bool Determining if we can proceed to uninstall module step (only if destination version is know by Distribution API)
+     */
+    protected $skipUninstallModule = false;
+
+    /**
      * installedLanguagesIso is an array of iso_code of each installed languages.
      *
      * @var string[]
@@ -91,6 +96,19 @@ class UpdateState extends AbstractState
     public function setDestinationVersion(?string $destinationVersion): self
     {
         $this->destinationVersion = $destinationVersion;
+        $this->save();
+
+        return $this;
+    }
+
+    public function getSkipUninstallModule(): bool
+    {
+        return $this->skipUninstallModule;
+    }
+
+    public function setSkipUninstallModule(bool $skipUninstallModule): self
+    {
+        $this->skipUninstallModule = $skipUninstallModule;
         $this->save();
 
         return $this;

--- a/classes/Task/Update/UninstallModules.php
+++ b/classes/Task/Update/UninstallModules.php
@@ -108,6 +108,15 @@ class UninstallModules extends AbstractTask
      */
     private function warmUp(): int
     {
+        if ($this->container->getUpdateState()->getSkipUninstallModule()) {
+            $this->stepDone = true;
+            $this->status = 'ok';
+            $this->next = TaskName::TASK_UPDATE_FILES;
+            $this->logger->info($this->translator->trans('Since this version of PrestaShop is not an official release, the module compatibility check for uninstallation cannot be performed. Proceed to the next step.'));
+
+            return ExitCode::SUCCESS;
+        }
+
         $this->container->getUpdateState()->setProgressPercentage(
             $this->container->getCompletionCalculator()->getBasePercentageOfTask(self::class)
         );

--- a/classes/Task/Update/UninstallModules.php
+++ b/classes/Task/Update/UninstallModules.php
@@ -112,7 +112,7 @@ class UninstallModules extends AbstractTask
             $this->stepDone = true;
             $this->status = 'ok';
             $this->next = TaskName::TASK_UPDATE_FILES;
-            $this->logger->info($this->translator->trans('Since this version of PrestaShop is not an official release, the module compatibility check for uninstallation cannot be performed. Proceed to the next step.'));
+            $this->logger->info($this->translator->trans('Since this version of PrestaShop is not released to the public, the module compatibility check for uninstallation cannot be performed. Skipping to the next step.'));
 
             return ExitCode::SUCCESS;
         }

--- a/classes/Task/Update/UpdateInitialization.php
+++ b/classes/Task/Update/UpdateInitialization.php
@@ -23,6 +23,7 @@ namespace PrestaShop\Module\AutoUpgrade\Task\Update;
 
 use Exception;
 use PrestaShop\Module\AutoUpgrade\Analytics;
+use PrestaShop\Module\AutoUpgrade\Exceptions\DistributionApiException;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\Task\AbstractTask;
 use PrestaShop\Module\AutoUpgrade\Task\ExitCode;
@@ -46,12 +47,14 @@ class UpdateInitialization extends AbstractTask
         $this->logger->info($this->translator->trans('Starting update...'));
         $this->container->getFileStorage()->cleanAllUpdateFiles();
 
-        $this->container->getUpdateState()->initDefault(
+        $updateState = $this->container->getUpdateState();
+
+        $updateState->initDefault(
             $this->container->getProperty(UpgradeContainer::PS_VERSION),
             $this->container->getUpgrader(),
             $this->container->getUpdateConfiguration()
         );
-        $this->container->getUpdateState()->setProgressPercentage(
+        $updateState->setProgressPercentage(
             $this->container->getCompletionCalculator()->getBasePercentageOfTask(self::class)
         );
 
@@ -63,7 +66,19 @@ class UpdateInitialization extends AbstractTask
             return ExitCode::SUCCESS;
         }
 
-        $this->logger->info($this->translator->trans('Destination version: %s', [$this->container->getUpdateState()->getDestinationVersion()]));
+        $this->logger->info($this->translator->trans('Destination version: %s', [$updateState->getDestinationVersion()]));
+
+        /**
+         * We rely on a method that checks the PHP version required for our PrestaShop version to determine if it's an official release.
+         * (if the PrestaShop version isn't found, an error is thrown)
+         * If it's not the case, we disable module uninstallation because we can't properly check their compatibility.
+         */
+        try {
+            $this->container->getDistributionApiService()->getPhpVersionRequirements($updateState->getDestinationVersion());
+        } catch(DistributionApiException $e) {
+            $updateState->setSkipUninstallModule(true);
+        }
+
 
         switch ($this->container->getUpdateConfiguration()->getChannelOrDefault()) {
             case UpgradeConfiguration::CHANNEL_LOCAL:

--- a/classes/Task/Update/UpdateInitialization.php
+++ b/classes/Task/Update/UpdateInitialization.php
@@ -23,7 +23,6 @@ namespace PrestaShop\Module\AutoUpgrade\Task\Update;
 
 use Exception;
 use PrestaShop\Module\AutoUpgrade\Analytics;
-use PrestaShop\Module\AutoUpgrade\Exceptions\DistributionApiException;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\Services\PhpVersionResolverService;
 use PrestaShop\Module\AutoUpgrade\Task\AbstractTask;

--- a/classes/Task/Update/UpdateInitialization.php
+++ b/classes/Task/Update/UpdateInitialization.php
@@ -25,6 +25,7 @@ use Exception;
 use PrestaShop\Module\AutoUpgrade\Analytics;
 use PrestaShop\Module\AutoUpgrade\Exceptions\DistributionApiException;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
+use PrestaShop\Module\AutoUpgrade\Services\PhpVersionResolverService;
 use PrestaShop\Module\AutoUpgrade\Task\AbstractTask;
 use PrestaShop\Module\AutoUpgrade\Task\ExitCode;
 use PrestaShop\Module\AutoUpgrade\Task\TaskName;
@@ -66,19 +67,18 @@ class UpdateInitialization extends AbstractTask
             return ExitCode::SUCCESS;
         }
 
-        $this->logger->info($this->translator->trans('Destination version: %s', [$updateState->getDestinationVersion()]));
+        $destinationVersion = $updateState->getDestinationVersion();
+
+        $this->logger->info($this->translator->trans('Destination version: %s', [$destinationVersion]));
 
         /**
-         * We rely on a method that checks the PHP version required for our PrestaShop version to determine if it's an official release.
-         * (if the PrestaShop version isn't found, an error is thrown)
-         * If it's not the case, we disable module uninstallation because we can't properly check their compatibility.
+         * We use the same method as UpgradeSelfCheck to determine if the target version is known. If it isn't, we skip the uninstallation step (otherwise, it would cause a mass uninstallation of all modules that are not up to date).
          */
-        try {
-            $this->container->getDistributionApiService()->getPhpVersionRequirements($updateState->getDestinationVersion());
-        } catch(DistributionApiException $e) {
+        $phpRequirementsState = $this->container->getPhpVersionResolverService()->getPhpRequirementsState(PHP_VERSION_ID, $destinationVersion);
+
+        if ($phpRequirementsState === PhpVersionResolverService::COMPATIBILITY_UNKNOWN) {
             $updateState->setSkipUninstallModule(true);
         }
-
 
         switch ($this->container->getUpdateConfiguration()->getChannelOrDefault()) {
             case UpgradeConfiguration::CHANNEL_LOCAL:

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -225,7 +225,7 @@ class UpgradeSelfCheck
             $warnings[self::PHP_COMPATIBILITY_UNKNOWN] = $this->getPhpRequirementsState() === PhpVersionResolverService::COMPATIBILITY_UNKNOWN;
         }
 
-        if ($warnings[self::PHP_COMPATIBILITY_UNKNOWN]) {
+        if (!$warnings[self::PHP_COMPATIBILITY_UNKNOWN]) {
             $warnings[self::MODULES_REQUIRE_ATTENTION] = $this->checkModuleRequiresAttention();
         }
 

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -225,7 +225,7 @@ class UpgradeSelfCheck
             $warnings[self::PHP_COMPATIBILITY_UNKNOWN] = $this->getPhpRequirementsState() === PhpVersionResolverService::COMPATIBILITY_UNKNOWN;
         }
 
-        if($warnings[self::PHP_COMPATIBILITY_UNKNOWN]) {
+        if ($warnings[self::PHP_COMPATIBILITY_UNKNOWN]) {
             $warnings[self::MODULES_REQUIRE_ATTENTION] = $this->checkModuleRequiresAttention();
         }
 

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -215,7 +215,6 @@ class UpgradeSelfCheck
             self::DESTINATION_VERSION_IS_NOT_SUPPORTED => empty($this->getLatestCompatibleModuleVersion()),
             self::THEME_TEMPERED_FILES_LIST_NOT_EMPTY => $isThemeTemperedFileListNotEmpty,
             self::CORE_TEMPERED_FILES_LIST_NOT_EMPTY => $isCoreTemperedFileListNotEmpty,
-            self::MODULES_REQUIRE_ATTENTION => $this->checkModuleRequiresAttention(),
         ];
 
         if (!$warnings[self::DESTINATION_VERSION_IS_NOT_SUPPORTED]) {
@@ -224,6 +223,10 @@ class UpgradeSelfCheck
 
         if ($this->updateConfiguration->isChannelLocal()) {
             $warnings[self::PHP_COMPATIBILITY_UNKNOWN] = $this->getPhpRequirementsState() === PhpVersionResolverService::COMPATIBILITY_UNKNOWN;
+        }
+
+        if($warnings[self::PHP_COMPATIBILITY_UNKNOWN]) {
+            $warnings[self::MODULES_REQUIRE_ATTENTION] = $this->checkModuleRequiresAttention();
         }
 
         return array_filter($warnings);

--- a/tests/unit/State/UpdateStateTest.php
+++ b/tests/unit/State/UpdateStateTest.php
@@ -46,7 +46,7 @@ class UpdateStateTest extends TestCase
             'destinationVersion' => '9.0.0',
             'installedLanguagesIso' => [],
             'warningDetected' => false,
-
+            'skipUninstallModule' => false,
             'progressPercentage' => 20,
         ];
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When updating to a PrestaShop version that is not yet officially released (e.g., 9.2.0), the module uninstalls almost all modules (e.g., 73 modules) because they are not yet marked as compatible with the new version. This is destructive and often unnecessary for development/testing environments.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Internal ticket
| Sponsor company   | @PrestaShopCorp

**How to test?**
Run a local update using a PrestaShop 9.2.0 .zip archive and its corresponding XML file.

During the Pre-check step: Verify that no warnings related to modules are displayed.

During the Update process: Ensure the following message appears: `Since this version of PrestaShop is not released to the public, the module compatibility check for uninstallation cannot be performed. Skipping to the next step.`

Verify that no modules are prompted to be uninstalled.