### PR TITLE
Add messages when no action is required or when the PrestaShop given version is not released yet

### DIFF
--- a/classes/Commands/CheckModulesCommand.php
+++ b/classes/Commands/CheckModulesCommand.php
@@ -25,6 +25,7 @@ use Exception;
 use PrestaShop\Module\AutoUpgrade\Models\Module\Marketplace\ModuleUpgradeCompatibility;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeFileNames;
+use PrestaShop\Module\AutoUpgrade\Services\PhpVersionResolverService;
 use PrestaShop\Module\AutoUpgrade\Task\ExitCode;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
 use Symfony\Component\Console\Helper\ProgressIndicator;
@@ -119,6 +120,12 @@ class CheckModulesCommand extends AbstractCommand
             $modulesInstalled = $this->upgradeContainer->getModuleAdapter()->listModulesPresentInFolderAndInstalled();
             $updateSelfCheck = $this->upgradeContainer->getUpgradeSelfCheck();
 
+            if ($config->isChannelLocal() && $updateSelfCheck->getPhpRequirementsState() === PhpVersionResolverService::COMPATIBILITY_UNKNOWN) {
+                $output->writeln('<error> ✗ The compatibility of the modules can\'t be checked with a version of PrestaShop that is not released yet.</error>');
+
+                return ExitCode::FAIL;
+            }
+
             if (!empty($modulesInstalled)) {
                 $progressIndicator = new ProgressIndicator($output);
                 $output->writeln(sprintf('Prestashop version: %s', $targetPsVersion));
@@ -201,6 +208,10 @@ class CheckModulesCommand extends AbstractCommand
             foreach ($checkResults['uncertain_modules'] as $module) {
                 $output->writeln("\t\t" . $module);
             }
+        }
+
+        if (empty($checkResults['incompatible_modules']) && empty($checkResults['uncertain_modules'])) {
+            $output->writeln('<success>✔</success> There is no action needed on the installed modules for this update.');
         }
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | We add messages in the command `update:check-modules` that cover the cases where the command is not supposed to be called (the command `update:check-requirements` did not suggest to call it) 
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShop
| How to test?      | <ul><li>Use the local channel with a PrestaShop version that is not released: You must get an error and the process must stop before checking the modules</li><li>Uninstall all the modules requiring your attention then rerun the command: A success message saying everything is fine must appear"

## No required action

```
$ bin/console update:check-modules --zip=2026-02-23-9.1.x-prestashop_9.1.0.zip --xml=2026-02-23-9.1.x-prestashop_9.1.0.xml admin-dev

INFO - Update process will use archive.
INFO - Configuration successfully updated.
 ✗ The compatibility of the modules can't be checked with a version of PrestaShop that is not released yet.
```

## Unknown PrestaShop version

```
$ bin/console update:check-modules admin-dev

Prestashop version: 8.2.4
 - Retrieving modules informations, please wait...WARNING - /var/www/html/modules/autoupgrade/classes/Services/MarketplaceService.php line 49 - file_get_contents(https://api.addons.prestashop.com/v2/products/gamification): Failed to open stream: HTTP request failed! HTTP/1.1 422 Unprocessable Entity

 - Retrieving modules informations: Done.
✔ There is no action needed on the installed modules for this update.
```