### PR TITLE
fix: Clean configuration file for check-requirements-command

### DIFF
--- a/classes/Commands/CheckRequirementsCommand.php
+++ b/classes/Commands/CheckRequirementsCommand.php
@@ -25,6 +25,7 @@ use Exception;
 use PrestaShop\Module\AutoUpgrade\Exceptions\DistributionApiException;
 use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
+use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeFileNames;
 use PrestaShop\Module\AutoUpgrade\Task\ExitCode;
 use PrestaShop\Module\AutoUpgrade\UpgradeSelfCheck;
 use Symfony\Component\Console\Input\InputArgument;
@@ -59,6 +60,7 @@ class CheckRequirementsCommand extends AbstractCommand
     {
         try {
             $this->setupEnvironment($input, $output);
+            $this->upgradeContainer->getFileStorage()->clean(UpgradeFileNames::UPDATE_CONFIG_FILENAME);
             $this->output = $output;
 
             $options = [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Clean configuration file for check-requirements-command
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | https://github.com/PrestaShop/autoupgrade/issues/1714
| Sponsor company   | -
| How to test?      | -
