### PR TITLE
Create "Order creation error" order status on upgrade (#32743)

### DIFF
--- a/upgrade/php/ps_920_add_order_creation_error_state.php
+++ b/upgrade/php/ps_920_add_order_creation_error_state.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+/**
+ * Creates the "Order creation error" order status and stores its id in the
+ * PS_OS_CREATION_ERROR configuration key on shops upgrading from a version
+ * that did not ship this status.
+ *
+ * Orders whose creation aborted on a server error are saved with no
+ * current_state (0). Without a dedicated status the back office renders such
+ * orders with the first status in the list pre-selected, which is misleading.
+ * This status lets merchants spot and fix them. See PrestaShop issue #32743.
+ *
+ * This script is invoked from upgrade/sql/9.2.0.sql via the line:
+ *     /* PHP:ps_920_add_order_creation_error_state(); *\/;
+ * The autoupgrade runner require_once's upgrade/php/<lowercased function
+ * name>.php, so the file name and the function name below MUST match. The
+ * version it runs at is decided by the SQL file that references it, not by the
+ * ps_920_ prefix. If the fix lands in a later release, move the /* PHP: *\/ line
+ * to that release's SQL file and rename file + function accordingly.
+ *
+ * @return bool
+ */
+function ps_920_add_order_creation_error_state()
+{
+    // Idempotent: skip if a previous run (or a catch-up script) already created it.
+    if ((int) Configuration::get('PS_OS_CREATION_ERROR') > 0) {
+        return true;
+    }
+
+    $orderState = new OrderState();
+    $orderState->send_email = false;
+    $orderState->invoice = false;
+    $orderState->color = '#E74C3C';
+    $orderState->unremovable = true;
+    $orderState->logable = false;
+    $orderState->delivery = false;
+    $orderState->shipped = false;
+    $orderState->paid = false;
+    $orderState->hidden = false;
+    $orderState->pdf_invoice = false;
+    $orderState->pdf_delivery = false;
+
+    // One localized name per installed language, taken from the same source
+    // string registered in classes/lang/KeysReference/OrderStateLang.php.
+    $translator = Context::getContext()->getTranslator();
+    $orderState->name = array();
+    $orderState->template = array();
+    foreach (Language::getLanguages(false) as $lang) {
+        $orderState->name[$lang['id_lang']] = $translator->trans(
+            'Order creation error',
+            array(),
+            'Admin.Orderscustomers.Feature',
+            $lang['locale']
+        );
+        // No customer email is sent for this status.
+        $orderState->template[$lang['id_lang']] = '';
+    }
+
+    if (!$orderState->add()) {
+        return false;
+    }
+
+    // Persist the mapping so the core can reference the new status.
+    Configuration::updateGlobalValue('PS_OS_CREATION_ERROR', (int) $orderState->id);
+
+    // Give it a status icon (img/os/<id>.gif). Reuse the payment-error icon as
+    // a safe default; replace later with a dedicated visual if desired.
+    $source = _PS_ROOT_DIR_ . '/img/os/' . (int) Configuration::get('PS_OS_ERROR') . '.gif';
+    $target = _PS_ROOT_DIR_ . '/img/os/' . (int) $orderState->id . '.gif';
+    if (file_exists($source) && !file_exists($target)) {
+        @copy($source, $target);
+    }
+
+    return true;
+}

--- a/upgrade/sql/9.2.0.sql
+++ b/upgrade/sql/9.2.0.sql
@@ -106,3 +106,6 @@ CREATE TABLE IF NOT EXISTS `PREFIX_b2b_role_authorization_role` (
 
 -- https://github.com/PrestaShop/PrestaShop/pull/41028
 /* PHP:ps_920_business_entities_tabs(); */;
+
+-- https://github.com/PrestaShop/PrestaShop/issues/32743
+/* PHP:ps_920_add_order_creation_error_state(); */;


### PR DESCRIPTION
# PR — PrestaShop/autoupgrade

**Base:** `PrestaShop/autoupgrade:dev`
**Head:** `idnovate/autoupgrade:fix/32743-order-creation-error-status`

## Title

Create "Order creation error" order status on upgrade (#32743)

## Description

Companion DB migration for PrestaShop/PrestaShop core PR for issue #32743.

Fresh installs get the new `Order creation error` status from the core install
fixtures. Existing shops need it created during upgrade — this PR does that.

### What changed

- `upgrade/php/ps_920_add_order_creation_error_state.php` — new script. Creates
  the `OrderState` (one localized name per installed language, red, unremovable,
  no email), stores its id in `PS_OS_CREATION_ERROR`, and copies a status icon
  to `img/os/<id>.gif`. Idempotent: it no-ops if the configuration key is
  already set.
- `upgrade/sql/9.2.0.sql` — appended one line that schedules the script:
  ```sql
  /* PHP:ps_920_add_order_creation_error_state(); */;
  ```

### Why this version

The runner derives the upgrade step from the **SQL file** that contains the
`/* PHP: */` line, not from the script's name. `9.2.0.sql` is the in-development
release matching core `_PS_INSTALL_VERSION_ = 9.2.0`, so the line goes there and
runs for any shop upgrading from `< 9.2.0` to `>= 9.2.0`. If 9.2.0 is already
frozen at merge time, move the line to the next release's SQL file (e.g.
`9.2.1.sql` / `9.3.0.sql`) and rename the script `ps_921_` / `ps_930_` to match.

### How to test

1. On a shop older than 9.2.0 without the status, run the upgrade to 9.2.0.
2. Confirm a new **Order creation error** status exists in
   *Shop Parameters > Order Settings > Statuses*, and that
   `Configuration::get('PS_OS_CREATION_ERROR')` returns its id.
3. Run the upgrade again (or a catch-up) and confirm no duplicate is created.
