### PR TITLE
fix: avoid undefined array key warnings in AjaxResponseBuilder

### DIFF
--- a/classes/AjaxResponseBuilder.php
+++ b/classes/AjaxResponseBuilder.php
@@ -36,11 +36,11 @@ class AjaxResponseBuilder
             'new_content' => $newContent,
         ];
 
-        if ($options['newRoute']) {
+        if (!empty($options['newRoute'])) {
             $arrayToReturn['new_route'] = $options['newRoute'];
         }
 
-        if ($options['addScript']) {
+        if (!empty($options['addScript'])) {
             $arrayToReturn['add_script'] = $options['addScript'];
         }
 


### PR DESCRIPTION


<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Use method `empty()` to check an array key exists to avoid warnings on strict PHP environments.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/autoupgrade/issues/1670
| Sponsor company   | @PrestaShopCorp
| How to test?      | Make your PHP configuration strict with error reporting level as E_ALL and run the module on PrestaShop v9.1