### PR TITLE
Fix the call to the module source provider that uses the composer.lock file

### DIFF
--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -611,10 +611,10 @@ class UpgradeContainer
         if (null === $this->moduleSourceProviders) {
             $this->moduleSourceProviders = [
                 new LocalSourceProvider($this->getProperty(self::WORKSPACE_PATH) . DIRECTORY_SEPARATOR . 'modules', $this->getFileStorage()),
-                new MarketplaceSourceProvider($this->getUpdateState()->getDestinationVersion(), $this->getProperty(self::PS_ROOT_PATH), $this->getFileLoader(), $this->getFileStorage()),
-                new DistributionApiSourceProvider($this->getUpdateState()->getDestinationVersion(), $this->getDistributionApiService(), $this->getFileStorage()),
                 new ComposerSourceProvider($this->getProperty(self::TMP_FILES_PATH), $this->getComposerService(), $this->getFileStorage()),
                 new PrestaShopArchiveSourceProvider($this->getProperty(self::TMP_FILES_PATH), $this->getComposerService(), $this->getFileStorage(), $this->getModuleAdapter()),
+                new MarketplaceSourceProvider($this->getUpdateState()->getDestinationVersion(), $this->getProperty(self::PS_ROOT_PATH), $this->getFileLoader(), $this->getFileStorage()),
+                new DistributionApiSourceProvider($this->getUpdateState()->getDestinationVersion(), $this->getDistributionApiService(), $this->getFileStorage()),
             ];
         }
 

--- a/classes/UpgradeTools/Module/Source/Provider/ComposerSourceProvider.php
+++ b/classes/UpgradeTools/Module/Source/Provider/ComposerSourceProvider.php
@@ -49,8 +49,8 @@ class ComposerSourceProvider extends AbstractModuleSourceProvider
 
     public function warmUp(): void
     {
-        if ($this->fileConfigurationStorage->exists(UpgradeFileNames::MODULE_SOURCE_PROVIDER_CACHE_LOCAL)) {
-            $this->localModuleZips = $this->fileConfigurationStorage->load(UpgradeFileNames::MODULE_SOURCE_PROVIDER_CACHE_LOCAL);
+        if ($this->fileConfigurationStorage->exists(UpgradeFileNames::MODULE_SOURCE_PROVIDER_CACHE_COMPOSER)) {
+            $this->localModuleZips = $this->fileConfigurationStorage->load(UpgradeFileNames::MODULE_SOURCE_PROVIDER_CACHE_COMPOSER);
 
             return;
         }
@@ -68,6 +68,6 @@ class ComposerSourceProvider extends AbstractModuleSourceProvider
             );
         }
 
-        $this->fileConfigurationStorage->save($this->localModuleZips, UpgradeFileNames::MODULE_SOURCE_PROVIDER_CACHE_LOCAL);
+        $this->fileConfigurationStorage->save($this->localModuleZips, UpgradeFileNames::MODULE_SOURCE_PROVIDER_CACHE_COMPOSER);
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Different module provider are being implement to look for potential module updates from different sources: The Marketplace, the Open Source project API, and other local sources. Based on the logs, the one using the PrestaShop composer.lock was surprisingly never called. This PR gives more priority to the local module source providers, and fixes an issue with the file cache name. 
| Type?             | bug fix 
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | When updating a fresh 9.1.3 to 9.1.4, the updated files of `ps_facetedsearch` should be taken from the PrestaShop file, not from the distribution API or the Marketplace.

### In the logs:

**Expected:**

```
[2026-06-04 19:23:21] DEBUG - ChainedTasks - Step DownloadModules
[2026-06-04 19:23:21] DEBUG - DownloadModules - Vérification des mises à jour du module ps_facetedsearch...
[2026-06-04 19:23:21] NOTICE - ModuleDownloader - Les fichiers de mise à jour du module ps_facetedsearch (4.0.3 => 4.0.4) ont été récupérés à partir de /var/www/html/**admin_folder**/autoupgrade/tmp/files/modules/ps_facetedsearch.
[2026-06-04 19:23:21] INFO - DownloadModules - 39 modules restant à vérifier.
```

**Behavior found in 7.6.x:**

```
[2026-06-04 16:07:59] DEBUG - ChainedTasks - Step DownloadModules
[2026-06-04 16:07:59] DEBUG - DownloadModules - Vérification des mises à jour du module ps_facetedsearch...
[2026-06-04 16:07:59] NOTICE - ModuleDownloader - Les fichiers de mise à jour du module ps_facetedsearch (4.0.3 => 4.0.4) ont été récupérés à partir de https://api.prestashop-project.org/assets/modules/ps_facetedsearch/v4.0.4/ps_facetedsearch.zip.
[2026-06-04 16:07:59] INFO - DownloadModules - 39 modules restant à vérifier.
```