### PR TITLE
Fix feature_value position backfill during 9.0.0 upgrade

### DIFF
--- a/upgrade/php/ps_900_init_feature_value_positions.php
+++ b/upgrade/php/ps_900_init_feature_value_positions.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+use PrestaShop\Module\AutoUpgrade\Database\DbWrapper;
+
+/**
+ * Initialize feature value positions after the position column is added in 9.0.0.
+ *
+ * Existing shops upgraded to 9 may already contain feature values, which all get
+ * the default position 0 when the column is introduced. We backfill sequential
+ * positions per feature to avoid duplicates and preserve a stable ordering.
+ *
+ * @return void
+ *
+ * @throws \PrestaShop\Module\AutoUpgrade\Exceptions\UpdateDatabaseException
+ */
+function ps_900_init_feature_value_positions()
+{
+    $hasInitializedPositions = (int) DbWrapper::getValue('
+        SELECT COUNT(*)
+        FROM `' . _DB_PREFIX_ . 'feature_value`
+        WHERE `position` <> 0
+    ');
+
+    if ($hasInitializedPositions > 0) {
+        return;
+    }
+
+    $featureValues = DbWrapper::executeS('
+        SELECT `id_feature_value`, `id_feature`
+        FROM `' . _DB_PREFIX_ . 'feature_value`
+        ORDER BY `id_feature` ASC, `id_feature_value` ASC
+    ');
+
+    if (empty($featureValues)) {
+        return;
+    }
+
+    $currentFeatureId = null;
+    $position = -1;
+
+    foreach ($featureValues as $featureValue) {
+        $featureId = (int) $featureValue['id_feature'];
+
+        if ($featureId !== $currentFeatureId) {
+            $currentFeatureId = $featureId;
+            $position = 0;
+        } else {
+            ++$position;
+        }
+
+        DbWrapper::update(
+            'feature_value',
+            ['position' => $position],
+            '`id_feature_value` = ' . (int) $featureValue['id_feature_value']
+        );
+    }
+}

--- a/upgrade/sql/9.0.0.sql
+++ b/upgrade/sql/9.0.0.sql
@@ -422,6 +422,7 @@ DELETE FROM `PREFIX_hook_module_exceptions` WHERE `id_hook` NOT IN (SELECT id_ho
 /* Feature value position */
 /* https://github.com/PrestaShop/PrestaShop/pull/37042 */
 /* PHP:add_column('feature_value', 'position', 'int(10) unsigned NOT NULL DEFAULT \'0\''); */;
+/* PHP:ps_900_init_feature_value_positions(); */;
 /* PHP:add_configuration_if_not_exists('PS_FEATURE_VALUES_ORDER', 'name'); */;
 
 /* Upgrade attachment names length */


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR fixes the PrestaShop 9.0.0 upgrade path for shops that already have feature values.<br/><br/>When the new `position` column is added to `feature_value`, existing rows all receive the default value `0`, which can cause ordering issues. This change adds a dedicated upgrade step that initializes sequential positions per feature during the `9.0.0` migration, while avoiding overwriting already-initialized data.| Type?             | bug fix
| BC breaks?        | yes
| Deprecations?     | yes
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/41554
| Sponsor company   | Codencode snc
| How to test?      | 1. Install PS version 8.x.x <br/>2. Upgrade to PrestaShop 9.x.x <br/>3. Check that the position field in the feature_value table is correctly populated and try changing the position of the values in the admin panel.

### NOTE
The positions could also have been set using this query:
```sql
UPDATE ps_feature_value fv
INNER JOIN (
    SELECT
        id_feature_value,
        ROW_NUMBER() OVER (
            PARTITION BY id_feature
            ORDER BY id_feature_value ASC
        ) - 1 AS new_position
    FROM ps_feature_value
) x ON x.id_feature_value = fv.id_feature_value
SET fv.position = x.new_position;
```

However, I preferred to create a PHP file for compatibility reasons with different MySQL / MariaDB versions.