### PR TITLE
Make wording about incompatible module more explicit about uninstallation

### DIFF
--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -443,9 +443,9 @@ class UpgradeSelfCheck
                         '[1]' => '<a class="link" href="#' . Routes::UPDATE_STEP_VERSION_CHOICE_MODULES_REPORT_DIALOG . '">',
                         '[/1]' => '</a>',
                     ];
-                    $message = $this->translator->trans('Some modules require your attention. [1]See the details[/1].', $params);
+                    $message = $this->translator->trans('Some installed modules are incompatible or have uncertain compatibility with the target version. Incompatible ones will be uninstalled. [1]See the details[/1].', $params);
                 } else {
-                    $message = $this->translator->trans('Some modules require your attention. Run bin/console %command%', ['%command%' => CheckModulesCommand::getDefaultName()]);
+                    $message = $this->translator->trans('Some installed modules are incompatible or have uncertain compatibility with the target version. Incompatible ones will be uninstalled. Run bin/console %command%', ['%command%' => CheckModulesCommand::getDefaultName()]);
                 }
 
                 return [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The wording wasn't clear enough about incompatible modules being uninstalled.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fix https://github.com/PrestaShop/autoupgrade/issues/1773
| Sponsor company   | @PrestaShopCorp
| How to test?      | Wording is updated on check of requirements on web and CLI
