### PR TITLE
Check module compatibility with both source and destination versions of PrestaShop

### DIFF
--- a/classes/Task/Update/UninstallModules.php
+++ b/classes/Task/Update/UninstallModules.php
@@ -137,7 +137,8 @@ class UninstallModules extends AbstractTask
 
             $checkResult = $this->container->getModuleCompatibilityChecker()->getModulesRequiringAttention(
                 $modulesList,
-                $targetVersion
+                $targetVersion,
+                $this->container->getUpdateState()->getCurrentVersion()
             );
 
             foreach ($checkResult['uncertain_modules'] as $moduleName) {

--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -788,7 +788,7 @@ class UpgradeSelfCheck
     {
         $modulesInstalled = $this->moduleAdapter->listModulesPresentInFolderAndInstalled();
 
-        return $this->moduleCompatibilityChecker->getModulesRequiringAttention($modulesInstalled, $this->destinationVersion, $mode);
+        return $this->moduleCompatibilityChecker->getModulesRequiringAttention($modulesInstalled, $this->destinationVersion, $this->currentVersion, $mode);
     }
 
     /**

--- a/classes/UpgradeTools/Module/ModuleCompatibilityChecker.php
+++ b/classes/UpgradeTools/Module/ModuleCompatibilityChecker.php
@@ -111,7 +111,7 @@ class ModuleCompatibilityChecker
                 }
             } elseif (!$moduleCompatibility->isCompatible()) {
                 if (!$moduleIsNative) {
-                    if (!$moduleDetails->product->isActive && $sourceVersion && !$this->marketplaceService->findCompatibleModuleUpgrade($moduleDetails, $sourceVersion, $localVersion)->isCompatible()) {
+                    if ($sourceVersion && !$this->marketplaceService->findCompatibleModuleUpgrade($moduleDetails, $sourceVersion, $localVersion)->isCompatible()) {
                         $result['uncertain_modules'][] = $localModuleName;
                     } else {
                         $result['incompatible_modules'][] = $localModuleName;

--- a/classes/UpgradeTools/Module/ModuleCompatibilityChecker.php
+++ b/classes/UpgradeTools/Module/ModuleCompatibilityChecker.php
@@ -55,7 +55,7 @@ class ModuleCompatibilityChecker
      *
      * @return array{incompatible_modules: string[], uncertain_modules: string[], compatibility: array<string, ?ModuleUpgradeCompatibility>}
      */
-    public function getModulesRequiringAttention(array $modulesInstalled, string $targetVersion, $mode = self::COMPLETE_SEARCH): array
+    public function getModulesRequiringAttention(array $modulesInstalled, string $targetVersion, ?string $sourceVersion = null, $mode = self::COMPLETE_SEARCH): array
     {
         $result = [
             'incompatible_modules' => [],
@@ -111,7 +111,7 @@ class ModuleCompatibilityChecker
                 }
             } elseif (!$moduleCompatibility->isCompatible()) {
                 if (!$moduleIsNative) {
-                    if (!$moduleDetails->product->isActive) {
+                    if (!$moduleDetails->product->isActive && $sourceVersion && !$this->marketplaceService->findCompatibleModuleUpgrade($moduleDetails, $sourceVersion, $localVersion)->isCompatible()) {
                         $result['uncertain_modules'][] = $localModuleName;
                     } else {
                         $result['incompatible_modules'][] = $localModuleName;

--- a/classes/UpgradeTools/Module/ModuleCompatibilityChecker.php
+++ b/classes/UpgradeTools/Module/ModuleCompatibilityChecker.php
@@ -111,7 +111,11 @@ class ModuleCompatibilityChecker
                 }
             } elseif (!$moduleCompatibility->isCompatible()) {
                 if (!$moduleIsNative) {
-                    $result['incompatible_modules'][] = $localModuleName;
+                    if (!$moduleDetails->product->isActive) {
+                        $result['uncertain_modules'][] = $localModuleName;
+                    } else {
+                        $result['incompatible_modules'][] = $localModuleName;
+                    }
                 }
 
                 if ($mode === self::QUICK_SEARCH) {

--- a/tests/integration/MarketplaceAndModuleCompatibilityTest.php
+++ b/tests/integration/MarketplaceAndModuleCompatibilityTest.php
@@ -42,6 +42,7 @@ class MarketplaceAndModuleCompatibilityTest extends TestCase
             // Compatible and active modules
             ['name' => 'ps_mcp_tools',      'currentVersion' => '1.0.0'],
             ['name' => 'paypal',            'currentVersion' => '1.0.0'],
+            ['name' => 'chronopost',        'currentVersion' => '1.0.0'],
 
             // psxdesign has is_active=false but does have releases compatible with PS 9.0.0.
             // It should be reported as compatible (absent from both lists).
@@ -52,6 +53,9 @@ class MarketplaceAndModuleCompatibilityTest extends TestCase
             ['name' => 'iqitpopup',         'currentVersion' => '1.0.0'],
             ['name' => 'monetico',          'currentVersion' => '1.0.0'],
             ['name' => 'lghidesubcat',      'currentVersion' => '1.0.0'],
+
+            // Module not maintained anymore on marketplace
+            ['name' => 'systempay',         'currentVersion' => '1.0.0'],
 
             // Modules known as incomaptible
             ['name' => 'ps_edition_basic',  'currentVersion' => '1.0.0'],
@@ -66,6 +70,6 @@ class MarketplaceAndModuleCompatibilityTest extends TestCase
         $result = $checker->getModulesRequiringAttention($modules, '9.0.0', '8.2.0', ModuleCompatibilityChecker::COMPLETE_SEARCH);
 
         $this->assertEquals(['ps_edition_basic'], $result['incompatible_modules']);
-        $this->assertEquals(['iqitpopup', 'monetico', 'lghidesubcat'], $result['uncertain_modules']);
+        $this->assertEquals(['iqitpopup', 'monetico', 'lghidesubcat', 'systempay'], $result['uncertain_modules']);
     }
 }

--- a/tests/integration/MarketplaceAndModuleCompatibilityTest.php
+++ b/tests/integration/MarketplaceAndModuleCompatibilityTest.php
@@ -20,10 +20,6 @@
  */
 
 use PHPUnit\Framework\TestCase;
-use PrestaShop\Module\AutoUpgrade\Exceptions\MarketplaceApiException;
-use PrestaShop\Module\AutoUpgrade\Models\Module\DistributionApi\Module as DistributionApiModule;
-use PrestaShop\Module\AutoUpgrade\Models\Module\Marketplace\Module as MarketplaceModule;
-use PrestaShop\Module\AutoUpgrade\Models\Module\Marketplace\ModuleUpgradeCompatibility;
 use PrestaShop\Module\AutoUpgrade\Models\Module\Marketplace\Release;
 use PrestaShop\Module\AutoUpgrade\Services\DistributionApiService;
 use PrestaShop\Module\AutoUpgrade\Services\MarketplaceService;

--- a/tests/integration/MarketplaceAndModuleCompatibilityTest.php
+++ b/tests/integration/MarketplaceAndModuleCompatibilityTest.php
@@ -63,7 +63,7 @@ class MarketplaceAndModuleCompatibilityTest extends TestCase
             new MarketplaceService($translator)
         );
 
-        $result = $checker->getModulesRequiringAttention($modules, '9.0.0', ModuleCompatibilityChecker::COMPLETE_SEARCH);
+        $result = $checker->getModulesRequiringAttention($modules, '9.0.0', '8.2.0', ModuleCompatibilityChecker::COMPLETE_SEARCH);
 
         $this->assertEquals(['ps_edition_basic'], $result['incompatible_modules']);
         $this->assertEquals(['iqitpopup', 'monetico', 'lghidesubcat'], $result['uncertain_modules']);

--- a/tests/integration/MarketplaceAndModuleCompatibilityTest.php
+++ b/tests/integration/MarketplaceAndModuleCompatibilityTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\Module\AutoUpgrade\Exceptions\MarketplaceApiException;
+use PrestaShop\Module\AutoUpgrade\Models\Module\DistributionApi\Module as DistributionApiModule;
+use PrestaShop\Module\AutoUpgrade\Models\Module\Marketplace\Module as MarketplaceModule;
+use PrestaShop\Module\AutoUpgrade\Models\Module\Marketplace\ModuleUpgradeCompatibility;
+use PrestaShop\Module\AutoUpgrade\Models\Module\Marketplace\Release;
+use PrestaShop\Module\AutoUpgrade\Services\DistributionApiService;
+use PrestaShop\Module\AutoUpgrade\Services\MarketplaceService;
+use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\ModuleCompatibilityChecker;
+use PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator;
+
+class MarketplaceAndModuleCompatibilityTest extends TestCase
+{
+    /**
+     * Integration tests hitting the real Marketplace and Distribution APIs.
+     * Requires network access.
+     */
+    public function testModulesWithOfflinePageAndNoCompatibleReleaseAreUncertain(): void
+    {
+        $modules = [
+            // Compatible and active modules
+            ['name' => 'ps_mcp_tools',      'currentVersion' => '1.0.0'],
+            ['name' => 'paypal',            'currentVersion' => '1.0.0'],
+
+            // psxdesign has is_active=false but does have releases compatible with PS 9.0.0.
+            // It should be reported as compatible (absent from both lists).
+            ['name' => 'psxdesign',         'currentVersion' => '2.0.0'],
+
+            // Third-party modules with is_active=false and no release compatible with the target
+            // version should be reported as uncertain, not incompatible.
+            ['name' => 'iqitpopup',         'currentVersion' => '1.0.0'],
+            ['name' => 'monetico',          'currentVersion' => '1.0.0'],
+            ['name' => 'lghidesubcat',      'currentVersion' => '1.0.0'],
+
+            // Modules known as incomaptible
+            ['name' => 'ps_edition_basic',  'currentVersion' => '1.0.0'],
+        ];
+
+        $translator = new Translator('en');
+        $checker = new ModuleCompatibilityChecker(
+            new DistributionApiService($translator),
+            new MarketplaceService($translator)
+        );
+
+        $result = $checker->getModulesRequiringAttention($modules, '9.0.0', ModuleCompatibilityChecker::COMPLETE_SEARCH);
+
+        $this->assertEquals(['ps_edition_basic'], $result['incompatible_modules']);
+        $this->assertEquals(['iqitpopup', 'monetico', 'lghidesubcat'], $result['uncertain_modules']);
+    }
+}

--- a/tests/integration/MarketplaceAndModuleCompatibilityTest.php
+++ b/tests/integration/MarketplaceAndModuleCompatibilityTest.php
@@ -68,4 +68,31 @@ class MarketplaceAndModuleCompatibilityTest extends TestCase
         $this->assertEquals(['ps_edition_basic'], $result['incompatible_modules']);
         $this->assertEquals(['iqitpopup', 'monetico', 'lghidesubcat', 'systempay'], $result['uncertain_modules']);
     }
+
+    public function testModulesWithOfflinePageAndNoCompatibleReleaseAreUncertainOnSameMajorVersion(): void
+    {
+        $modules = [
+            // Compatible and active modules
+            ['name' => 'ps_mcp_tools',      'currentVersion' => '1.0.0'],
+            ['name' => 'paypal',            'currentVersion' => '1.0.0'],
+            ['name' => 'chronopost',        'currentVersion' => '1.0.0'],
+
+            // Modules for PrestaShop 1.7. Updates from and to PS 8 tell if the modules has been made compliant.
+            ['name' => 'anscrolltop',       'currentVersion' => '1.0.0'],
+            ['name' => 'ps_buybuttonlite',  'currentVersion' => '1.0.0'],
+            ['name' => 'psaddonsconnect',   'currentVersion' => '1.0.0'],
+            ['name' => 'welcome',           'currentVersion' => '1.0.0'],
+        ];
+
+        $translator = new Translator('en');
+        $checker = new ModuleCompatibilityChecker(
+            new DistributionApiService($translator),
+            new MarketplaceService($translator)
+        );
+
+        $result = $checker->getModulesRequiringAttention($modules, '8.2.5', '8.2.1', ModuleCompatibilityChecker::COMPLETE_SEARCH);
+
+        $this->assertEquals([], $result['incompatible_modules']);
+        $this->assertEquals(['anscrolltop', 'ps_buybuttonlite', 'psaddonsconnect', 'welcome'], $result['uncertain_modules']);
+    }
 }

--- a/tests/unit/UpgradeTools/Module/ModuleCompatibilityCheckerTest.php
+++ b/tests/unit/UpgradeTools/Module/ModuleCompatibilityCheckerTest.php
@@ -81,7 +81,7 @@ class ModuleCompatibilityCheckerTest extends TestCase
 
         $this->marketplaceService->expects($this->exactly(3))->method('getModuleDetail');
 
-        $actual = $this->moduleCompatibilityChecker->getModulesRequiringAttention($installedModules, '99.99.99', '', ModuleCompatibilityChecker::COMPLETE_SEARCH);
+        $actual = $this->moduleCompatibilityChecker->getModulesRequiringAttention($installedModules, '99.99.99', null, ModuleCompatibilityChecker::COMPLETE_SEARCH);
 
         $this->assertEquals($expected['incompatible_modules'], $actual['incompatible_modules']);
         $this->assertEquals($expected['uncertain_modules'], $actual['uncertain_modules']);
@@ -111,7 +111,7 @@ class ModuleCompatibilityCheckerTest extends TestCase
         // The results are the same but the number of calls to the marketplace is different
         $this->marketplaceService->expects($this->exactly(6))->method('getModuleDetail');
 
-        $actual = $this->moduleCompatibilityChecker->getModulesRequiringAttention($installedModules, '99.99.99', '', ModuleCompatibilityChecker::DETAILED_SEARCH);
+        $actual = $this->moduleCompatibilityChecker->getModulesRequiringAttention($installedModules, '99.99.99', null, ModuleCompatibilityChecker::DETAILED_SEARCH);
 
         $this->assertEquals($expected['incompatible_modules'], $actual['incompatible_modules']);
         $this->assertEquals($expected['uncertain_modules'], $actual['uncertain_modules']);
@@ -136,7 +136,7 @@ class ModuleCompatibilityCheckerTest extends TestCase
 
         $this->marketplaceService->expects($this->never())->method('getModuleDetail');
 
-        $actual = $this->moduleCompatibilityChecker->getModulesRequiringAttention($installedModules, '99.99.99', '', ModuleCompatibilityChecker::COMPLETE_SEARCH);
+        $actual = $this->moduleCompatibilityChecker->getModulesRequiringAttention($installedModules, '99.99.99', null, ModuleCompatibilityChecker::COMPLETE_SEARCH);
 
         $this->assertEquals($expected['incompatible_modules'], $actual['incompatible_modules']);
         $this->assertEquals($expected['uncertain_modules'], $actual['uncertain_modules']);
@@ -164,7 +164,7 @@ class ModuleCompatibilityCheckerTest extends TestCase
 
         $this->marketplaceService->expects($this->once())->method('getModuleDetail');
 
-        $actual = $this->moduleCompatibilityChecker->getModulesRequiringAttention($installedModules, '99.99.99', '', ModuleCompatibilityChecker::QUICK_SEARCH);
+        $actual = $this->moduleCompatibilityChecker->getModulesRequiringAttention($installedModules, '99.99.99', null, ModuleCompatibilityChecker::QUICK_SEARCH);
 
         $this->assertEquals($expected['incompatible_modules'], $actual['incompatible_modules']);
         $this->assertEquals($expected['uncertain_modules'], $actual['uncertain_modules']);
@@ -191,7 +191,7 @@ class ModuleCompatibilityCheckerTest extends TestCase
 
         $this->marketplaceService->expects($this->once())->method('getModuleDetail');
 
-        $actual = $this->moduleCompatibilityChecker->getModulesRequiringAttention($installedModules, '99.99.99', '', ModuleCompatibilityChecker::QUICK_SEARCH);
+        $actual = $this->moduleCompatibilityChecker->getModulesRequiringAttention($installedModules, '99.99.99', null, ModuleCompatibilityChecker::QUICK_SEARCH);
 
         $this->assertEquals($expected['incompatible_modules'], $actual['incompatible_modules']);
         $this->assertEquals($expected['uncertain_modules'], $actual['uncertain_modules']);
@@ -222,7 +222,7 @@ class ModuleCompatibilityCheckerTest extends TestCase
         }));
         $checker = new ModuleCompatibilityChecker($this->distributionApiService, $marketplaceService);
 
-        $actual = $checker->getModulesRequiringAttention($installedModules, '99.99.99', '', ModuleCompatibilityChecker::COMPLETE_SEARCH);
+        $actual = $checker->getModulesRequiringAttention($installedModules, '99.99.99', null, ModuleCompatibilityChecker::COMPLETE_SEARCH);
 
         $this->assertEquals($expected['incompatible_modules'], $actual['incompatible_modules']);
         $this->assertEquals($expected['uncertain_modules'], $actual['uncertain_modules']);

--- a/tests/unit/UpgradeTools/Module/ModuleCompatibilityCheckerTest.php
+++ b/tests/unit/UpgradeTools/Module/ModuleCompatibilityCheckerTest.php
@@ -81,7 +81,7 @@ class ModuleCompatibilityCheckerTest extends TestCase
 
         $this->marketplaceService->expects($this->exactly(3))->method('getModuleDetail');
 
-        $actual = $this->moduleCompatibilityChecker->getModulesRequiringAttention($installedModules, '99.99.99', ModuleCompatibilityChecker::COMPLETE_SEARCH);
+        $actual = $this->moduleCompatibilityChecker->getModulesRequiringAttention($installedModules, '99.99.99', '', ModuleCompatibilityChecker::COMPLETE_SEARCH);
 
         $this->assertEquals($expected['incompatible_modules'], $actual['incompatible_modules']);
         $this->assertEquals($expected['uncertain_modules'], $actual['uncertain_modules']);
@@ -111,7 +111,7 @@ class ModuleCompatibilityCheckerTest extends TestCase
         // The results are the same but the number of calls to the marketplace is different
         $this->marketplaceService->expects($this->exactly(6))->method('getModuleDetail');
 
-        $actual = $this->moduleCompatibilityChecker->getModulesRequiringAttention($installedModules, '99.99.99', ModuleCompatibilityChecker::DETAILED_SEARCH);
+        $actual = $this->moduleCompatibilityChecker->getModulesRequiringAttention($installedModules, '99.99.99', '', ModuleCompatibilityChecker::DETAILED_SEARCH);
 
         $this->assertEquals($expected['incompatible_modules'], $actual['incompatible_modules']);
         $this->assertEquals($expected['uncertain_modules'], $actual['uncertain_modules']);
@@ -136,7 +136,7 @@ class ModuleCompatibilityCheckerTest extends TestCase
 
         $this->marketplaceService->expects($this->never())->method('getModuleDetail');
 
-        $actual = $this->moduleCompatibilityChecker->getModulesRequiringAttention($installedModules, '99.99.99', ModuleCompatibilityChecker::COMPLETE_SEARCH);
+        $actual = $this->moduleCompatibilityChecker->getModulesRequiringAttention($installedModules, '99.99.99', '', ModuleCompatibilityChecker::COMPLETE_SEARCH);
 
         $this->assertEquals($expected['incompatible_modules'], $actual['incompatible_modules']);
         $this->assertEquals($expected['uncertain_modules'], $actual['uncertain_modules']);
@@ -164,7 +164,7 @@ class ModuleCompatibilityCheckerTest extends TestCase
 
         $this->marketplaceService->expects($this->once())->method('getModuleDetail');
 
-        $actual = $this->moduleCompatibilityChecker->getModulesRequiringAttention($installedModules, '99.99.99', ModuleCompatibilityChecker::QUICK_SEARCH);
+        $actual = $this->moduleCompatibilityChecker->getModulesRequiringAttention($installedModules, '99.99.99', '', ModuleCompatibilityChecker::QUICK_SEARCH);
 
         $this->assertEquals($expected['incompatible_modules'], $actual['incompatible_modules']);
         $this->assertEquals($expected['uncertain_modules'], $actual['uncertain_modules']);
@@ -191,7 +191,7 @@ class ModuleCompatibilityCheckerTest extends TestCase
 
         $this->marketplaceService->expects($this->once())->method('getModuleDetail');
 
-        $actual = $this->moduleCompatibilityChecker->getModulesRequiringAttention($installedModules, '99.99.99', ModuleCompatibilityChecker::QUICK_SEARCH);
+        $actual = $this->moduleCompatibilityChecker->getModulesRequiringAttention($installedModules, '99.99.99', '', ModuleCompatibilityChecker::QUICK_SEARCH);
 
         $this->assertEquals($expected['incompatible_modules'], $actual['incompatible_modules']);
         $this->assertEquals($expected['uncertain_modules'], $actual['uncertain_modules']);
@@ -222,14 +222,15 @@ class ModuleCompatibilityCheckerTest extends TestCase
         }));
         $checker = new ModuleCompatibilityChecker($this->distributionApiService, $marketplaceService);
 
-        $actual = $checker->getModulesRequiringAttention($installedModules, '99.99.99', ModuleCompatibilityChecker::COMPLETE_SEARCH);
+        $actual = $checker->getModulesRequiringAttention($installedModules, '99.99.99', '', ModuleCompatibilityChecker::COMPLETE_SEARCH);
 
         $this->assertEquals($expected['incompatible_modules'], $actual['incompatible_modules']);
         $this->assertEquals($expected['uncertain_modules'], $actual['uncertain_modules']);
     }
 
-    public function testIncompatibleModuleWithOfflinePageIsUncertainNotIncompatible(): void
+    public function testOfflineModuleNotCompatibleWithSourceVersionIsUncertain(): void
     {
+        // iqitpopup only has releases for PS 1.6, so it was not compatible with the 8.x source version
         $installedModules = [
             ['name' => 'iqitpopup', 'currentVersion' => '1.0.0'],
         ];
@@ -247,10 +248,37 @@ class ModuleCompatibilityCheckerTest extends TestCase
         }));
 
         $checker = new ModuleCompatibilityChecker($this->distributionApiService, $marketplaceService);
-        $actual = $checker->getModulesRequiringAttention($installedModules, '9.0.0', ModuleCompatibilityChecker::COMPLETE_SEARCH);
+        $actual = $checker->getModulesRequiringAttention($installedModules, '9.0.0', '8.2.0', ModuleCompatibilityChecker::COMPLETE_SEARCH);
 
         $this->assertEmpty($actual['incompatible_modules']);
         $this->assertEquals(['iqitpopup'], $actual['uncertain_modules']);
+    }
+
+    public function testOfflineModuleCompatibleWithSourceVersionIsIncompatible(): void
+    {
+        // ps_edition_basic had releases for PS 8.x, so it was compatible with the source version
+        $installedModules = [
+            ['name' => 'ps_edition_basic', 'currentVersion' => '1.0.0'],
+        ];
+
+        $marketplaceService = $this->createMock(MarketplaceService::class);
+        $marketplaceService->method('getModuleDetail')->willReturn(
+            MarketplaceModule::fromArray(['product' => ['is_active' => false]])
+        );
+        // First call: target 9.0.0 → not compatible. Second call: source 8.2.0 → compatible.
+        $marketplaceService->method('findCompatibleModuleUpgrade')->will($this->returnCallback(function (MarketplaceModule $module, string $version) {
+            $compat = $this->createMock(ModuleUpgradeCompatibility::class);
+            $compat->method('isCompatible')->willReturn($version === '8.2.0');
+            $compat->method('getLatestRelease')->willReturn(Release::fromArray($this->createModuleRelease()));
+
+            return $compat;
+        }));
+
+        $checker = new ModuleCompatibilityChecker($this->distributionApiService, $marketplaceService);
+        $actual = $checker->getModulesRequiringAttention($installedModules, '9.0.0', '8.2.0', ModuleCompatibilityChecker::COMPLETE_SEARCH);
+
+        $this->assertEquals(['ps_edition_basic'], $actual['incompatible_modules']);
+        $this->assertEmpty($actual['uncertain_modules']);
     }
 
     public function testCompatibleModuleWithOfflinePageRemainsCompatible(): void

--- a/tests/unit/UpgradeTools/Module/ModuleCompatibilityCheckerTest.php
+++ b/tests/unit/UpgradeTools/Module/ModuleCompatibilityCheckerTest.php
@@ -228,6 +228,56 @@ class ModuleCompatibilityCheckerTest extends TestCase
         $this->assertEquals($expected['uncertain_modules'], $actual['uncertain_modules']);
     }
 
+    public function testIncompatibleModuleWithOfflinePageIsUncertainNotIncompatible(): void
+    {
+        $installedModules = [
+            ['name' => 'iqitpopup', 'currentVersion' => '1.0.0'],
+        ];
+
+        $marketplaceService = $this->createMock(MarketplaceService::class);
+        $marketplaceService->method('getModuleDetail')->willReturn(
+            MarketplaceModule::fromArray(['product' => ['is_active' => false]])
+        );
+        $marketplaceService->method('findCompatibleModuleUpgrade')->will($this->returnCallback(function () {
+            $compat = $this->createMock(ModuleUpgradeCompatibility::class);
+            $compat->method('isCompatible')->willReturn(false);
+            $compat->method('getLatestRelease')->willReturn(Release::fromArray($this->createModuleRelease()));
+
+            return $compat;
+        }));
+
+        $checker = new ModuleCompatibilityChecker($this->distributionApiService, $marketplaceService);
+        $actual = $checker->getModulesRequiringAttention($installedModules, '9.0.0', ModuleCompatibilityChecker::COMPLETE_SEARCH);
+
+        $this->assertEmpty($actual['incompatible_modules']);
+        $this->assertEquals(['iqitpopup'], $actual['uncertain_modules']);
+    }
+
+    public function testCompatibleModuleWithOfflinePageRemainsCompatible(): void
+    {
+        $installedModules = [
+            ['name' => 'psxdesign', 'currentVersion' => '2.0.0'],
+        ];
+
+        $marketplaceService = $this->createMock(MarketplaceService::class);
+        $marketplaceService->method('getModuleDetail')->willReturn(
+            MarketplaceModule::fromArray(['product' => ['is_active' => false]])
+        );
+        $marketplaceService->method('findCompatibleModuleUpgrade')->will($this->returnCallback(function () {
+            $compat = $this->createMock(ModuleUpgradeCompatibility::class);
+            $compat->method('isCompatible')->willReturn(true);
+            $compat->method('getLatestRelease')->willReturn(Release::fromArray($this->createModuleRelease()));
+
+            return $compat;
+        }));
+
+        $checker = new ModuleCompatibilityChecker($this->distributionApiService, $marketplaceService);
+        $actual = $checker->getModulesRequiringAttention($installedModules, '9.0.0', ModuleCompatibilityChecker::COMPLETE_SEARCH);
+
+        $this->assertEmpty($actual['incompatible_modules']);
+        $this->assertEmpty($actual['uncertain_modules']);
+    }
+
     private function mockDistributionApiService()
     {
         $distributionApiService = $this->createMock(DistributionApiService::class);
@@ -252,7 +302,10 @@ class ModuleCompatibilityCheckerTest extends TestCase
 
             // Module exists. Compatibility will be reported with the other method
             // We hack one data of the module class as the technical name is not present.
-            return MarketplaceModule::fromArray(['product' => ['id_product' => (int) !in_array($arg, self::INCOMPATIBLE_MODULES)]]);
+            return MarketplaceModule::fromArray(['product' => [
+                'id_product' => (int) !in_array($arg, self::INCOMPATIBLE_MODULES),
+                'is_active' => true,
+            ]]);
         }));
 
         $marketplaceService->method('findCompatibleModuleUpgrade')->will($this->returnCallback(function (MarketplaceModule $arg) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When the Marketplace API returns a module with its product page offline and no compatible release exists for the target PS version, the module was always reported as **Incompatible**. This was inaccurate, because the module probably never received an actual zip, has been disabled for all versions of PrestaShop etc. We can't distinguish the `diabled` / `hidden` cases  when is_active: false and no compatible release is found for the target version. So from now: <ul><li>The module was compatible with the source version → Incompatible (it worked before, won't work after. So a genuine breaking change to flag)</li><li>The module was not compatible with  the source version  → Uncertain (it was already incompatible before the upgrade, we cannot say more)</li></ul>
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/autoupgrade/issues/1773
| Sponsor company   | @PrestaShopCorp
| How to test?      | The test cases can be added in `tests/integration/MarketplaceAndModuleCompatibilityTest.php`, where calls to the marketplace are actually made. Third-party modules that are disabled on the marketplace should get the uncertain state, unless they had a version compatible with the destination version the user updates to.