### PR TITLE
Feat: add checkout process provider config and hook to 9.2.0 upgrade

### DIFF
--- a/upgrade/sql/9.2.0.sql
+++ b/upgrade/sql/9.2.0.sql
@@ -107,7 +107,7 @@ CREATE TABLE IF NOT EXISTS `PREFIX_b2b_role_authorization_role` (
 -- https://github.com/PrestaShop/PrestaShop/pull/41028
 /* PHP:ps_920_business_entities_tabs(); */;
 
-/* https://github.com/PrestaShop/PrestaShop/pull/41047 */
+-- https://github.com/PrestaShop/PrestaShop/pull/41047 */
 INSERT INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES
   (NULL, 'actionCheckoutBuildProcess', 'Build checkout process', 'This hook is called before rendering checkout. Only the module configured in PS_CHECKOUT_PROCESS_PROVIDER_MODULE is executed and can return a CheckoutProcess instance.', '1')
 ON DUPLICATE KEY UPDATE `title` = VALUES(`title`), `description` = VALUES(`description`);

--- a/upgrade/sql/9.2.0.sql
+++ b/upgrade/sql/9.2.0.sql
@@ -106,3 +106,8 @@ CREATE TABLE IF NOT EXISTS `PREFIX_b2b_role_authorization_role` (
 
 -- https://github.com/PrestaShop/PrestaShop/pull/41028
 /* PHP:ps_920_business_entities_tabs(); */;
+
+/* https://github.com/PrestaShop/PrestaShop/pull/41047 */
+INSERT INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES
+  (NULL, 'actionCheckoutBuildProcess', 'Build checkout process', 'This hook is called before rendering checkout. Only the module configured in PS_CHECKOUT_PROCESS_PROVIDER_MODULE is executed and can return a CheckoutProcess instance.', '1')
+ON DUPLICATE KEY UPDATE `title` = VALUES(`title`), `description` = VALUES(`description`);

--- a/upgrade/sql/9.2.0.sql
+++ b/upgrade/sql/9.2.0.sql
@@ -109,5 +109,5 @@ CREATE TABLE IF NOT EXISTS `PREFIX_b2b_role_authorization_role` (
 
 -- https://github.com/PrestaShop/PrestaShop/pull/41047
 INSERT INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES
-  (NULL, 'actionCheckoutBuildProcess', 'Build checkout process', 'This hook is called before rendering checkout. Only the module configured in PS_CHECKOUT_PROCESS_PROVIDER_MODULE is executed and can return a CheckoutProcess instance.', '1')
+  (NULL, 'actionCheckoutBuildProcess', 'Build checkout process', 'This hook is triggered before the checkout is rendered. Modules may return a checkout process provider. The provider is used only when exactly one enabled and valid provider is available.', '1')
 ON DUPLICATE KEY UPDATE `title` = VALUES(`title`), `description` = VALUES(`description`);

--- a/upgrade/sql/9.2.0.sql
+++ b/upgrade/sql/9.2.0.sql
@@ -107,7 +107,7 @@ CREATE TABLE IF NOT EXISTS `PREFIX_b2b_role_authorization_role` (
 -- https://github.com/PrestaShop/PrestaShop/pull/41028
 /* PHP:ps_920_business_entities_tabs(); */;
 
--- https://github.com/PrestaShop/PrestaShop/pull/41047 */
+-- https://github.com/PrestaShop/PrestaShop/pull/41047
 INSERT INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES
   (NULL, 'actionCheckoutBuildProcess', 'Build checkout process', 'This hook is called before rendering checkout. Only the module configured in PS_CHECKOUT_PROCESS_PROVIDER_MODULE is executed and can return a CheckoutProcess instance.', '1')
 ON DUPLICATE KEY UPDATE `title` = VALUES(`title`), `description` = VALUES(`description`);


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Adds the missing 9.2.0 autoupgrade entries for the new checkout process provider feature introduced in PrestaShop/PrestaShop#41047.
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | PrestaShop SA
| How to test?      |  N/A

