### PR TITLE
Try workflow autolabel on qa approve

### DIFF
--- a/.github/workflows/label-on-qa-approve.yml
+++ b/.github/workflows/label-on-qa-approve.yml
@@ -22,7 +22,7 @@ jobs:
             const prNumber = context.issue.number;
 
             try {
-              await github.rest.teams.getMembershipInOrg({
+              await github.rest.teams.getMembershipForUserInOrg({
                 org: org,
                 team_slug: team_slug,
                 username: username,

--- a/.github/workflows/label-on-qa-approve.yml
+++ b/.github/workflows/label-on-qa-approve.yml
@@ -21,6 +21,8 @@ jobs:
             const repo = context.repo.repo;
             const prNumber = context.issue.number;
 
+            console.log(`Checking if user "${username}" belongs to the team "${team_slug}"...`);
+
             try {
               await github.rest.teams.getMembershipForUserInOrg({
                 org: org,
@@ -28,6 +30,9 @@ jobs:
                 username: username,
               });
 
+              console.log(`Success: User "${username}" is a member of @${org}/${team_slug}.`);
+
+              // Handling 'waiting for QA' label removal
               try {
                 await github.rest.issues.removeLabel({
                   owner,
@@ -35,15 +40,25 @@ jobs:
                   issue_number: prNumber,
                   name: 'waiting for QA'
                 });
-              } catch (e) {}
+                console.log(`Label "waiting for QA" has been removed.`);
+              } catch (e) {
+                console.log(`Label "waiting for QA" was not found on PR #${prNumber}. Skipping removal.`);
+              }
 
+              // Handling 'QA ✓' label addition
               await github.rest.issues.addLabels({
                 owner,
                 repo,
                 issue_number: prNumber,
                 labels: ['QA ✓']
               });
+              console.log(`Label "QA ✓" has been successfully added.`);
 
             } catch (error) {
-              if (error.status !== 404) throw error;
+              if (error.status === 404) {
+                console.log(`Notice: User "${username}" is NOT a member of @${org}/${team_slug}. No action taken.`);
+              } else {
+                console.error(`Error occurred: ${error.message}`);
+                throw error;
+              }
             }

--- a/.github/workflows/label-on-qa-approve.yml
+++ b/.github/workflows/label-on-qa-approve.yml
@@ -15,7 +15,7 @@ jobs:
           github-token: ${{ secrets.JARVIS_TOKEN }}
           script: |
             const org = 'PrestaShop';
-            const team_slug = 'QA Functional';
+            const team_slug = 'qa-functional';
             const username = context.payload.review.user.login;
             const owner = context.repo.owner;
             const repo = context.repo.repo;

--- a/.github/workflows/label-on-qa-approve.yml
+++ b/.github/workflows/label-on-qa-approve.yml
@@ -50,7 +50,7 @@ jobs:
                 owner,
                 repo,
                 issue_number: prNumber,
-                labels: ['QA ✓']
+                labels: ['QA ✔️']
               });
               console.log(`Label "QA ✓" has been successfully added.`);
 

--- a/.github/workflows/label-on-qa-approve.yml
+++ b/.github/workflows/label-on-qa-approve.yml
@@ -1,0 +1,49 @@
+name: "Autolabel on QA approve"
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  update-labels:
+    if: github.event.review.state == 'approved'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Team Membership and Update Labels
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.JARVIS_TOKEN }}
+          script: |
+            const org = 'PrestaShop';
+            const team_slug = 'QA Functional';
+            const username = context.payload.review.user.login;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = context.issue.number;
+
+            try {
+              await github.rest.teams.getMembershipInOrg({
+                org: org,
+                team_slug: team_slug,
+                username: username,
+              });
+
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: prNumber,
+                  name: 'waiting for QA'
+                });
+              } catch (e) {}
+
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: prNumber,
+                labels: ['QA ✓']
+              });
+
+            } catch (error) {
+              if (error.status !== 404) throw error;
+            }


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Try workflow autolabel on qa approve
| Type?             | github / improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | @PrestaShopCorp
| How to test?      | Open a PR, waiting for a QA to approuve it, if label switch from 'waiting for QA' to 'QA ✓ ' it work !
