### PR TITLE
Fix value of inserted feature flag for the new page Module Positions

### DIFF
--- a/upgrade/sql/9.2.0.sql
+++ b/upgrade/sql/9.2.0.sql
@@ -34,7 +34,7 @@ WHERE cr.`quantity` IS NOT NULL;
 -- https://github.com/PrestaShop/PrestaShop/pull/41407
 -- Insert new feature flag introduced for the migration of the Hook a module page
 INSERT INTO `PREFIX_feature_flag` (`name`, `type`, `label_wording`, `label_domain`, `description_wording`, `description_domain`, `state`, `stability`) VALUES
-  ('hook_module_v2', 'env,dotenv,db', 'Hook a module', 'Admin.Design.Feature', 'Enable / Disable the migrated Hook a module form page.', 'Admin.Design.Help', 1, 'stable');
+  ('hook_module_v2', 'env,dotenv,db', 'Hook a module', 'Admin.Design.Feature', 'Enable / Disable the migrated Hook a module form page.', 'Admin.Design.Help', 0, 'stable');
 
 
 -- New B2B feature


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The feature flags added during an update of PrestaShop should be switched off by default. This PR fixes one of them that was enabled. 
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/autoupgrade/pull/1847#discussion_r3436772887
| Sponsor company   | @PrestaShopCorp
| How to test?      | Feature flag is switched off after after an update to PS 9.2.0