### PR TITLE
Make latest release nullable in module compatibility class

### DIFF
--- a/classes/Models/Module/Marketplace/ModuleUpgradeCompatibility.php
+++ b/classes/Models/Module/Marketplace/ModuleUpgradeCompatibility.php
@@ -29,7 +29,7 @@ class ModuleUpgradeCompatibility
     /** @var bool */
     private $hasUpdateAvailable;
 
-    /** @var Release */
+    /** @var Release|null */
     private $latestRelease;
 
     /** @var Release|null */
@@ -38,7 +38,7 @@ class ModuleUpgradeCompatibility
     public function __construct(
         bool $isCompatible,
         bool $hasUpdateAvailable,
-        Release $latestRelease,
+        ?Release $latestRelease = null,
         ?Release $compatibleRelease = null
     ) {
         $this->isCompatible = $isCompatible;
@@ -62,7 +62,7 @@ class ModuleUpgradeCompatibility
         return $this->compatibleRelease;
     }
 
-    public function getLatestRelease(): Release
+    public function getLatestRelease(): ?Release
     {
         return $this->latestRelease;
     }

--- a/classes/UpgradeTools/Module/ModuleCompatibilityChecker.php
+++ b/classes/UpgradeTools/Module/ModuleCompatibilityChecker.php
@@ -101,7 +101,15 @@ class ModuleCompatibilityChecker
 
             $result['compatibility'][$localModuleName] = $moduleCompatibility;
 
-            if (!$moduleCompatibility->isCompatible()) {
+            if (!$moduleCompatibility->getLatestRelease()) {
+                if (!$moduleIsNative) {
+                    $result['uncertain_modules'][] = $localModuleName;
+                }
+
+                if ($mode === self::QUICK_SEARCH) {
+                    return $result;
+                }
+            } elseif (!$moduleCompatibility->isCompatible()) {
                 if (!$moduleIsNative) {
                     $result['incompatible_modules'][] = $localModuleName;
                 }

--- a/tests/unit/UpgradeTools/Module/ModuleCompatibilityCheckerTest.php
+++ b/tests/unit/UpgradeTools/Module/ModuleCompatibilityCheckerTest.php
@@ -24,6 +24,7 @@ use PrestaShop\Module\AutoUpgrade\Exceptions\MarketplaceApiException;
 use PrestaShop\Module\AutoUpgrade\Models\Module\DistributionApi\Module as DistributionApiModule;
 use PrestaShop\Module\AutoUpgrade\Models\Module\Marketplace\Module as MarketplaceModule;
 use PrestaShop\Module\AutoUpgrade\Models\Module\Marketplace\ModuleUpgradeCompatibility;
+use PrestaShop\Module\AutoUpgrade\Models\Module\Marketplace\Release;
 use PrestaShop\Module\AutoUpgrade\Services\DistributionApiService;
 use PrestaShop\Module\AutoUpgrade\Services\MarketplaceService;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\ModuleCompatibilityChecker;
@@ -196,6 +197,37 @@ class ModuleCompatibilityCheckerTest extends TestCase
         $this->assertEquals($expected['uncertain_modules'], $actual['uncertain_modules']);
     }
 
+    public function testModuleWithNoReleaseNoMarketplaceIsUncertain()
+    {
+        $installedModules = [
+            ['name' => 'wololo', 'currentVersion' => '1.0.0'],
+        ];
+
+        /** @var array{incompatible_modules: string[], uncertain_modules: string[], compatibility: array<string, ?ModuleUpgradeCompatibility>} */
+        $expected = [
+            'incompatible_modules' => [],
+            'uncertain_modules' => ['wololo'],
+            'compatibility' => [
+                // Not checked
+            ],
+        ];
+
+        $marketplaceService = $this->createMock(MarketplaceService::class);
+        $marketplaceService->expects($this->once())->method('getModuleDetail')->willReturn(MarketplaceModule::fromArray(['product' => ['id_product' => 0]]));
+        $marketplaceService->method('findCompatibleModuleUpgrade')->will($this->returnCallback(function () {
+            $moduleUpgradeCompatibility = $this->createMock(ModuleUpgradeCompatibility::class);
+            $moduleUpgradeCompatibility->method('getLatestRelease')->willReturn(null);
+
+            return $moduleUpgradeCompatibility;
+        }));
+        $checker = new ModuleCompatibilityChecker($this->distributionApiService, $marketplaceService);
+
+        $actual = $checker->getModulesRequiringAttention($installedModules, '99.99.99', ModuleCompatibilityChecker::COMPLETE_SEARCH);
+
+        $this->assertEquals($expected['incompatible_modules'], $actual['incompatible_modules']);
+        $this->assertEquals($expected['uncertain_modules'], $actual['uncertain_modules']);
+    }
+
     private function mockDistributionApiService()
     {
         $distributionApiService = $this->createMock(DistributionApiService::class);
@@ -228,10 +260,33 @@ class ModuleCompatibilityCheckerTest extends TestCase
 
             $moduleUpgradeCompatibility = $this->createMock(ModuleUpgradeCompatibility::class);
             $moduleUpgradeCompatibility->method('isCompatible')->willReturn($isCompatible);
+            $moduleUpgradeCompatibility->method('getLatestRelease')->willReturn(Release::fromArray($this->createModuleRelease()));
 
             return $moduleUpgradeCompatibility;
         }));
 
         return $marketplaceService;
+    }
+
+    private function createModuleRelease(): array
+    {
+        return [
+            'product_version' => '5.2.2',
+            'compatibility_checked' => 0,
+            'compatible_from' => '9.0.0',
+            'compatible_to' => '100.1.0',
+            'is_ps_account' => 0,
+            'is_cloudsync' => 0,
+            'is_billing' => 0,
+            'is_mcp_compliant' => 0,
+            'is_eaa_compliant' => 0,
+            'translations' => ['EN', 'DE', 'ES', 'FR', 'IT', 'NL', 'PL', 'PT', 'RO', 'RU'],
+            'release_date' => '2026-01-05',
+            'rgpd_compliant' => 1,
+            'is_security_update' => 0,
+            'has_overrides' => null,
+            'is_major_update' => 0,
+            'change_logs' => ['Bug fixes'],
+        ];
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix the signature of a class that can receive `null` as parameter. The modules falling in this case don't have any release on the marketplace, and must be considered as Unknown compatibility.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/autoupgrade/issues/1755
| Sponsor company   | @PrestaShopCorp
| How to test?      | No change on the existing features. However, if we have a module that has no releases on the marketplace, the module won't crash anymore (example to be found) and it must be reported as "Uncertain compatibility".

If you create a fake module `litespeedcache` and install it on your shop, you will get this error:

```
CRITICAL - /var/www/html/modules/autoupgrade/classes/Models/Module/Marketplace/ModuleUpgradeCompatibility.php line 38 - TypeError: PrestaShop\Module\AutoUpgrade\Models\Module\Marketplace\ModuleUpgradeCompatibility::__construct(): Argument #3 ($latestRelease) must be of type PrestaShop\Module\AutoUpgrade\Models\Module\Marketplace\Release, null given, called in /var/www/html/modules/autoupgrade/classes/Services/MarketplaceService.php on line 90
#0 /var/www/html/modules/autoupgrade/classes/Services/MarketplaceService.php(90): PrestaShop\Module\AutoUpgrade\Models\Module\Marketplace\ModuleUpgradeCompatibility->__construct(false, false, NULL)
#1 /var/www/html/modules/autoupgrade/classes/UpgradeSelfCheck.php(817): PrestaShop\Module\AutoUpgrade\Services\MarketplaceService->findCompatibleModuleUpgrade(Object(PrestaShop\Module\AutoUpgrade\Models\Module\Marketplace\Module), '8.2.5', '7.5.0')
#2 /var/www/html/modules/autoupgrade/classes/Commands/CheckModulesCommand.php(134): PrestaShop\Module\AutoUpgrade\UpgradeSelfCheck->getModulesRequiringAttention()
#3 /var/www/html/modules/autoupgrade/sub-vendors/php8/vendor/symfony/console/Command/Command.php(326): PrestaShop\Module\AutoUpgrade\Commands\CheckModulesCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#4 /var/www/html/modules/autoupgrade/sub-vendors/php8/vendor/symfony/console/Application.php(1078): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#5 /var/www/html/modules/autoupgrade/sub-vendors/php8/vendor/symfony/console/Application.php(324): Symfony\Component\Console\Application->doRunCommand(Object(PrestaShop\Module\AutoUpgrade\Commands\CheckModulesCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#6 /var/www/html/modules/autoupgrade/sub-vendors/php8/vendor/symfony/console/Application.php(175): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#7 /var/www/html/modules/autoupgrade/bin/console(74): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#8 {main}
```

## Module to install in order to test
[litespeedcache.zip](https://github.com/user-attachments/files/26375009/litespeedcache.zip)
