### PR TITLE
Add update option for module uninstallation

### DIFF
--- a/classes/Analytics.php
+++ b/classes/Analytics.php
@@ -134,6 +134,7 @@ class Analytics
                     'upgrade_channel' => $this->updateConfiguration->getChannel(),
                     'update_type' => $this->updateConfiguration->getUpdateType(),
                     'disable_non_native_modules' => $this->updateConfiguration->shouldDeactivateCustomModules(),
+                    'uninstall_incompatible_modules' => $this->updateConfiguration->shouldUninstallNonCompatibleModules(),
                     'regenerate_customized_email_templates' => $this->updateConfiguration->shouldRegenerateMailTemplates(),
                 ];
                 $upgradeProperties = $this->properties[self::WITH_UPDATE_PROPERTIES] ?? [];

--- a/classes/Commands/UpdateCommand.php
+++ b/classes/Commands/UpdateCommand.php
@@ -60,6 +60,7 @@ class UpdateCommand extends AbstractCommand
             ->addOption('zip', null, InputOption::VALUE_REQUIRED, 'Sets the archive zip file for a local update')
             ->addOption('xml', null, InputOption::VALUE_REQUIRED, 'Sets the archive xml file for a local update')
             ->addOption('disable-non-native-modules', null, InputOption::VALUE_REQUIRED, 'Disable all modules installed after the store creation (1 for yes, 0 for no). Ignored for PrestaShop v9 and above.')
+            ->addOption('uninstall-incompatible-modules', null, InputOption::VALUE_REQUIRED, 'Uninstall the modules incompatible with the new version of PrestaShop (1 for yes, 0 for no). Their configuration and data will be lost.')
             ->addOption('regenerate-email-templates', null, InputOption::VALUE_REQUIRED, "Regenerate email templates. If you've customized email templates, your changes will be lost if you activate this option (1 for yes, 0 for no)")
             ->addOption('disable-all-overrides', null, InputOption::VALUE_REQUIRED, 'Overriding is a way to replace business behaviors (class files and controller files) to target only one method or as many as you need. This option disables all classes & controllers overrides, allowing you to avoid conflicts during and after updates (1 for yes, 0 for no)')
             ->addOption('config-file-path', null, InputOption::VALUE_REQUIRED, 'Configuration file location for update.')
@@ -182,6 +183,7 @@ class UpdateCommand extends AbstractCommand
             UpgradeConfiguration::ARCHIVE_ZIP => 'zip',
             UpgradeConfiguration::ARCHIVE_XML => 'xml',
             UpgradeConfiguration::PS_AUTOUP_CUSTOM_MOD_DESACT => 'disable-non-native-modules',
+            UpgradeConfiguration::PS_AUTOUP_UNINSTALL_NON_COMPAT_MODS => 'uninstall-incompatible-modules',
             UpgradeConfiguration::PS_AUTOUP_REGEN_EMAIL => 'regenerate-email-templates',
             UpgradeConfiguration::PS_DISABLE_OVERRIDES => 'disable-all-overrides',
         ];

--- a/classes/Parameters/UpgradeConfiguration.php
+++ b/classes/Parameters/UpgradeConfiguration.php
@@ -34,6 +34,7 @@ use UnexpectedValueException;
 class UpgradeConfiguration extends ArrayCollection
 {
     const PS_AUTOUP_CUSTOM_MOD_DESACT = 'PS_AUTOUP_CUSTOM_MOD_DESACT';
+    const PS_AUTOUP_UNINSTALL_NON_COMPAT_MODS = 'PS_AUTOUP_UNINSTALL_NON_COMPAT_MODS';
     const PS_AUTOUP_CHANGE_DEFAULT_THEME = 'PS_AUTOUP_CHANGE_DEFAULT_THEME';
     const PS_AUTOUP_REGEN_EMAIL = 'PS_AUTOUP_REGEN_EMAIL';
     const PS_AUTOUP_KEEP_IMAGES = 'PS_AUTOUP_KEEP_IMAGES';
@@ -52,6 +53,7 @@ class UpgradeConfiguration extends ArrayCollection
 
     const UPGRADE_CONST_KEYS = [
         self::PS_AUTOUP_CUSTOM_MOD_DESACT,
+        self::PS_AUTOUP_UNINSTALL_NON_COMPAT_MODS,
         self::PS_AUTOUP_CHANGE_DEFAULT_THEME,
         self::PS_AUTOUP_REGEN_EMAIL,
         self::PS_AUTOUP_KEEP_IMAGES,
@@ -65,6 +67,7 @@ class UpgradeConfiguration extends ArrayCollection
 
     const PS_CONST_DEFAULT_VALUE = [
         self::PS_AUTOUP_CUSTOM_MOD_DESACT => true,
+        self::PS_AUTOUP_UNINSTALL_NON_COMPAT_MODS => true,
         self::PS_AUTOUP_CHANGE_DEFAULT_THEME => false,
         self::PS_AUTOUP_REGEN_EMAIL => true,
         self::PS_AUTOUP_KEEP_IMAGES => true,
@@ -220,6 +223,11 @@ class UpgradeConfiguration extends ArrayCollection
     public function shouldDeactivateCustomModules(): bool
     {
         return $this->computeBooleanConfiguration(self::PS_AUTOUP_CUSTOM_MOD_DESACT);
+    }
+
+    public function shouldUninstallNonCompatibleModules(): bool
+    {
+        return $this->computeBooleanConfiguration(self::PS_AUTOUP_UNINSTALL_NON_COMPAT_MODS);
     }
 
     /**

--- a/classes/Task/Update/UninstallModules.php
+++ b/classes/Task/Update/UninstallModules.php
@@ -111,7 +111,11 @@ class UninstallModules extends AbstractTask
             $this->stepDone = true;
             $this->status = 'ok';
             $this->next = TaskName::TASK_UPDATE_FILES;
-            $this->logger->info($this->translator->trans('Since this version of PrestaShop is not released to the public, the module compatibility check for uninstallation cannot be performed. Skipping to the next step.'));
+            if (!$this->container->getUpdateConfiguration()->shouldUninstallNonCompatibleModules()) {
+                $this->logger->info($this->translator->trans('Uninstallation of incompatible modules is disabled. Skipping to the next step.'));
+            } else {
+                $this->logger->info($this->translator->trans('Since this version of PrestaShop is not released to the public, the module compatibility check for uninstallation cannot be performed. Skipping to the next step.'));
+            }
 
             return ExitCode::SUCCESS;
         }

--- a/classes/Task/Update/UninstallModules.php
+++ b/classes/Task/Update/UninstallModules.php
@@ -98,7 +98,7 @@ class UninstallModules extends AbstractTask
     public function init(): void
     {
         $this->container->initPrestaShopCore();
-        // Container may be needed on uninstallation if the module loads services.
+        // Container may be needed to uninstall if the module loads services.
         $this->container->getSymfonyAdapter()->initKernel();
     }
 
@@ -112,7 +112,7 @@ class UninstallModules extends AbstractTask
             $this->status = 'ok';
             $this->next = TaskName::TASK_UPDATE_FILES;
             if (!$this->container->getUpdateConfiguration()->shouldUninstallNonCompatibleModules()) {
-                $this->logger->info($this->translator->trans('Uninstallation of incompatible modules is disabled. Skipping to the next step.'));
+                $this->logger->info($this->translator->trans('Uninstalling incompatible modules is disabled. Skipping to the next step.'));
             } else {
                 $this->logger->info($this->translator->trans('Since this version of PrestaShop is not released to the public, the module compatibility check for uninstallation cannot be performed. Skipping to the next step.'));
             }

--- a/classes/Task/Update/UpdateInitialization.php
+++ b/classes/Task/Update/UpdateInitialization.php
@@ -70,12 +70,13 @@ class UpdateInitialization extends AbstractTask
 
         $this->logger->info($this->translator->trans('Destination version: %s', [$destinationVersion]));
 
-        /**
-         * We use the same method as UpgradeSelfCheck to determine if the target version is known. If it isn't, we skip the uninstallation step (otherwise, it would cause a mass uninstallation of all modules that are not up to date).
+        /*
+         * If the option to uninstall incompatible modules is enabled, we use the same method as UpgradeSelfCheck to determine
+         * if the target version is known. If it isn't, we skip the uninstallation step (otherwise, it would cause a mass uninstallation of all modules that are not up to date).
          */
-        $phpRequirementsState = $this->container->getPhpVersionResolverService()->getPhpRequirementsState(PHP_VERSION_ID, $destinationVersion);
-
-        if ($phpRequirementsState === PhpVersionResolverService::COMPATIBILITY_UNKNOWN) {
+        if (!$this->container->getUpdateConfiguration()->shouldUninstallNonCompatibleModules()
+            || $this->container->getPhpVersionResolverService()->getPhpRequirementsState(PHP_VERSION_ID, $destinationVersion) === PhpVersionResolverService::COMPATIBILITY_UNKNOWN
+        ) {
             $updateState->setSkipUninstallModule(true);
         }
 

--- a/controllers/admin/self-managed/UpdatePageUpdateOptionsController.php
+++ b/controllers/admin/self-managed/UpdatePageUpdateOptionsController.php
@@ -59,6 +59,7 @@ class UpdatePageUpdateOptionsController extends AbstractPageWithStepController
 
         $config = [
             UpgradeConfiguration::PS_AUTOUP_CUSTOM_MOD_DESACT => $this->request->request->getBoolean(UpgradeConfiguration::PS_AUTOUP_CUSTOM_MOD_DESACT, false),
+            UpgradeConfiguration::PS_AUTOUP_UNINSTALL_NON_COMPAT_MODS => $this->request->request->getBoolean(UpgradeConfiguration::PS_AUTOUP_UNINSTALL_NON_COMPAT_MODS, false),
             UpgradeConfiguration::PS_AUTOUP_REGEN_EMAIL => $this->request->request->getBoolean(UpgradeConfiguration::PS_AUTOUP_REGEN_EMAIL, false),
             UpgradeConfiguration::PS_DISABLE_OVERRIDES => $this->request->request->getBoolean(UpgradeConfiguration::PS_DISABLE_OVERRIDES, false),
         ];
@@ -108,6 +109,10 @@ class UpdatePageUpdateOptionsController extends AbstractPageWithStepController
                         'visible' => version_compare('9.0.0', $this->upgradeContainer->getUpgrader()->getDestinationVersion(), '>'),
                         'field' => UpgradeConfiguration::PS_AUTOUP_CUSTOM_MOD_DESACT,
                         'value' => $updateConfiguration->shouldDeactivateCustomModules(),
+                    ],
+                    'uninstall_incompatible_modules' => [
+                        'field' => UpgradeConfiguration::PS_AUTOUP_UNINSTALL_NON_COMPAT_MODS,
+                        'value' => $updateConfiguration->shouldUninstallNonCompatibleModules(),
                     ],
                     'regenerate_email_templates' => [
                         'field' => UpgradeConfiguration::PS_AUTOUP_REGEN_EMAIL,

--- a/tests/unit/AnalyticsTest.php
+++ b/tests/unit/AnalyticsTest.php
@@ -53,6 +53,7 @@ class AnalyticsTest extends TestCase
         $updateConfiguration = $configurationStorage->loadUpdateConfiguration();
         $updateConfiguration->merge([
             UpgradeConfiguration::PS_AUTOUP_CUSTOM_MOD_DESACT => false,
+            UpgradeConfiguration::PS_AUTOUP_UNINSTALL_NON_COMPAT_MODS => true,
             UpgradeConfiguration::PS_AUTOUP_CHANGE_DEFAULT_THEME => true,
             UpgradeConfiguration::PS_AUTOUP_REGEN_EMAIL => true,
             UpgradeConfiguration::PS_AUTOUP_KEEP_IMAGES => false,
@@ -109,6 +110,7 @@ class AnalyticsTest extends TestCase
                     'to_ps_version' => '8.8.808',
                     'upgrade_channel' => 'local',
                     'disable_non_native_modules' => false,
+                    'uninstall_incompatible_modules' => true,
                     'regenerate_customized_email_templates' => true,
                     'regenerate_rtl_stylesheet' => false,
                     'update_type' => 'patch',

--- a/views/templates/steps/update-options.html.twig
+++ b/views/templates/steps/update-options.html.twig
@@ -45,6 +45,15 @@
     {% endif %}
 
     {% include "@ModuleAutoUpgrade/components/render-switch.html.twig" with {
+      id: form_fields.uninstall_incompatible_modules.field,
+      name: form_fields.uninstall_incompatible_modules.field,
+      title: "Uninstall incompatible modules"|trans({}),
+      description: "Modules detected as incompatible with the new version of PrestaShop will be uninstalled before the update begins, so they can safely remove their modifications. Their configuration and data will be lost."|trans({}),
+      value: form_fields.uninstall_incompatible_modules.value,
+      error_message: errors[form_fields.uninstall_incompatible_modules.field] is defined ? errors[form_fields.uninstall_incompatible_modules.field] : null,
+    } %}
+
+    {% include "@ModuleAutoUpgrade/components/render-switch.html.twig" with {
       id: form_fields.regenerate_email_templates.field,
       name: form_fields.regenerate_email_templates.field,
       title: "Regenerate email templates"|trans({}),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      |Add an option to uninstall modules.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fix https://github.com/PrestaShop/autoupgrade/issues/1773
| Sponsor company   | @PrestaShopCorp
| How to test?      | See below

### Acceptance criteria

1. A new "Uninstall incompatible modules" toggle is visible on the update options page and enabled by default
2. When enabled, the upgrade behaves as today: incompatible modules are uninstalled
3. When disabled, incompatible modules are not uninstalled during upgrade
4. The option state is taken in account on web UI and CLI workflows
5. Web: When upgrading to PrestaShop 1.7 or 8, the option appears in second position in the list, after "Disable non-native modules"
6. Web: When upgrading to PrestaShop 9 and above, the option appears in first position, replacing "Disable non-native modules"
7. CLI: The option is managed with the input `--uninstall-incompatible-modules=`
8. CLI: The option is managed with a configuration file and a key `PS_AUTOUP_UNINSTALL_NON_COMPAT_MODS`