### PR TITLE
Improve performance of update of order_detail table data

### DIFF
--- a/upgrade/sql/1.7.7.0.sql
+++ b/upgrade/sql/1.7.7.0.sql
@@ -404,17 +404,17 @@ ALTER TABLE `PREFIX_order_cart_rule` CHANGE `value_tax_excl` `value_tax_excl` DE
 
 UPDATE
     `PREFIX_order_detail` `od`
+LEFT JOIN (
+    SELECT
+        `id_order_detail`,
+        SUM(`amount_tax_excl`) AS `total_tax_excl`,
+        SUM(`amount_tax_incl`) AS `total_tax_incl`
+    FROM `PREFIX_order_slip_detail`
+    GROUP BY `id_order_detail`
+) `osd` ON `osd`.`id_order_detail` = `od`.`id_order_detail`
 SET
-    `od`.`total_refunded_tax_excl` = IFNULL((
-        SELECT SUM(`osd`.`amount_tax_excl`)
-        FROM `PREFIX_order_slip_detail` `osd`
-        WHERE `osd`.`id_order_detail` = `od`.`id_order_detail`
-    ), 0),
-    `od`.`total_refunded_tax_incl` = IFNULL((
-        SELECT SUM(`osd`.`amount_tax_incl`)
-        FROM `PREFIX_order_slip_detail` `osd`
-        WHERE `osd`.`id_order_detail` = `od`.`id_order_detail`
-    ), 0)
+    `od`.`total_refunded_tax_excl` = IFNULL(`osd`.`total_tax_excl`, 0),
+    `od`.`total_refunded_tax_incl` = IFNULL(`osd`.`total_tax_incl`, 0)
 ;
 INSERT INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`)
 VALUES (NULL, 'actionOrderMessageFormBuilderModifier', 'Modify order message identifiable object form',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix a bottleneck on a SQL request that contains 2 sub queries to the same table for each row.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/autoupgrade/issues/1561
| Sponsor company   | @PrestaShopCorp
| How to test?      | Table contents of `order_detail` after an update to 1.7.7.0+ is the same before and after the PR.


### Technical details

  **EXPLAIN - Original query**                                                                                                                      
                                                                                                                                                
  id  select_type         table   type   key                   rows    Extra
  1   UPDATE              od      index  PRIMARY               100082  NULL                                                                     
  2   DEPENDENT SUBQUERY  osd     ref    idx_id_order_detail   2       NULL                                                                     
  3   DEPENDENT SUBQUERY  osd     ref    idx_id_order_detail   2       NULL                                                                     
                                                                                                                                                
  **EXPLAIN - Optimized query**                                                                                                                     
                                                                                                                                                
  id  select_type  table                type   key            rows   Extra
  1   UPDATE       od                   ALL    NULL           100082 NULL                                                                       
  1   PRIMARY      <derived2>           ref    <auto_key0>    10     NULL
  2   DERIVED      test_order_slip_det  index  idx_id_order…  9689   NULL                                                                       
                                                                                                                                                
  **Timing**                                                                                                                                        
                                                                  
|      Query   |Duration |                                                                                                
  | -- | -- |
| Original (correlated subquery)  |  2.258s  |
|Optimized (LEFT JOIN)  | 0.429s |
| Speedup | 5.3× |
