### PR TITLE
Improve performance of getModulesRequiringAttention with parallel HTTP calls

### DIFF
--- a/classes/Services/MarketplaceService.php
+++ b/classes/Services/MarketplaceService.php
@@ -31,6 +31,9 @@ class MarketplaceService
     /** @var Translator */
     private $translator;
 
+    /** @var array<string, Module|MarketplaceApiException> */
+    private array $cache = [];
+
     const ADDONS_API_URL = 'https://api.addons.prestashop.com';
 
     /**
@@ -42,23 +45,120 @@ class MarketplaceService
     }
 
     /**
+     * Fetches raw response bodies for multiple modules.
+     * Returns a map of module name => response body string, or false on failure.
+     *
+     * @param string[] $toFetch
+     *
+     * @return array<string, string|false>
+     */
+    protected function fetchModulesRaw(array $toFetch): array
+    {
+        $multiHandle = curl_multi_init();
+        $handles = [];
+
+        foreach ($toFetch as $name) {
+            $ch = curl_init(self::ADDONS_API_URL . '/v2/products/' . $name);
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($ch, CURLOPT_TIMEOUT, 10);
+            curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+            curl_multi_add_handle($multiHandle, $ch);
+            $handles[$name] = $ch;
+        }
+
+        $running = 0;
+        do {
+            curl_multi_exec($multiHandle, $running);
+            if ($running > 0 && curl_multi_select($multiHandle, 1.0) === -1) {
+                usleep(100);
+            }
+        } while ($running > 0);
+
+        $raw = [];
+        foreach ($handles as $name => $ch) {
+            $body = curl_multi_getcontent($ch);
+            $errno = curl_errno($ch);
+            curl_multi_remove_handle($multiHandle, $ch);
+            curl_close($ch);
+            $raw[$name] = ($errno || $body === null) ? false : $body;
+        }
+
+        curl_multi_close($multiHandle);
+
+        return $raw;
+    }
+
+    /**
+     * Fetches details for multiple modules in parallel via curl_multi.
+     * Returns a map of module name => Module on success, or MarketplaceApiException on failure.
+     *
+     * @param string[] $moduleNames
+     *
+     * @return array<string, Module|MarketplaceApiException>
+     */
+    public function getModuleDetails(array $moduleNames): array
+    {
+        $toFetch = [];
+        $result = [];
+
+        foreach ($moduleNames as $name) {
+            if (isset($this->cache[$name])) {
+                $result[$name] = $this->cache[$name];
+            } else {
+                $toFetch[] = $name;
+            }
+        }
+
+        if (empty($toFetch)) {
+            return $result;
+        }
+
+        $raw = $this->fetchModulesRaw($toFetch);
+
+        // Ensure every requested name gets a result, even if fetchModulesRaw omits it.
+        foreach ($toFetch as $name) {
+            if (!array_key_exists($name, $raw)) {
+                $raw[$name] = false;
+            }
+        }
+
+        foreach ($raw as $name => $body) {
+            if (!$body) {
+                $value = new MarketplaceApiException(
+                    $this->translator->trans('Error when retrieving data from Marketplace API'),
+                    MarketplaceApiException::API_NOT_CALLABLE_CODE
+                );
+            } else {
+                $data = json_decode($body, true);
+                if (!$data || !is_array($data)) {
+                    $value = new MarketplaceApiException(
+                        $this->translator->trans('Unable to retrieve module %s information. Ignored.', [$name]),
+                        MarketplaceApiException::EMPTY_DATA_CODE
+                    );
+                } else {
+                    $value = Module::fromArray($data);
+                }
+            }
+
+            $this->cache[$name] = $value;
+            $result[$name] = $value;
+        }
+
+        return $result;
+    }
+
+    /**
      * @throws MarketplaceApiException
      */
     public function getModuleDetail(string $module): Module
     {
-        $response = file_get_contents(self::ADDONS_API_URL . '/v2/products/' . $module);
-
-        if (!$response) {
-            throw new MarketplaceApiException($this->translator->trans('Error when retrieving data from Marketplace API'), MarketplaceApiException::API_NOT_CALLABLE_CODE);
+        $results = $this->getModuleDetails([$module]);
+        $value = $results[$module];
+        if ($value instanceof MarketplaceApiException) {
+            throw $value;
         }
 
-        $data = json_decode($response, true);
-
-        if (!$data || !is_array($data)) {
-            throw new MarketplaceApiException($this->translator->trans('Unable to retrieve module %s information. Ignored.', [$module]), MarketplaceApiException::EMPTY_DATA_CODE);
-        }
-
-        return Module::fromArray($data);
+        return $value;
     }
 
     /**

--- a/classes/Services/MarketplaceService.php
+++ b/classes/Services/MarketplaceService.php
@@ -116,11 +116,7 @@ class MarketplaceService
         $raw = $this->fetchModulesRaw($toFetch);
 
         // Ensure every requested name gets a result, even if fetchModulesRaw omits it.
-        foreach ($toFetch as $name) {
-            if (!array_key_exists($name, $raw)) {
-                $raw[$name] = false;
-            }
-        }
+        $raw += array_fill_keys($toFetch, false);
 
         foreach ($raw as $name => $body) {
             if (!$body) {

--- a/classes/Services/MarketplaceService.php
+++ b/classes/Services/MarketplaceService.php
@@ -32,7 +32,7 @@ class MarketplaceService
     private $translator;
 
     /** @var array<string, Module|MarketplaceApiException> */
-    private array $cache = [];
+    private $cache = [];
 
     const ADDONS_API_URL = 'https://api.addons.prestashop.com';
 

--- a/classes/Task/Update/UninstallModules.php
+++ b/classes/Task/Update/UninstallModules.php
@@ -138,24 +138,27 @@ class UninstallModules extends AbstractTask
 
             $marketPlaceService = $this->container->getMarketplaceService();
 
+            $moduleNames = array_column($modulesList, 'name');
+            $moduleDetailsMap = $marketPlaceService->getModuleDetails($moduleNames);
+
             $modulesToUninstallList = [];
 
             foreach ($modulesList as $module) {
-                try {
-                    $moduleDetails = $marketPlaceService->getModuleDetail($module['name']);
-
-                    $moduleCompatibility = $marketPlaceService->findCompatibleModuleUpgrade(
-                        $moduleDetails,
-                        $targetVersion,
-                        $module['currentVersion']
-                    );
-
-                    if (!$moduleCompatibility->isCompatible()) {
-                        $modulesToUninstallList[] = $module['name'];
-                    }
-                } catch (MarketplaceApiException $e) {
-                    $this->logger->warning($e);
+                $moduleDetails = $moduleDetailsMap[$module['name']];
+                if ($moduleDetails instanceof MarketplaceApiException) {
+                    $this->logger->warning($moduleDetails);
                     $this->container->getUpdateState()->setWarningDetected(true);
+                    continue;
+                }
+
+                $moduleCompatibility = $marketPlaceService->findCompatibleModuleUpgrade(
+                    $moduleDetails,
+                    $targetVersion,
+                    $module['currentVersion']
+                );
+
+                if (!$moduleCompatibility->isCompatible()) {
+                    $modulesToUninstallList[] = $module['name'];
                 }
             }
 

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -798,21 +798,24 @@ class UpgradeSelfCheck
         ];
         $modulesInstalled = $this->moduleAdapter->listModulesPresentInFolderAndInstalled();
 
+        $moduleNames = array_column($modulesInstalled, 'name');
+        $moduleDetailsMap = $this->marketplaceService->getModuleDetails($moduleNames);
+
         foreach ($modulesInstalled as $localModule) {
             $localModuleName = $localModule['name'];
             $localVersion = $localModule['currentVersion'];
             $result['compatibility'][$localModuleName] = null;
 
-            try {
-                $moduleDetails = $this->marketplaceService->getModuleDetail($localModuleName);
-            } catch (MarketplaceApiException $e) {
-                $result['uncertain_modules'][] = $localModule['name'];
+            $moduleDetails = $moduleDetailsMap[$localModuleName];
+            if ($moduleDetails instanceof MarketplaceApiException) {
+                $result['uncertain_modules'][] = $localModuleName;
 
                 if ($mode === self::QUICK_SEARCH) {
                     return $result;
                 }
                 continue;
             }
+
             $moduleCompatibility = $this->marketplaceService->findCompatibleModuleUpgrade(
                 $moduleDetails,
                 $this->destinationVersion,
@@ -822,7 +825,7 @@ class UpgradeSelfCheck
             $result['compatibility'][$localModuleName] = $moduleCompatibility;
 
             if (!$moduleCompatibility->isCompatible()) {
-                $result['incompatible_modules'][] = $localModule['name'];
+                $result['incompatible_modules'][] = $localModuleName;
 
                 if ($mode === self::QUICK_SEARCH) {
                     return $result;

--- a/tests/unit/Services/MarketplaceServiceTest.php
+++ b/tests/unit/Services/MarketplaceServiceTest.php
@@ -9,7 +9,7 @@
  * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/AFL-3.0
- * If you did not receive a copy of the license and was unable to
+ * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *

--- a/tests/unit/Services/MarketplaceServiceTest.php
+++ b/tests/unit/Services/MarketplaceServiceTest.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and was unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace Services;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\Module\AutoUpgrade\Exceptions\MarketplaceApiException;
+use PrestaShop\Module\AutoUpgrade\Models\Module\Marketplace\Module;
+use PrestaShop\Module\AutoUpgrade\Services\MarketplaceService;
+use PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator;
+
+class TestableMarketplaceService extends MarketplaceService
+{
+    /** @var array<string, string|false> */
+    public array $stubResponses = [];
+
+    public int $fetchCallCount = 0;
+
+    /**
+     * @param string[] $toFetch
+     *
+     * @return array<string, string|false>
+     */
+    protected function fetchModulesRaw(array $toFetch): array
+    {
+        ++$this->fetchCallCount;
+
+        return array_intersect_key($this->stubResponses, array_flip($toFetch));
+    }
+}
+
+class MarketplaceServiceTest extends TestCase
+{
+    private TestableMarketplaceService $service;
+
+    protected function setUp(): void
+    {
+        $translator = $this->createMock(Translator::class);
+        $translator->method('trans')->willReturnArgument(0);
+
+        $this->service = new TestableMarketplaceService($translator);
+    }
+
+    private function validModuleJson(): string
+    {
+        return json_encode([
+            'attributes' => [],
+            'compliance' => [],
+            'product' => [],
+            'technical_info' => [],
+        ]);
+    }
+
+    public function testEmptyInputReturnsEmptyArray(): void
+    {
+        $result = $this->service->getModuleDetails([]);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testSingleModuleValidJsonReturnsModule(): void
+    {
+        $this->service->stubResponses = ['foo' => $this->validModuleJson()];
+
+        $result = $this->service->getModuleDetails(['foo']);
+
+        $this->assertArrayHasKey('foo', $result);
+        $this->assertInstanceOf(Module::class, $result['foo']);
+    }
+
+    public function testSingleModuleFalseResponseReturnsApiNotCallableException(): void
+    {
+        $this->service->stubResponses = ['foo' => false];
+
+        $result = $this->service->getModuleDetails(['foo']);
+
+        $this->assertArrayHasKey('foo', $result);
+        $this->assertInstanceOf(MarketplaceApiException::class, $result['foo']);
+        $this->assertSame(MarketplaceApiException::API_NOT_CALLABLE_CODE, $result['foo']->getCode());
+    }
+
+    public function testSingleModuleInvalidJsonReturnsEmptyDataException(): void
+    {
+        $this->service->stubResponses = ['foo' => 'not-json'];
+
+        $result = $this->service->getModuleDetails(['foo']);
+
+        $this->assertArrayHasKey('foo', $result);
+        $this->assertInstanceOf(MarketplaceApiException::class, $result['foo']);
+        $this->assertSame(MarketplaceApiException::EMPTY_DATA_CODE, $result['foo']->getCode());
+    }
+
+    public function testMultipleModulesAllReturnedCorrectly(): void
+    {
+        $this->service->stubResponses = [
+            'foo' => $this->validModuleJson(),
+            'bar' => false,
+            'baz' => 'bad-json',
+        ];
+
+        $result = $this->service->getModuleDetails(['foo', 'bar', 'baz']);
+
+        $this->assertCount(3, $result);
+        $this->assertInstanceOf(Module::class, $result['foo']);
+        $this->assertInstanceOf(MarketplaceApiException::class, $result['bar']);
+        $this->assertSame(MarketplaceApiException::API_NOT_CALLABLE_CODE, $result['bar']->getCode());
+        $this->assertInstanceOf(MarketplaceApiException::class, $result['baz']);
+        $this->assertSame(MarketplaceApiException::EMPTY_DATA_CODE, $result['baz']->getCode());
+    }
+
+    public function testSameNameCalledTwiceDoesNotRefetch(): void
+    {
+        $this->service->stubResponses = ['foo' => $this->validModuleJson()];
+
+        $this->service->getModuleDetails(['foo']);
+        $this->service->getModuleDetails(['foo']);
+
+        $this->assertSame(1, $this->service->fetchCallCount);
+    }
+
+    public function testGetModuleDetailDelegatesToGetModuleDetailsAndReturnsModule(): void
+    {
+        $this->service->stubResponses = ['foo' => $this->validModuleJson()];
+
+        $result = $this->service->getModuleDetail('foo');
+
+        $this->assertInstanceOf(Module::class, $result);
+    }
+
+    public function testGetModuleDetailThrowsWhenMapValueIsException(): void
+    {
+        $this->service->stubResponses = ['foo' => false];
+
+        $this->expectException(MarketplaceApiException::class);
+        $this->service->getModuleDetail('foo');
+    }
+}

--- a/tests/unit/Services/MarketplaceServiceTest.php
+++ b/tests/unit/Services/MarketplaceServiceTest.php
@@ -29,9 +29,10 @@ use PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator;
 class TestableMarketplaceService extends MarketplaceService
 {
     /** @var array<string, string|false> */
-    public array $stubResponses = [];
+    public $stubResponses = [];
 
-    public int $fetchCallCount = 0;
+    /** @var int */
+    public $fetchCallCount = 0;
 
     /**
      * @param string[] $toFetch
@@ -48,7 +49,8 @@ class TestableMarketplaceService extends MarketplaceService
 
 class MarketplaceServiceTest extends TestCase
 {
-    private TestableMarketplaceService $service;
+    /** @var TestableMarketplaceService */
+    private $service;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When running a PS with lots of modules installed, the modules requiring attention modal takes a lot of time to load. I Improved performance by using parallel HTTP calls. Applied also in the Uninstall Module step
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | /
| Sponsor company   | @prestashopCorp
| How to test?      | Upgrade from 8.2.3 to 8.2.4. The modal should should load correctly and faster. Modules not compatible with target version should be correctly uninstalled