### PR TITLE
Make sure checkModuleRequiresAttention() is called for all channels expect when version is unknown or store is up-to-date

### DIFF
--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -221,7 +221,7 @@ class UpgradeSelfCheck
             $warnings[self::PHP_COMPATIBILITY_UNKNOWN] = $this->getPhpRequirementsState() === PhpVersionResolverService::COMPATIBILITY_UNKNOWN;
         }
 
-        if (!isset($warnings[self::PHP_COMPATIBILITY_UNKNOWN])) {
+        if ($this->destinationVersion !== null && empty($warnings[self::PHP_COMPATIBILITY_UNKNOWN])) {
             $warnings[self::MODULES_REQUIRE_ATTENTION] = $this->checkModuleRequiresAttention();
         }
 

--- a/tests/unit/UpgradeSelfCheckTest.php
+++ b/tests/unit/UpgradeSelfCheckTest.php
@@ -1,0 +1,205 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\Module\AutoUpgrade\Parameters\UpgradeConfiguration;
+use PrestaShop\Module\AutoUpgrade\PrestashopConfiguration;
+use PrestaShop\Module\AutoUpgrade\Services\PhpVersionResolverService;
+use PrestaShop\Module\AutoUpgrade\Upgrader;
+use PrestaShop\Module\AutoUpgrade\UpgradeSelfCheck;
+use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\ModuleAdapter;
+use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\ModuleCompatibilityChecker;
+use PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator;
+use PrestaShop\Module\AutoUpgrade\Xml\ChecksumCompare;
+
+class UpgradeSelfCheckTest extends TestCase
+{
+    /**
+     * When the shop is already up-to-date, getDestinationVersion() returns null.
+     * getWarnings() must not throw a TypeError by passing null to ModuleCompatibilityChecker.
+     */
+    public function testGetWarningsDoesNotCrashWhenShopIsUpToDate(): void
+    {
+        if (PHP_VERSION_ID >= 80000) {
+            $this->markTestSkipped('An issue with this version of PHPUnit and PHP 8+ prevents this test to run.');
+        }
+
+        $upgrader = $this->createMock(Upgrader::class);
+        $upgrader->method('getDestinationVersion')->willReturn(null);
+        $upgrader->method('getLatestCompatibleModuleVersion')->willReturn('');
+
+        $updateConfiguration = $this->createMock(UpgradeConfiguration::class);
+        $updateConfiguration->method('isChannelLocal')->willReturn(false);
+
+        $prestashopConfiguration = $this->createMock(PrestashopConfiguration::class);
+        $translator = $this->createMock(Translator::class);
+        $phpVersionResolverService = $this->createMock(PhpVersionResolverService::class);
+
+        $checksumCompare = $this->createMock(ChecksumCompare::class);
+        // Return false so isAlteredFilesNull() returns true, simplifying getWarnings()
+        $checksumCompare->method('getTamperedFilesOnShop')->willReturn(false);
+
+        $moduleAdapter = $this->createMock(ModuleAdapter::class);
+
+        $moduleCompatibilityChecker = $this->createMock(ModuleCompatibilityChecker::class);
+        // This must NOT be called when destinationVersion is null
+        $moduleCompatibilityChecker->expects($this->never())->method('getModulesRequiringAttention');
+
+        $selfCheck = new UpgradeSelfCheck(
+            $upgrader,
+            $updateConfiguration,
+            $prestashopConfiguration,
+            $translator,
+            $phpVersionResolverService,
+            $checksumCompare,
+            $moduleAdapter,
+            $moduleCompatibilityChecker,
+            '/var/www/html',
+            '/var/www/html/admin-dev',
+            '/var/www/html/modules/autoupgrade',
+            '9.2.0'
+        );
+
+        $warnings = $selfCheck->getWarnings();
+
+        $this->assertArrayNotHasKey(UpgradeSelfCheck::MODULES_REQUIRE_ATTENTION, $warnings);
+    }
+
+    /**
+     * checkModuleRequiresAttention() must be called in all cases except when the local archive
+     * targets a non-officially-released version (PHP compatibility unknown).
+     *
+     * @dataProvider provideChannelConfigurationsExpectingModuleCheck
+     */
+    public function testCheckModuleRequiresAttentionIsCalled(bool $isChannelLocal, int $phpCompatibilityState): void
+    {
+        if (PHP_VERSION_ID >= 80000) {
+            $this->markTestSkipped('An issue with this version of PHPUnit and PHP 8+ prevents this test to run.');
+        }
+
+        $upgrader = $this->createMock(Upgrader::class);
+        $upgrader->method('getDestinationVersion')->willReturn('9.0.0');
+        // Empty string triggers DESTINATION_VERSION_IS_NOT_SUPPORTED, skipping isModuleVersionLatest() call
+        $upgrader->method('getLatestCompatibleModuleVersion')->willReturn('');
+
+        $updateConfiguration = $this->createMock(UpgradeConfiguration::class);
+        $updateConfiguration->method('isChannelLocal')->willReturn($isChannelLocal);
+
+        $prestashopConfiguration = $this->createMock(PrestashopConfiguration::class);
+        $translator = $this->createMock(Translator::class);
+
+        $phpVersionResolverService = $this->createMock(PhpVersionResolverService::class);
+        $phpVersionResolverService->method('getPhpRequirementsState')->willReturn($phpCompatibilityState);
+
+        $checksumCompare = $this->createMock(ChecksumCompare::class);
+        $checksumCompare->method('getTamperedFilesOnShop')->willReturn(false);
+
+        $moduleAdapter = $this->createMock(ModuleAdapter::class);
+        $moduleAdapter->method('listModulesPresentInFolderAndInstalled')->willReturn([]);
+
+        $moduleCompatibilityChecker = $this->createMock(ModuleCompatibilityChecker::class);
+        $moduleCompatibilityChecker->expects($this->once())
+            ->method('getModulesRequiringAttention')
+            ->willReturn(['incompatible_modules' => [], 'uncertain_modules' => [], 'compatibility' => []]);
+
+        $selfCheck = new UpgradeSelfCheck(
+            $upgrader,
+            $updateConfiguration,
+            $prestashopConfiguration,
+            $translator,
+            $phpVersionResolverService,
+            $checksumCompare,
+            $moduleAdapter,
+            $moduleCompatibilityChecker,
+            '/var/www/html',
+            '/var/www/html/admin-dev',
+            '/var/www/html/modules/autoupgrade',
+            '9.2.0'
+        );
+
+        $selfCheck->getWarnings();
+    }
+
+    /**
+     * @return array<string, array{bool, int}>
+     */
+    public function provideChannelConfigurationsExpectingModuleCheck(): array
+    {
+        return [
+            'non-local channel' => [false, PhpVersionResolverService::COMPATIBILITY_VALID],
+            'local channel, officially released version (PHP valid)' => [true, PhpVersionResolverService::COMPATIBILITY_VALID],
+            'local channel, officially released version (PHP invalid)' => [true, PhpVersionResolverService::COMPATIBILITY_INVALID],
+        ];
+    }
+
+    /**
+     * When the local archive targets a non-officially-released version, PHP compatibility cannot
+     * be determined (COMPATIBILITY_UNKNOWN). In this case, module compatibility data is unavailable
+     * too, so checkModuleRequiresAttention() must not be called.
+     */
+    public function testCheckModuleRequiresAttentionIsNotCalledForUnofficialLocalRelease(): void
+    {
+        if (PHP_VERSION_ID >= 80000) {
+            $this->markTestSkipped('An issue with this version of PHPUnit and PHP 8+ prevents this test to run.');
+        }
+
+        $upgrader = $this->createMock(Upgrader::class);
+        $upgrader->method('getDestinationVersion')->willReturn('9.0.0');
+        $upgrader->method('getLatestCompatibleModuleVersion')->willReturn('');
+
+        $updateConfiguration = $this->createMock(UpgradeConfiguration::class);
+        $updateConfiguration->method('isChannelLocal')->willReturn(true);
+
+        $prestashopConfiguration = $this->createMock(PrestashopConfiguration::class);
+        $translator = $this->createMock(Translator::class);
+
+        $phpVersionResolverService = $this->createMock(PhpVersionResolverService::class);
+        $phpVersionResolverService->method('getPhpRequirementsState')
+            ->willReturn(PhpVersionResolverService::COMPATIBILITY_UNKNOWN);
+
+        $checksumCompare = $this->createMock(ChecksumCompare::class);
+        $checksumCompare->method('getTamperedFilesOnShop')->willReturn(false);
+
+        $moduleAdapter = $this->createMock(ModuleAdapter::class);
+
+        $moduleCompatibilityChecker = $this->createMock(ModuleCompatibilityChecker::class);
+        $moduleCompatibilityChecker->expects($this->never())->method('getModulesRequiringAttention');
+
+        $selfCheck = new UpgradeSelfCheck(
+            $upgrader,
+            $updateConfiguration,
+            $prestashopConfiguration,
+            $translator,
+            $phpVersionResolverService,
+            $checksumCompare,
+            $moduleAdapter,
+            $moduleCompatibilityChecker,
+            '/var/www/html',
+            '/var/www/html/admin-dev',
+            '/var/www/html/modules/autoupgrade',
+            '9.2.0'
+        );
+
+        $warnings = $selfCheck->getWarnings();
+
+        $this->assertArrayNotHasKey(UpgradeSelfCheck::MODULES_REQUIRE_ATTENTION, $warnings);
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix a bug that doesn't check module required attention if we are on local channel
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | @PrestaShopCorp
| How to test?      | <ul><li>Using a local update must check the modules compatibility, UNLESS the release is not public yet</li><li>If the shop is up to date, the command must not fail but show instead there is nothing to do.</li></ul>