### PR TITLE
Update the post-update page following the changes of Update Assistant 7.6

### DIFF
--- a/views/templates/steps/post-update.html.twig
+++ b/views/templates/steps/post-update.html.twig
@@ -45,9 +45,11 @@
           })|raw }}
         </li>
         <li>
-          {{ '%startbold%Re-enable and check your modules%endbold% one by one to prevent any compatibility issue.'|trans({
+          {{ '%startbold%Check the %startlink%Module Manager%endlink%%endbold% and re-enable the modules%endbold% that have been disabled to prevent any compatibility issue.'|trans({
             '%startbold%': '<b>',
-            '%endbold%': '</b>'
+            '%endbold%': '</b>',
+            '%startlink%': '<a id="dialog-confirm-module-manager-link" class="link" href="#' ~ form_route_to_confirm_module_manager_dialog ~ '">',
+            '%endlink%': '</a>'
           })|raw }}
         </li>
         <li>
@@ -63,11 +65,10 @@
           })|raw }}
         </li>
         <li>
-          {{ '%startbold%Check the %startlink%Module Manager%endlink%%endbold% to discover and install the modules extracted on your server during the update process.'|trans({
+          {{ '%startbold%Review the state of your modules:%endbold% compatible modules have been updated automatically, while incompatible ones with PrestaShop %version% have been uninstalled.'|trans({
             '%startbold%': '<b>',
             '%endbold%': '</b>',
-            '%startlink%': '<a id="dialog-confirm-module-manager-link" class="link" href="#' ~ form_route_to_confirm_module_manager_dialog ~ '">',
-            '%endlink%': '</a>'
+            '%version%': ps_version
           })|raw }}
         </li>
       </ul>

--- a/views/templates/steps/post-update.html.twig
+++ b/views/templates/steps/post-update.html.twig
@@ -45,7 +45,7 @@
           })|raw }}
         </li>
         <li>
-          {{ '%startbold%Check the %startlink%Module Manager%endlink%%endbold% and re-enable the modules%endbold% that have been disabled to prevent any compatibility issue.'|trans({
+          {{ '%startbold%Check the %startlink%Module Manager%endlink%%endbold% and re-enable the modules that have been disabled to prevent any compatibility issue.'|trans({
             '%startbold%': '<b>',
             '%endbold%': '</b>',
             '%startlink%': '<a id="dialog-confirm-module-manager-link" class="link" href="#' ~ form_route_to_confirm_module_manager_dialog ~ '">',

--- a/views/templates/steps/post-update.html.twig
+++ b/views/templates/steps/post-update.html.twig
@@ -45,7 +45,7 @@
           })|raw }}
         </li>
         <li>
-          {{ '%startbold%Check the %startlink%Module Manager%endlink%%endbold% and re-enable the modules that have been disabled to prevent any compatibility issue.'|trans({
+          {{ '%startbold%Check the %startlink%Module Manager%endlink%%endbold% and re-enable any modules disabled due to migration issues.'|trans({
             '%startbold%': '<b>',
             '%endbold%': '</b>',
             '%startlink%': '<a id="dialog-confirm-module-manager-link" class="link" href="#' ~ form_route_to_confirm_module_manager_dialog ~ '">',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Update the post-update page to reflect the changes on the incoming version.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | The static contents is updated, the link to the module manager still works and the target PrestaShop version is properly displayed.

## Solved issues:

* With the progressive removal of the disable non-native modules, the modules are only disabled if an issue occured during their update. The wording reflects this slight change.
* The incoming version of Update Assistant does not copy anymore the modules that are not installed.
* The incoming version uninstall modules that are not compatible, and the post update page does not show this action.



