### PR TITLE
Check modules compliancy with destination version of PrestaShop with Marketplace and Open-Source project APIs

### DIFF
--- a/autoupgrade.php
+++ b/autoupgrade.php
@@ -35,7 +35,7 @@ class Autoupgrade extends Module
         $this->name = 'autoupgrade';
         $this->tab = 'administration';
         $this->author = 'PrestaShop';
-        $this->version = '7.6.0';
+        $this->version = '7.6.1';
         $this->need_instance = 1;
         $this->module_key = '926bc3e16738b7b834f37fc63d59dcf8';
 

--- a/classes/Commands/CheckModulesCommand.php
+++ b/classes/Commands/CheckModulesCommand.php
@@ -28,6 +28,7 @@ use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeFileNames;
 use PrestaShop\Module\AutoUpgrade\Services\PhpVersionResolverService;
 use PrestaShop\Module\AutoUpgrade\Task\ExitCode;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
+use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\ModuleCompatibilityChecker;
 use Symfony\Component\Console\Helper\ProgressIndicator;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
@@ -131,7 +132,8 @@ class CheckModulesCommand extends AbstractCommand
                 $output->writeln(sprintf('Prestashop version: %s', $targetPsVersion));
 
                 $progressIndicator->start('Retrieving modules informations, please wait...');
-                $checkResults = $updateSelfCheck->getModulesRequiringAttention();
+                $mode = $output->isVerbose() ? ModuleCompatibilityChecker::DETAILED_SEARCH : ModuleCompatibilityChecker::COMPLETE_SEARCH;
+                $checkResults = $updateSelfCheck->getModulesRequiringAttention($mode);
                 $progressIndicator->finish('Retrieving modules informations: Done.');
 
                 if ($output->isVerbose()) {

--- a/classes/Services/DistributionApiService.php
+++ b/classes/Services/DistributionApiService.php
@@ -240,7 +240,7 @@ class DistributionApiService
         $modules = [];
 
         foreach ($data as $moduleInfoName => $moduleInfo) {
-            $modules[] = new Module(
+            $modules[$moduleInfoName] = new Module(
                 $moduleInfoName,
                 $moduleInfo['version'],
                 $moduleInfo['download_url'],

--- a/classes/Services/DistributionApiService.php
+++ b/classes/Services/DistributionApiService.php
@@ -240,7 +240,7 @@ class DistributionApiService
         $modules = [];
 
         foreach ($data as $moduleInfoName => $moduleInfo) {
-            $modules[$moduleInfoName] = new Module(
+            $modules[] = new Module(
                 $moduleInfoName,
                 $moduleInfo['version'],
                 $moduleInfo['download_url'],

--- a/classes/Task/Update/UninstallModules.php
+++ b/classes/Task/Update/UninstallModules.php
@@ -22,7 +22,6 @@
 namespace PrestaShop\Module\AutoUpgrade\Task\Update;
 
 use Exception;
-use PrestaShop\Module\AutoUpgrade\Exceptions\MarketplaceApiException;
 use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeFileNames;
 use PrestaShop\Module\AutoUpgrade\Progress\Backlog;
@@ -136,29 +135,17 @@ class UninstallModules extends AbstractTask
                 return !in_array($module['name'], $moduleToUpgradeNames);
             });
 
-            $marketPlaceService = $this->container->getMarketplaceService();
+            $checkResult = $this->container->getModuleCompatibilityChecker()->getModulesRequiringAttention(
+                $modulesList,
+                $targetVersion
+            );
 
-            $modulesToUninstallList = [];
-
-            foreach ($modulesList as $module) {
-                try {
-                    $moduleDetails = $marketPlaceService->getModuleDetail($module['name']);
-
-                    $moduleCompatibility = $marketPlaceService->findCompatibleModuleUpgrade(
-                        $moduleDetails,
-                        $targetVersion,
-                        $module['currentVersion']
-                    );
-
-                    if (!$moduleCompatibility->isCompatible()) {
-                        $modulesToUninstallList[] = $module['name'];
-                    }
-                } catch (MarketplaceApiException $e) {
-                    $this->logger->warning($e);
-                    $this->container->getUpdateState()->setWarningDetected(true);
-                }
+            foreach ($checkResult['uncertain_modules'] as $moduleName) {
+                $this->logger->warning($this->translator->trans('Could not check compatibility of module %s with the Marketplace API.', [$moduleName]));
+                $this->container->getUpdateState()->setWarningDetected(true);
             }
 
+            $modulesToUninstallList = $checkResult['incompatible_modules'];
             $totalModulesToUninstall = count($modulesToUninstallList);
 
             $this->container->getFileStorage()->save(

--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -60,6 +60,7 @@ use PrestaShop\Module\AutoUpgrade\UpgradeTools\CacheCleaner;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\FileFilter;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\FilesystemAdapter;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\ModuleAdapter;
+use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\ModuleCompatibilityChecker;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\QuarantineZone;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\Source\Provider\AbstractModuleSourceProvider;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\Source\Provider\ComposerSourceProvider;
@@ -254,6 +255,9 @@ class UpgradeContainer
 
     /** @var MarketplaceService */
     private $marketplaceService;
+
+    /** @var ModuleCompatibilityChecker */
+    private $moduleCompatibilityChecker;
 
     /** @var UrlGenerator */
     private $urlGenerator;
@@ -886,8 +890,7 @@ class UpgradeContainer
                 $this->getPhpVersionResolverService(),
                 $this->getChecksumCompare(),
                 $this->getModuleAdapter(),
-                $this->getMarketplaceService(),
-                $this->getDistributionApiService(),
+                $this->getModuleCompatibilityChecker(),
                 $this->psRootDir,
                 $this->adminDir,
                 $this->getProperty(UpgradeContainer::WORKSPACE_PATH),
@@ -896,6 +899,18 @@ class UpgradeContainer
         }
 
         return $this->upgradeSelfCheck;
+    }
+
+    public function getModuleCompatibilityChecker(): ModuleCompatibilityChecker
+    {
+        if (null === $this->moduleCompatibilityChecker) {
+            $this->moduleCompatibilityChecker = new ModuleCompatibilityChecker(
+                $this->getDistributionApiService(),
+                $this->getMarketplaceService()
+            );
+        }
+
+        return $this->moduleCompatibilityChecker;
     }
 
     /**

--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -887,6 +887,7 @@ class UpgradeContainer
                 $this->getChecksumCompare(),
                 $this->getModuleAdapter(),
                 $this->getMarketplaceService(),
+                $this->getDistributionApiService(),
                 $this->psRootDir,
                 $this->adminDir,
                 $this->getProperty(UpgradeContainer::WORKSPACE_PATH),

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -27,16 +27,13 @@ use Context;
 use Exception;
 use PrestaShop\Module\AutoUpgrade\Commands\CheckModulesCommand;
 use PrestaShop\Module\AutoUpgrade\Exceptions\DistributionApiException;
-use PrestaShop\Module\AutoUpgrade\Exceptions\MarketplaceApiException;
 use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
-use PrestaShop\Module\AutoUpgrade\Models\Module\DistributionApi\Module;
 use PrestaShop\Module\AutoUpgrade\Models\Module\Marketplace\ModuleUpgradeCompatibility;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\Router\Routes;
-use PrestaShop\Module\AutoUpgrade\Services\DistributionApiService;
-use PrestaShop\Module\AutoUpgrade\Services\MarketplaceService;
 use PrestaShop\Module\AutoUpgrade\Services\PhpVersionResolverService;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\ModuleAdapter;
+use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\ModuleCompatibilityChecker;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator;
 use PrestaShop\Module\AutoUpgrade\Xml\ChecksumCompare;
 use Shop;
@@ -101,14 +98,8 @@ class UpgradeSelfCheck
     private $checksumCompare;
     /** @var ModuleAdapter */
     private $moduleAdapter;
-    /** @var MarketplaceService */
-    private $marketplaceService;
-    /** @var DistributionApiService */
-    private $distributionApiService;
-
-    // Some compatibility checks may return quickly to display a message in the list
-    const COMPLETE_SEARCH = 'complete';
-    const QUICK_SEARCH = 'quick';
+    /** @var ModuleCompatibilityChecker */
+    private $moduleCompatibilityChecker;
 
     // Errors const
     const PHP_COMPATIBILITY_INVALID = 0;
@@ -145,8 +136,7 @@ class UpgradeSelfCheck
         PhpVersionResolverService $phpRequirementService,
         ChecksumCompare $checksumCompare,
         ModuleAdapter $moduleAdapter,
-        MarketplaceService $marketplaceService,
-        DistributionApiService $distributionApiService,
+        ModuleCompatibilityChecker $moduleCompatibilityChecker,
         string $prodRootPath,
         string $adminPath,
         string $autoUpgradePath,
@@ -159,8 +149,7 @@ class UpgradeSelfCheck
         $this->phpRequirementService = $phpRequirementService;
         $this->checksumCompare = $checksumCompare;
         $this->moduleAdapter = $moduleAdapter;
-        $this->marketplaceService = $marketplaceService;
-        $this->distributionApiService = $distributionApiService;
+        $this->moduleCompatibilityChecker = $moduleCompatibilityChecker;
         $this->prodRootPath = $prodRootPath;
         $this->adminPath = $adminPath;
         $this->autoUpgradePath = $autoUpgradePath;
@@ -791,63 +780,15 @@ class UpgradeSelfCheck
     }
 
     /**
-     * @param self::*_SEARCH $mode
+     * @param ModuleCompatibilityChecker::*_SEARCH $mode
      *
      * @return array{incompatible_modules: string[], uncertain_modules: string[], compatibility: array<string, ?ModuleUpgradeCompatibility>}
      */
-    public function getModulesRequiringAttention($mode = self::COMPLETE_SEARCH): array
+    public function getModulesRequiringAttention($mode = ModuleCompatibilityChecker::COMPLETE_SEARCH): array
     {
-        $result = [
-            'incompatible_modules' => [],
-            'uncertain_modules' => [],
-            'compatibility_details' => [],
-        ];
         $modulesInstalled = $this->moduleAdapter->listModulesPresentInFolderAndInstalled();
 
-        $modulesNamesFromDistributionApi = array_map(
-            function (Module $module) { return $module->getName(); },
-            $this->distributionApiService->getModules($this->destinationVersion)
-        );
-
-        foreach ($modulesInstalled as $localModule) {
-            $localModuleName = $localModule['name'];
-
-            // Do not check on Marketplace API if known on Distribution API
-            if (in_array($localModuleName, $modulesNamesFromDistributionApi)) {
-                continue;
-            }
-
-            $localVersion = $localModule['currentVersion'];
-            $result['compatibility'][$localModuleName] = null;
-
-            try {
-                $moduleDetails = $this->marketplaceService->getModuleDetail($localModuleName);
-            } catch (MarketplaceApiException $e) {
-                $result['uncertain_modules'][] = $localModule['name'];
-
-                if ($mode === self::QUICK_SEARCH) {
-                    return $result;
-                }
-                continue;
-            }
-            $moduleCompatibility = $this->marketplaceService->findCompatibleModuleUpgrade(
-                $moduleDetails,
-                $this->destinationVersion,
-                $localVersion
-            );
-
-            $result['compatibility'][$localModuleName] = $moduleCompatibility;
-
-            if (!$moduleCompatibility->isCompatible()) {
-                $result['incompatible_modules'][] = $localModule['name'];
-
-                if ($mode === self::QUICK_SEARCH) {
-                    return $result;
-                }
-            }
-        }
-
-        return $result;
+        return $this->moduleCompatibilityChecker->getModulesRequiringAttention($modulesInstalled, $this->destinationVersion, $mode);
     }
 
     /**
@@ -855,7 +796,7 @@ class UpgradeSelfCheck
      */
     public function checkModuleRequiresAttention(): bool
     {
-        $moduleRequiringAttention = $this->getModulesRequiringAttention(self::QUICK_SEARCH);
+        $moduleRequiringAttention = $this->getModulesRequiringAttention(ModuleCompatibilityChecker::QUICK_SEARCH);
 
         return !empty($moduleRequiringAttention['uncertain_modules']) || !empty($moduleRequiringAttention['incompatible_modules']);
     }

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -29,6 +29,7 @@ use PrestaShop\Module\AutoUpgrade\Commands\CheckModulesCommand;
 use PrestaShop\Module\AutoUpgrade\Exceptions\DistributionApiException;
 use PrestaShop\Module\AutoUpgrade\Exceptions\MarketplaceApiException;
 use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
+use PrestaShop\Module\AutoUpgrade\Models\Module\DistributionApi\Module;
 use PrestaShop\Module\AutoUpgrade\Models\Module\Marketplace\ModuleUpgradeCompatibility;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\Router\Routes;
@@ -803,13 +804,16 @@ class UpgradeSelfCheck
         ];
         $modulesInstalled = $this->moduleAdapter->listModulesPresentInFolderAndInstalled();
 
-        $modulesFromDistribApi = array_keys($this->distributionApiService->getModules($this->destinationVersion));
+        $modulesNamesFromDistributionApi = array_map(
+            function (Module $module) { return $module->getName(); },
+            $this->distributionApiService->getModules($this->destinationVersion)
+        );
 
         foreach ($modulesInstalled as $localModule) {
             $localModuleName = $localModule['name'];
 
             // Do not check on Marketplace API if known on Distribution API
-            if (in_array($localModuleName, $modulesFromDistribApi)) {
+            if (in_array($localModuleName, $modulesNamesFromDistributionApi)) {
                 continue;
             }
 

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -32,6 +32,7 @@ use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
 use PrestaShop\Module\AutoUpgrade\Models\Module\Marketplace\ModuleUpgradeCompatibility;
 use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
 use PrestaShop\Module\AutoUpgrade\Router\Routes;
+use PrestaShop\Module\AutoUpgrade\Services\DistributionApiService;
 use PrestaShop\Module\AutoUpgrade\Services\MarketplaceService;
 use PrestaShop\Module\AutoUpgrade\Services\PhpVersionResolverService;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\ModuleAdapter;
@@ -101,6 +102,8 @@ class UpgradeSelfCheck
     private $moduleAdapter;
     /** @var MarketplaceService */
     private $marketplaceService;
+    /** @var DistributionApiService */
+    private $distributionApiService;
 
     // Some compatibility checks may return quickly to display a message in the list
     const COMPLETE_SEARCH = 'complete';
@@ -142,6 +145,7 @@ class UpgradeSelfCheck
         ChecksumCompare $checksumCompare,
         ModuleAdapter $moduleAdapter,
         MarketplaceService $marketplaceService,
+        DistributionApiService $distributionApiService,
         string $prodRootPath,
         string $adminPath,
         string $autoUpgradePath,
@@ -155,6 +159,7 @@ class UpgradeSelfCheck
         $this->checksumCompare = $checksumCompare;
         $this->moduleAdapter = $moduleAdapter;
         $this->marketplaceService = $marketplaceService;
+        $this->distributionApiService = $distributionApiService;
         $this->prodRootPath = $prodRootPath;
         $this->adminPath = $adminPath;
         $this->autoUpgradePath = $autoUpgradePath;
@@ -798,8 +803,16 @@ class UpgradeSelfCheck
         ];
         $modulesInstalled = $this->moduleAdapter->listModulesPresentInFolderAndInstalled();
 
+        $modulesFromDistribApi = array_keys($this->distributionApiService->getModules($this->destinationVersion));
+
         foreach ($modulesInstalled as $localModule) {
             $localModuleName = $localModule['name'];
+
+            // Do not check on Marketplace API if known on Distribution API
+            if (in_array($localModuleName, $modulesFromDistribApi)) {
+                continue;
+            }
+
             $localVersion = $localModule['currentVersion'];
             $result['compatibility'][$localModuleName] = null;
 

--- a/classes/UpgradeTools/Module/ModuleCompatibilityChecker.php
+++ b/classes/UpgradeTools/Module/ModuleCompatibilityChecker.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\AutoUpgrade\UpgradeTools\Module;
+
+use PrestaShop\Module\AutoUpgrade\Exceptions\MarketplaceApiException;
+use PrestaShop\Module\AutoUpgrade\Models\Module\DistributionApi\Module;
+use PrestaShop\Module\AutoUpgrade\Models\Module\Marketplace\ModuleUpgradeCompatibility;
+use PrestaShop\Module\AutoUpgrade\Services\DistributionApiService;
+use PrestaShop\Module\AutoUpgrade\Services\MarketplaceService;
+
+class ModuleCompatibilityChecker
+{
+    const COMPLETE_SEARCH = 'complete';
+    const QUICK_SEARCH = 'quick';
+
+    /** @var DistributionApiService */
+    private $distributionApiService;
+    /** @var MarketplaceService */
+    private $marketplaceService;
+
+    public function __construct(
+        DistributionApiService $distributionApiService,
+        MarketplaceService $marketplaceService
+    ) {
+        $this->distributionApiService = $distributionApiService;
+        $this->marketplaceService = $marketplaceService;
+    }
+
+    /**
+     * @param array<array{name: string, currentVersion: string}> $modulesInstalled
+     * @param self::*_SEARCH $mode
+     *
+     * @return array{incompatible_modules: string[], uncertain_modules: string[], compatibility: array<string, ?ModuleUpgradeCompatibility>}
+     */
+    public function getModulesRequiringAttention(array $modulesInstalled, string $targetVersion, $mode = self::COMPLETE_SEARCH): array
+    {
+        $result = [
+            'incompatible_modules' => [],
+            'uncertain_modules' => [],
+            'compatibility' => [],
+        ];
+
+        $modulesNamesFromDistributionApi = array_map(
+            function (Module $module) { return $module->getName(); },
+            $this->distributionApiService->getModules($targetVersion)
+        );
+
+        foreach ($modulesInstalled as $localModule) {
+            $localModuleName = $localModule['name'];
+
+            // Do not check on Marketplace API if known on Distribution API
+            if (in_array($localModuleName, $modulesNamesFromDistributionApi)) {
+                continue;
+            }
+
+            $localVersion = $localModule['currentVersion'];
+            $result['compatibility'][$localModuleName] = null;
+
+            try {
+                $moduleDetails = $this->marketplaceService->getModuleDetail($localModuleName);
+            } catch (MarketplaceApiException $e) {
+                $result['uncertain_modules'][] = $localModuleName;
+
+                if ($mode === self::QUICK_SEARCH) {
+                    return $result;
+                }
+                continue;
+            }
+
+            $moduleCompatibility = $this->marketplaceService->findCompatibleModuleUpgrade(
+                $moduleDetails,
+                $targetVersion,
+                $localVersion
+            );
+
+            $result['compatibility'][$localModuleName] = $moduleCompatibility;
+
+            if (!$moduleCompatibility->isCompatible()) {
+                $result['incompatible_modules'][] = $localModuleName;
+
+                if ($mode === self::QUICK_SEARCH) {
+                    return $result;
+                }
+            }
+        }
+
+        return $result;
+    }
+}

--- a/classes/UpgradeTools/Module/ModuleCompatibilityChecker.php
+++ b/classes/UpgradeTools/Module/ModuleCompatibilityChecker.php
@@ -29,7 +29,11 @@ use PrestaShop\Module\AutoUpgrade\Services\MarketplaceService;
 
 class ModuleCompatibilityChecker
 {
+    // Check all modules and return details from the marketplace
+    const DETAILED_SEARCH = 'detailed';
+    // Check all modules
     const COMPLETE_SEARCH = 'complete';
+    // Return on the first module with issue
     const QUICK_SEARCH = 'quick';
 
     /** @var DistributionApiService */
@@ -68,7 +72,8 @@ class ModuleCompatibilityChecker
             $localModuleName = $localModule['name'];
 
             // Do not check on Marketplace API if known on Distribution API
-            if (in_array($localModuleName, $modulesNamesFromDistributionApi)) {
+            $moduleIsNative = in_array($localModuleName, $modulesNamesFromDistributionApi);
+            if ($mode !== self::DETAILED_SEARCH && $moduleIsNative) {
                 continue;
             }
 
@@ -78,7 +83,9 @@ class ModuleCompatibilityChecker
             try {
                 $moduleDetails = $this->marketplaceService->getModuleDetail($localModuleName);
             } catch (MarketplaceApiException $e) {
-                $result['uncertain_modules'][] = $localModuleName;
+                if (!$moduleIsNative) {
+                    $result['uncertain_modules'][] = $localModuleName;
+                }
 
                 if ($mode === self::QUICK_SEARCH) {
                     return $result;
@@ -95,7 +102,9 @@ class ModuleCompatibilityChecker
             $result['compatibility'][$localModuleName] = $moduleCompatibility;
 
             if (!$moduleCompatibility->isCompatible()) {
-                $result['incompatible_modules'][] = $localModuleName;
+                if (!$moduleIsNative) {
+                    $result['incompatible_modules'][] = $localModuleName;
+                }
 
                 if ($mode === self::QUICK_SEARCH) {
                     return $result;

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>autoupgrade</name>
     <displayName><![CDATA[Update Assistant]]></displayName>
-    <version><![CDATA[7.6.0]]></version>
+    <version><![CDATA[7.6.1]]></version>
     <description><![CDATA[The Update Assistant module helps you backup, update and restore your PrestaShop store. With just a few clicks, you can move to the latest version of PrestaShop with confidence.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[administration]]></tab>

--- a/tests/unit/UpgradeTools/Module/ModuleCompatibilityCheckerTest.php
+++ b/tests/unit/UpgradeTools/Module/ModuleCompatibilityCheckerTest.php
@@ -1,0 +1,237 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\Module\AutoUpgrade\Exceptions\MarketplaceApiException;
+use PrestaShop\Module\AutoUpgrade\Models\Module\DistributionApi\Module as DistributionApiModule;
+use PrestaShop\Module\AutoUpgrade\Models\Module\Marketplace\Module as MarketplaceModule;
+use PrestaShop\Module\AutoUpgrade\Models\Module\Marketplace\ModuleUpgradeCompatibility;
+use PrestaShop\Module\AutoUpgrade\Services\DistributionApiService;
+use PrestaShop\Module\AutoUpgrade\Services\MarketplaceService;
+use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\ModuleCompatibilityChecker;
+
+class ModuleCompatibilityCheckerTest extends TestCase
+{
+    // These modules are known as native modules. No need to check the Marketplace -> OK
+    const NATIVE_MODULES = ['statsdata', 'autoupgrade', 'psgdpr'];
+    // Not existing in both APIs -> Uncertain
+    const NON_EXISTING_MODULES = ['gamification'];
+    // Found but no available version -> Incompatible
+    const INCOMPATIBLE_MODULES = ['ps_mcp', 'ps_welcome'];
+    // The rest -> OK
+
+    /** @var PHPUnit_Framework_MockObject_MockObject */
+    private $distributionApiService;
+    /** @var PHPUnit_Framework_MockObject_MockObject */
+    private $marketplaceService;
+    /** @var ModuleCompatibilityChecker */
+    private $moduleCompatibilityChecker;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (PHP_VERSION_ID >= 80000) {
+            $this->markTestSkipped('An issue with this version of PHPUnit and PHP 8+ prevents this test to run.');
+        }
+
+        $this->distributionApiService = $this->mockDistributionApiService();
+        $this->marketplaceService = $this->mockMarketplaceService();
+        $this->moduleCompatibilityChecker = new ModuleCompatibilityChecker($this->distributionApiService, $this->marketplaceService);
+    }
+
+    public function testFullCheckup(): void
+    {
+        $installedModules = [
+            ['name' => 'statsdata', 'currentVersion' => '1.0.0'],
+            ['name' => 'autoupgrade', 'currentVersion' => '7.6.0'],
+            ['name' => 'ps_welcome', 'currentVersion' => '2.0.0'],
+            ['name' => 'psgdpr', 'currentVersion' => '4.1.0'],
+            ['name' => 'gamification', 'currentVersion' => '1.2.3'],
+            ['name' => 'ps_mcp', 'currentVersion' => '3.4.4'],
+        ];
+
+        /** @var array{incompatible_modules: string[], uncertain_modules: string[], compatibility: array<string, ?ModuleUpgradeCompatibility>} */
+        $expected = [
+            'incompatible_modules' => ['ps_welcome', 'ps_mcp'],
+            'uncertain_modules' => ['gamification'],
+            'compatibility' => [
+                // Not checked
+            ],
+        ];
+
+        $this->marketplaceService->expects($this->exactly(3))->method('getModuleDetail');
+
+        $actual = $this->moduleCompatibilityChecker->getModulesRequiringAttention($installedModules, '99.99.99', ModuleCompatibilityChecker::COMPLETE_SEARCH);
+
+        $this->assertEquals($expected['incompatible_modules'], $actual['incompatible_modules']);
+        $this->assertEquals($expected['uncertain_modules'], $actual['uncertain_modules']);
+    }
+
+    // Detailed Checkup allows the marketplace to be displayed for all modules.
+    public function testDetailedCheckup(): void
+    {
+        $installedModules = [
+            ['name' => 'statsdata', 'currentVersion' => '1.0.0'],
+            ['name' => 'autoupgrade', 'currentVersion' => '7.6.0'],
+            ['name' => 'ps_welcome', 'currentVersion' => '2.0.0'],
+            ['name' => 'psgdpr', 'currentVersion' => '4.1.0'],
+            ['name' => 'gamification', 'currentVersion' => '1.2.3'],
+            ['name' => 'ps_mcp', 'currentVersion' => '3.4.4'],
+        ];
+
+        /** @var array{incompatible_modules: string[], uncertain_modules: string[], compatibility: array<string, ?ModuleUpgradeCompatibility>} */
+        $expected = [
+            'incompatible_modules' => ['ps_welcome', 'ps_mcp'],
+            'uncertain_modules' => ['gamification'],
+            'compatibility' => [
+                // Not checked
+            ],
+        ];
+
+        // The results are the same but the number of calls to the marketplace is different
+        $this->marketplaceService->expects($this->exactly(6))->method('getModuleDetail');
+
+        $actual = $this->moduleCompatibilityChecker->getModulesRequiringAttention($installedModules, '99.99.99', ModuleCompatibilityChecker::DETAILED_SEARCH);
+
+        $this->assertEquals($expected['incompatible_modules'], $actual['incompatible_modules']);
+        $this->assertEquals($expected['uncertain_modules'], $actual['uncertain_modules']);
+    }
+
+    public function testWithOnlyNativeModules(): void
+    {
+        $installedModules = [
+            ['name' => 'statsdata', 'currentVersion' => '1.0.0'],
+            ['name' => 'autoupgrade', 'currentVersion' => '7.6.0'],
+            ['name' => 'psgdpr', 'currentVersion' => '4.1.0'],
+        ];
+
+        /** @var array{incompatible_modules: string[], uncertain_modules: string[], compatibility: array<string, ?ModuleUpgradeCompatibility>} */
+        $expected = [
+            'incompatible_modules' => [],
+            'uncertain_modules' => [],
+            'compatibility' => [
+                // Not checked
+            ],
+        ];
+
+        $this->marketplaceService->expects($this->never())->method('getModuleDetail');
+
+        $actual = $this->moduleCompatibilityChecker->getModulesRequiringAttention($installedModules, '99.99.99', ModuleCompatibilityChecker::COMPLETE_SEARCH);
+
+        $this->assertEquals($expected['incompatible_modules'], $actual['incompatible_modules']);
+        $this->assertEquals($expected['uncertain_modules'], $actual['uncertain_modules']);
+    }
+
+    public function testMethodReturnsQuicklyAfterFirstIncompatibleModules(): void
+    {
+        $installedModules = [
+            ['name' => 'statsdata', 'currentVersion' => '1.0.0'],
+            ['name' => 'autoupgrade', 'currentVersion' => '7.6.0'],
+            ['name' => 'ps_welcome', 'currentVersion' => '2.0.0'],
+            ['name' => 'psgdpr', 'currentVersion' => '4.1.0'],
+            ['name' => 'gamification', 'currentVersion' => '1.2.3'],
+            ['name' => 'ps_mcp', 'currentVersion' => '3.4.4'],
+        ];
+
+        /** @var array{incompatible_modules: string[], uncertain_modules: string[], compatibility: array<string, ?ModuleUpgradeCompatibility>} */
+        $expected = [
+            'incompatible_modules' => ['ps_welcome'],
+            'uncertain_modules' => [],
+            'compatibility' => [
+                // Not checked
+            ],
+        ];
+
+        $this->marketplaceService->expects($this->once())->method('getModuleDetail');
+
+        $actual = $this->moduleCompatibilityChecker->getModulesRequiringAttention($installedModules, '99.99.99', ModuleCompatibilityChecker::QUICK_SEARCH);
+
+        $this->assertEquals($expected['incompatible_modules'], $actual['incompatible_modules']);
+        $this->assertEquals($expected['uncertain_modules'], $actual['uncertain_modules']);
+    }
+
+    public function testMethodReturnsQuicklyAfterFirstUncertainModule(): void
+    {
+        $installedModules = [
+            ['name' => 'statsdata', 'currentVersion' => '1.0.0'],
+            ['name' => 'autoupgrade', 'currentVersion' => '7.6.0'],
+            ['name' => 'psgdpr', 'currentVersion' => '4.1.0'],
+            ['name' => 'gamification', 'currentVersion' => '1.2.3'],
+            ['name' => 'ps_mcp', 'currentVersion' => '3.4.4'],
+        ];
+
+        /** @var array{incompatible_modules: string[], uncertain_modules: string[], compatibility: array<string, ?ModuleUpgradeCompatibility>} */
+        $expected = [
+            'incompatible_modules' => [],
+            'uncertain_modules' => ['gamification'],
+            'compatibility' => [
+                // Not checked
+            ],
+        ];
+
+        $this->marketplaceService->expects($this->once())->method('getModuleDetail');
+
+        $actual = $this->moduleCompatibilityChecker->getModulesRequiringAttention($installedModules, '99.99.99', ModuleCompatibilityChecker::QUICK_SEARCH);
+
+        $this->assertEquals($expected['incompatible_modules'], $actual['incompatible_modules']);
+        $this->assertEquals($expected['uncertain_modules'], $actual['uncertain_modules']);
+    }
+
+    private function mockDistributionApiService()
+    {
+        $distributionApiService = $this->createMock(DistributionApiService::class);
+
+        $nativeModules = [];
+        foreach (self::NATIVE_MODULES as $name) {
+            $nativeModules[] = new DistributionApiModule($name, '9.9.9', 'https://example.com/download', 'icon.png', null, null, null, null, null, null);
+        }
+
+        $distributionApiService->method('getModules')->willReturn($nativeModules);
+
+        return $distributionApiService;
+    }
+
+    private function mockMarketplaceService()
+    {
+        $marketplaceService = $this->createMock(MarketplaceService::class);
+        $marketplaceService->method('getModuleDetail')->will($this->returnCallback(function ($arg) {
+            if (in_array($arg, self::NON_EXISTING_MODULES)) {
+                throw new MarketplaceApiException('HTTP 404 Error: Module Unknown');
+            }
+
+            // Module exists. Compatibility will be reported with the other method
+            // We hack one data of the module class as the technical name is not present.
+            return MarketplaceModule::fromArray(['product' => ['id_product' => (int) !in_array($arg, self::INCOMPATIBLE_MODULES)]]);
+        }));
+
+        $marketplaceService->method('findCompatibleModuleUpgrade')->will($this->returnCallback(function (MarketplaceModule $arg) {
+            $isCompatible = (bool) $arg->product->id;
+
+            $moduleUpgradeCompatibility = $this->createMock(ModuleUpgradeCompatibility::class);
+            $moduleUpgradeCompatibility->method('isCompatible')->willReturn($isCompatible);
+
+            return $moduleUpgradeCompatibility;
+        }));
+
+        return $marketplaceService;
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When checking the compatibility of modules with the newer version of PrestaShop, the Marketplace API endpoint /v2/products/{technical_name} may return an inactive/deprecated product instead of the correct one. While we work on it more deeply with the team maintaining the API, we avoid calling the marketplace for native modules that are likely to be concerned by this issue.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | `psgdpr`, `ps_themecusto`, `contactform` should not be uninstalled anymore as we now get the proper product sheet.
