### PR TITLE
Handle no chain mode configuration

### DIFF
--- a/classes/Commands/UpdateCommand.php
+++ b/classes/Commands/UpdateCommand.php
@@ -84,7 +84,7 @@ class UpdateCommand extends AbstractCommand
             $action = $input->getOption('action');
 
             // if we are in the 1st step of the update, we update the configuration
-            if ($action === null || $action === TaskName::TASK_UPDATE_INITIALIZATION) {
+            if ($action === null || $action === TaskName::TASK_UPDATE_INITIALIZATION || $noChainMode) {
                 $this->logger->debug('Cleaning previous configuration file.');
                 $this->upgradeContainer->getFileStorage()->clean(UpgradeFileNames::UPDATE_CONFIG_FILENAME);
 

--- a/classes/Commands/UpdateCommand.php
+++ b/classes/Commands/UpdateCommand.php
@@ -83,23 +83,36 @@ class UpdateCommand extends AbstractCommand
 
             $action = $input->getOption('action');
 
+            $isInitializationStep = $action === null || $action === TaskName::TASK_UPDATE_INITIALIZATION || $noChainMode;
+
             // if we are in the 1st step of the update, we update the configuration
-            if ($action === null || $action === TaskName::TASK_UPDATE_INITIALIZATION || $noChainMode) {
+            if ($isInitializationStep) {
                 $this->logger->debug('Cleaning previous configuration file.');
-                $this->upgradeContainer->getFileStorage()->clean(UpgradeFileNames::UPDATE_CONFIG_FILENAME);
+                $this->upgradeContainer
+                    ->getFileStorage()
+                    ->clean(UpgradeFileNames::UPDATE_CONFIG_FILENAME);
 
                 $this->processConsoleInputConfiguration($input);
+
                 $configPath = $input->getOption('config-file-path');
                 $exitCode = $this->loadConfiguration($configPath);
+
                 if ($exitCode !== ExitCode::SUCCESS) {
                     return $exitCode;
                 }
-            } else {
-                $updateState = $this->upgradeContainer->getUpdateState();
+            }
+
+            if (!$isInitializationStep || ($noChainMode && $action !== null && $action !== TaskName::TASK_UPDATE_INITIALIZATION)) {
                 // In the special case the user inits the process from a specific task that is not the initialization,
                 // we need to initialize the state manually.
+                $updateState = $this->upgradeContainer->getUpdateState();
+
                 if (!$updateState->isInitialized()) {
-                    $updateState->initDefault($this->upgradeContainer->getProperty(UpgradeContainer::PS_VERSION), $this->upgradeContainer->getUpgrader(), $this->upgradeContainer->getUpdateConfiguration());
+                    $updateState->initDefault(
+                        $this->upgradeContainer->getProperty(UpgradeContainer::PS_VERSION),
+                        $this->upgradeContainer->getUpgrader(),
+                        $this->upgradeContainer->getUpdateConfiguration()
+                    );
                 }
             }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Improved the configuration file creation process in the update command. It now correctly handles commands passed in no-chain mode at specific steps.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | https://github.com/PrestaShop/autoupgrade/issues/1752
| Sponsor company   | -
| How to test?      | see https://github.com/PrestaShop/autoupgrade/issues/1752
