### PR TITLE
Migrate Quick Access page to Symfony

### DIFF
--- a/upgrade/php/ps_920_quick_access_tab.php
+++ b/upgrade/php/ps_920_quick_access_tab.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+use PrestaShop\Module\AutoUpgrade\Database\DbWrapper;
+
+/**
+ * Migration of the "Configure > Advanced Parameters > Quick Access" page to Symfony.
+ *
+ * @see https://github.com/PrestaShop/PrestaShop/pull/41508
+ *
+ * The legacy AdminQuickAccesses tab used to be a hidden top-level tab (id_parent = -1).
+ * The migration moves it under Advanced Parameters and keeps it inactive (hidden from the
+ * menu, the page being reached through the quick access UI / feature flag), and introduces
+ * the CRUD authorization roles required by the new Symfony grid.
+ *
+ * @return void
+ *
+ * @throws \PrestaShop\Module\AutoUpgrade\Exceptions\UpdateDatabaseException
+ */
+function ps_920_quick_access_tab()
+{
+    include_once __DIR__ . '/add_new_tab.php';
+
+    // The AdminQuickAccesses tab already exists (legacy hidden tab), so add_new_tab_17() does not
+    // re-create it: it only adds the CRUD authorization roles and copies the accesses from the
+    // parent Advanced Parameters tab, mirroring the install fixtures.
+    add_new_tab_17('AdminQuickAccesses', 'en:Quick Access', 0, false, 'AdminAdvancedParameters');
+
+    $advancedParametersTabId = DbWrapper::getValue(
+        'SELECT `id_tab` FROM `' . _DB_PREFIX_ . 'tab` WHERE `class_name` = \'AdminAdvancedParameters\''
+    );
+
+    if (!empty($advancedParametersTabId)) {
+        // Move the existing tab under Advanced Parameters and keep it inactive (reached through the quick access UI).
+        DbWrapper::execute(
+            'UPDATE `' . _DB_PREFIX_ . 'tab`
+            SET `id_parent` = ' . (int) $advancedParametersTabId . ', `active` = 0
+            WHERE `class_name` = \'AdminQuickAccesses\''
+        );
+    }
+}

--- a/upgrade/sql/9.2.0.sql
+++ b/upgrade/sql/9.2.0.sql
@@ -36,6 +36,14 @@ WHERE cr.`quantity` IS NOT NULL;
 INSERT INTO `PREFIX_feature_flag` (`name`, `type`, `label_wording`, `label_domain`, `description_wording`, `description_domain`, `state`, `stability`) VALUES
   ('hook_module_v2', 'env,dotenv,db', 'Hook a module', 'Admin.Design.Feature', 'Enable / Disable the migrated Hook a module form page.', 'Admin.Design.Help', 1, 'stable');
 
+-- https://github.com/PrestaShop/PrestaShop/pull/41508
+-- Insert new feature flag introduced for the migration of the Quick Access page
+INSERT INTO `PREFIX_feature_flag` (`name`, `type`, `label_wording`, `label_domain`, `description_wording`, `description_domain`, `state`, `stability`) VALUES
+  ('quick_access', 'env,dotenv,db', 'Quick access', 'Admin.Advparameters.Feature', 'Enable / Disable the migrated quick access page.', 'Admin.Advparameters.Help', 0, 'stable');
+
+-- Move the AdminQuickAccesses tab under Advanced Parameters and create the authorization roles introduced for the migrated page
+/* PHP:ps_920_quick_access_tab(); */;
+
 
 -- New B2B feature
 


### PR DESCRIPTION
## Questions

| Question | Answer |
| --- | --- |
| Description? | Adds the upgrade steps for the Symfony migration of the **Configure > Advanced Parameters > Quick Access** page. |
| Type? | new feature |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | Companion of PrestaShop/PrestaShop#41508 |
| How to test? | Update a store to 9.2.0 and check that the `quick_access` feature flag is present (stable), that the Quick Access page is reachable, and that the `AdminQuickAccesses` tab sits under Advanced Parameters. |

## Description

The page **Configure > Advanced Parameters > Quick Access** was migrated to Symfony in the core (PrestaShop/PrestaShop#41508), gated behind a `quick_access` feature flag whose stability was set to `stable` in PrestaShop/PrestaShop#41630.

This PR mirrors the related install fixtures in the 9.2.0 upgrade script so merchants updating to **9.2.0** get the feature:

- **`upgrade/sql/9.2.0.sql`** — insert the `quick_access` feature flag (`state=1`, `stability=stable`), following the same pattern as `hook_module_v2`.
- **`upgrade/php/ps_920_quick_access_tab.php`** (new) — move the `AdminQuickAccesses` tab under Advanced Parameters and set it inactive (`id_parent="-1" active="1"` → `id_parent="Advanced_Parameters" active="0"`), then create the new `ROLE_MOD_TAB_ADMINQUICKACCESSES_{CREATE,READ,UPDATE,DELETE}` authorization roles (idempotent `INSERT IGNORE`) and grant them to the SuperAdmin profile, mirroring `access.xml` / `authorization_role.xml`.
