### PR TITLE
Fix undefined key 19 in UpgradeSelfCheck

### DIFF
--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -226,7 +226,7 @@ class UpgradeSelfCheck
             $warnings[self::PHP_COMPATIBILITY_UNKNOWN] = $this->getPhpRequirementsState() === PhpVersionResolverService::COMPATIBILITY_UNKNOWN;
         }
 
-        if (!$warnings[self::PHP_COMPATIBILITY_UNKNOWN]) {
+        if (!isset($warnings[self::PHP_COMPATIBILITY_UNKNOWN])) {
             $warnings[self::MODULES_REQUIRE_ATTENTION] = $this->checkModuleRequiresAttention();
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix of the reported `warnimng: modules/autoupgrade/classes/UpgradeSelfCheck.php line 229 - Undefined array key 19`
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/autoupgrade/issues/1760
| Sponsor company   | @PrestaShopCorp
| How to test?      | Warning disappears from the logs. Having the PHP error reporter as E_ALL may help to reproduce the issue. 

## Module to install in order to test
[litespeedcache.zip](https://github.com/user-attachments/files/26375009/litespeedcache.zip)