### PR TITLE
Update B2B foundation SQL for 9.2.0

### DIFF
--- a/upgrade/sql/9.2.0.sql
+++ b/upgrade/sql/9.2.0.sql
@@ -2,96 +2,106 @@
 INSERT INTO `PREFIX_feature_flag` (`name`, `type`, `label_wording`, `label_domain`, `description_wording`, `description_domain`, `state`, `stability`) VALUES
   ('improved_b2b', 'env,dotenv,db', 'Improved B2B', 'Admin.Advparameters.Feature', 'Enable / Disable the improved B2B mode. To use the feature activate the B2B mode in General Settings', 'Admin.Advparameters.Help', 0, 'beta');
 
-/* Insert B2B foundation */
 /* https://github.com/PrestaShop/PrestaShop/pull/40632 */
-CREATE TABLE `PREFIX_business_entity`
-(
-    `id_business_entity`       INT UNSIGNED AUTO_INCREMENT                     NOT NULL,
-    `external_ref`             VARCHAR(255) DEFAULT NULL,
-    `name`                     VARCHAR(255) NOT NULL,
-    `legal_name`               VARCHAR(255) DEFAULT NULL,
-    `flag_delivery_authorized` TINYINT(1)                                      NOT NULL DEFAULT 0,
-    `status`                   ENUM ('pending','active','inactive','rejected') NOT NULL DEFAULT 'pending',
-    `created_at`               DATETIME     NOT NULL,
-    `updated_at`               DATETIME     NOT NULL,
-    INDEX                      `business_entity_external_ref_idx` (`external_ref`),
-    PRIMARY KEY (`id_business_entity`)
+/* Insert B2B foundation */
+CREATE TABLE IF NOT EXISTS `PREFIX_business_entity` (
+  `id_business_entity` INT UNSIGNED AUTO_INCREMENT NOT NULL,
+  `id_shop` INT UNSIGNED NOT NULL,
+  `id_customer_group` INT UNSIGNED NOT NULL,
+  `external_ref` VARCHAR(255) DEFAULT NULL,
+  `name` VARCHAR(255) NOT NULL,
+  `legal_name` VARCHAR(255) DEFAULT NULL,
+  `delivery_authorized` TINYINT(1) NOT NULL DEFAULT 0,
+  `status` ENUM ('pending', 'active', 'inactive', 'rejected') NOT NULL DEFAULT 'pending',
+  `deleted` TINYINT(1) NOT NULL DEFAULT 0,
+  `created_at` DATETIME NOT NULL,
+  `updated_at` DATETIME NOT NULL,
+  PRIMARY KEY (`id_business_entity`),
+  KEY `business_entity_shop_idx` (`id_shop`),
+  KEY `business_entity_customer_group_idx` (`id_customer_group`),
+  KEY `business_entity_external_ref_idx` (`external_ref`),
+  KEY `business_entity_deleted_idx` (`deleted`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
-CREATE TABLE `PREFIX_customer_b2b`
-(
-    `id_customer_b2b` INT UNSIGNED AUTO_INCREMENT         NOT NULL,
-    `id_customer`     INT UNSIGNED                        NOT NULL,
-    `status`          ENUM ('pending','active','refused') NOT NULL DEFAULT 'pending',
-    `external_ref`    VARCHAR(255) DEFAULT NULL,
-    `created_at`      DATETIME NOT NULL,
-    `updated_at`      DATETIME NOT NULL,
-    UNIQUE INDEX `uniq_customer_b2b_customer` (`id_customer`),
-    PRIMARY KEY (`id_customer_b2b`)
+CREATE TABLE IF NOT EXISTS `PREFIX_customer_b2b` (
+  `id_customer_b2b` INT UNSIGNED AUTO_INCREMENT NOT NULL,
+  `id_customer` INT UNSIGNED NOT NULL,
+  `status` ENUM ('pending', 'active', 'rejected') NOT NULL DEFAULT 'pending',
+  `external_ref` VARCHAR(255) DEFAULT NULL,
+  `created_at` DATETIME NOT NULL,
+  `updated_at` DATETIME NOT NULL,
+  UNIQUE KEY `uniq_customer_b2b_customer` (`id_customer`),
+  PRIMARY KEY (`id_customer_b2b`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
-CREATE TABLE `PREFIX_business_entity_customer_b2b`
-(
-    `id_business_entity_customer_b2b` INT UNSIGNED AUTO_INCREMENT NOT NULL,
-    `id_business_entity`              INT UNSIGNED                NOT NULL,
-    `id_customer_b2b`                 INT UNSIGNED                NOT NULL,
-    `id_role_b2b`                     INT UNSIGNED                NOT NULL,
-    `is_default`                      TINYINT(1)                  NOT NULL DEFAULT 0,
-    `created_at`                      DATETIME NOT NULL,
-    UNIQUE INDEX `uniq_be_customer` (`id_business_entity`, `id_customer_b2b`),
-    INDEX                             `business_entity_customer_b2b_be_idx` (`id_business_entity`),
-    INDEX                             `business_entity_customer_b2b_customer_idx` (`id_customer_b2b`),
-    INDEX                             `business_entity_customer_b2b_role_idx` (`id_role_b2b`),
-    PRIMARY KEY (`id_business_entity_customer_b2b`)
+CREATE TABLE IF NOT EXISTS `PREFIX_business_entity_customer_b2b` (
+  `id_business_entity_customer_b2b` INT UNSIGNED AUTO_INCREMENT NOT NULL,
+  `id_business_entity` INT UNSIGNED NOT NULL,
+  `id_customer_b2b` INT UNSIGNED NOT NULL,
+  `id_role` INT UNSIGNED NOT NULL,
+  `is_default` TINYINT(1) NOT NULL DEFAULT 0,
+  `created_at` DATETIME NOT NULL,
+  `updated_at` DATETIME NOT NULL,
+  PRIMARY KEY (`id_business_entity_customer_b2b`),
+  UNIQUE KEY `uniq_be_customer` (`id_business_entity`, `id_customer_b2b`),
+  KEY `business_entity_customer_b2b_be_idx` (`id_business_entity`),
+  KEY `business_entity_customer_b2b_customer_idx` (`id_customer_b2b`),
+  KEY `business_entity_customer_b2b_role_idx` (`id_role`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
-CREATE TABLE `PREFIX_business_entity_identifier`
-(
-    `id_identifier`                  INT UNSIGNED AUTO_INCREMENT    NOT NULL,
-    `id_business_entity`         INT UNSIGNED                       NOT NULL,
-    `id_business_identifier`     INT UNSIGNED                       NOT NULL,
-    `value`              VARCHAR(255) NOT NULL,
-    UNIQUE INDEX `uniq_business_entity_identifier` (`id_business_entity`, `id_business_identifier`),
-    INDEX                `business_entity_identifier_id_business_entity_idx` (`id_business_entity`),
-    INDEX                `business_entity_identifier_id_business_identifier_idx` (`id_business_identifier`),
-    INDEX                `business_entity_identifier_value_idx` (`value`),
-    PRIMARY KEY (`id_identifier`)
+CREATE TABLE IF NOT EXISTS `PREFIX_business_entity_identifier` (
+  `id_identifier` INT UNSIGNED AUTO_INCREMENT NOT NULL,
+  `id_business_entity` INT UNSIGNED NOT NULL,
+  `id_business_identifier` INT UNSIGNED NOT NULL,
+  `value` VARCHAR(255) NOT NULL,
+  `created_at` DATETIME NOT NULL,
+  `updated_at` DATETIME NOT NULL,
+  PRIMARY KEY (`id_identifier`),
+  UNIQUE KEY `uniq_business_entity_identifier` (`id_business_entity`, `id_business_identifier`),
+  KEY `business_entity_identifier_id_business_entity_idx` (`id_business_entity`),
+  KEY `business_entity_identifier_id_business_identifier_idx` (`id_business_identifier`),
+  KEY `business_entity_identifier_value_idx` (`value`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
-CREATE TABLE `PREFIX_business_identifier`
-(
-    `id_business_identifier` INT UNSIGNED AUTO_INCREMENT NOT NULL,
-    `label`                  VARCHAR(255)                NOT NULL,
-    `unremovable`            TINYINT(1)                  NOT NULL DEFAULT 0,
-    `deleted`                TINYINT(1)                  NOT NULL DEFAULT 0,
-    PRIMARY KEY (`id_business_identifier`)
+CREATE TABLE IF NOT EXISTS `PREFIX_business_identifier` (
+  `id_business_identifier` INT UNSIGNED AUTO_INCREMENT NOT NULL,
+  `label` VARCHAR(255) NOT NULL,
+  `unremovable` TINYINT(1) NOT NULL DEFAULT 0,
+  `id_zone` INT UNSIGNED NOT NULL,
+  `deleted` TINYINT(1) NOT NULL DEFAULT 0,
+  `created_at` DATETIME NOT NULL,
+  `updated_at` DATETIME NOT NULL,
+  PRIMARY KEY (`id_business_identifier`),
+  KEY `business_identifier_zone_idx` (`id_zone`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
-CREATE TABLE `PREFIX_business_entity_address`
-(
-    `id_business_entity` INT UNSIGNED                       NOT NULL,
-    `id_address`         INT UNSIGNED                       NOT NULL,
-    `address_type`       ENUM ('both','invoice','delivery') NOT NULL DEFAULT 'both',
-    `default`            TINYINT(1)                         NOT NULL DEFAULT 0,
-    PRIMARY KEY (`id_business_entity`, `id_address`),
-    INDEX                `business_entity_address_address_idx` (`id_address`)
+CREATE TABLE IF NOT EXISTS `PREFIX_business_entity_address` (
+  `id_business_entity_address` INT UNSIGNED AUTO_INCREMENT NOT NULL,
+  `id_business_entity` INT UNSIGNED NOT NULL,
+  `id_address` INT UNSIGNED NOT NULL,
+  `address_type` ENUM ('both', 'invoice', 'delivery') NOT NULL DEFAULT 'both',
+  `is_default` TINYINT(1) NOT NULL DEFAULT 0,
+  `created_at` DATETIME NOT NULL,
+  `updated_at` DATETIME NOT NULL,
+  PRIMARY KEY (`id_business_entity_address`),
+  UNIQUE KEY `uniq_be_address` (`id_business_entity`, `id_address`, `address_type`),
+  KEY `business_entity_address_be_idx` (`id_business_entity`),
+  KEY `business_entity_address_address_idx` (`id_address`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
-CREATE TABLE `PREFIX_b2b_role`
-(
-    `id_role` INT UNSIGNED AUTO_INCREMENT NOT NULL,
-    `role`    VARCHAR(64) NOT NULL,
-    UNIQUE INDEX `uniq_b2b_role` (`role`),
-    PRIMARY KEY (`id_role`)
+CREATE TABLE IF NOT EXISTS `PREFIX_b2b_role` (
+  `id_role` INT UNSIGNED AUTO_INCREMENT NOT NULL,
+  `role` VARCHAR(64) NOT NULL,
+  UNIQUE KEY `uniq_b2b_role` (`role`),
+  PRIMARY KEY (`id_role`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
-CREATE TABLE `PREFIX_b2b_role_authorization_role`
-(
-    `id_role`               INT UNSIGNED NOT NULL,
-    `id_authorization_role` INT UNSIGNED NOT NULL,
-    PRIMARY KEY (`id_role`, `id_authorization_role`),
-    INDEX                   `b2b_role_authorization_role_role_idx` (`id_role`),
-    INDEX                   `b2b_role_authorization_role_auth_role_idx` (`id_authorization_role`)
+CREATE TABLE IF NOT EXISTS `PREFIX_b2b_role_authorization_role` (
+  `id_role` INT UNSIGNED NOT NULL,
+  `id_authorization_role` INT UNSIGNED NOT NULL,
+  PRIMARY KEY (`id_role`, `id_authorization_role`),
+  KEY `b2b_role_authorization_role_role_idx` (`id_role`),
+  KEY `b2b_role_authorization_role_auth_role_idx` (`id_authorization_role`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- https://github.com/PrestaShop/PrestaShop/pull/41028

--- a/upgrade/sql/9.2.0.sql
+++ b/upgrade/sql/9.2.0.sql
@@ -67,7 +67,7 @@ CREATE TABLE IF NOT EXISTS `PREFIX_business_identifier` (
   `id_business_identifier` INT UNSIGNED AUTO_INCREMENT NOT NULL,
   `label` VARCHAR(255) NOT NULL,
   `unremovable` TINYINT(1) NOT NULL DEFAULT 0,
-  `id_zone` INT UNSIGNED NOT NULL,
+  `id_zone` INT UNSIGNED DEFAULT NULL,
   `deleted` TINYINT(1) NOT NULL DEFAULT 0,
   `created_at` DATETIME NOT NULL,
   `updated_at` DATETIME NOT NULL,


### PR DESCRIPTION
| Questions         | Answers
  | ------------------| -------------------------------------------------------
  | Description?      | Align the B2B foundation SQL upgrade script (9.2.0) with the revised hybrid-mode data model applied on the PrestaShop core. Updates the 8 B2B tables (`business_entity`, `business_entity_address`, `business_entity_customer_b2b`, `business_entity_identifier`, `business_identifier`, `customer_b2b`, `b2b_role`, `b2b_role_authorization_role`) so an upgraded shop ends up with the exact same schema as a fresh install. Companion PR of the core change.
  | Type?             | improvement
  | BC breaks?        | no
  | Deprecations?     | no
  | Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/41329
  | Sponsor company   | Soledis
  | How to test?      | Upgrade to version 9.2.0