### PR TITLE
Catch IOException in CacheCleaner to prevent upgrade abort on locked cache files

### DIFF
--- a/classes/UpgradeTools/CacheCleaner.php
+++ b/classes/UpgradeTools/CacheCleaner.php
@@ -24,6 +24,7 @@ namespace PrestaShop\Module\AutoUpgrade\UpgradeTools;
 use Exception;
 use PrestaShop\Module\AutoUpgrade\Log\LoggerInterface;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
+use Symfony\Component\Filesystem\Exception\IOException;
 
 class CacheCleaner
 {
@@ -71,8 +72,15 @@ class CacheCleaner
                 $this->logger->debug($this->container->getTranslator()->trans('Directory "%s" does not exist and cannot be emptied.', [str_replace($this->container->getProperty(UpgradeContainer::PS_ROOT_PATH), '', $dir)]));
                 continue;
             }
-            $this->container->getFilesystemAdapter()->clearDirectory($dir);
-            $this->logger->debug($this->container->getTranslator()->trans('Directory %s emptied', [$dir]));
+            try {
+                $this->container->getFilesystemAdapter()->clearDirectory($dir);
+                $this->logger->debug($this->container->getTranslator()->trans('Directory %s emptied', [$dir]));
+            } catch (IOException $e) {
+                $this->logger->warning($this->container->getTranslator()->trans(
+                    'Could not fully clear directory %s: %s. Some cache files may be locked by running processes.',
+                    [$dir, $e->getMessage()]
+                ));
+            }
         }
     }
 }


### PR DESCRIPTION
During an upgrade, if PHP-FPM processes have cache files open, clearDirectory() throws an IOException and the upgrade process aborts completely.

This change wraps the clearDirectory() call in a try/catch so that locked files produce a warning in the log instead of an unhandled exception, allowing the upgrade to continue.

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | During an upgrade, if PHP-FPM processes have cache files open, `clearDirectory()` throws an `IOException` and the upgrade process aborts completely. This change wraps the `clearDirectory()` call in a try/catch so that locked files produce a warning in the log instead of an unhandled exception, allowing the upgrade to continue.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | N/A
| How to test?      | 1. Run a PrestaShop instance with PHP-FPM <br> 2. Start an upgrade while PHP-FPM processes have cache files open <br> 3. **Before:** the upgrade aborts with an unhandled IOException <br> 4. **After:** the upgrade continues and a warning appears in the log instead

## Possible impacts

- Cache clearing behavior during upgrades
- Upgrade log output (a new warning message may appear when cache files are locked)