### PR TITLE
Add extra property definitions tab to 9.2.0 upgrade

### DIFF
--- a/upgrade/php/ps_920_extra_property_definitions_tab.php
+++ b/upgrade/php/ps_920_extra_property_definitions_tab.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+use PrestaShop\Module\AutoUpgrade\Database\DbWrapper;
+
+function ps_920_extra_property_definitions_tab()
+{
+    include_once __DIR__ . '/add_new_tab.php';
+
+    $adminExtraPropertyDefinitionsId = add_new_tab_17(
+        'AdminExtraPropertyDefinitions',
+        'en:Extra Properties',
+        0,
+        true,
+        'AdminAdvancedParameters'
+    );
+
+    if (empty($adminExtraPropertyDefinitionsId)) {
+        return;
+    }
+
+    DbWrapper::execute(
+        'UPDATE `' . _DB_PREFIX_
+        . 'tab` SET `active`=1, `enabled`=1, `wording`="Extra Properties", `wording_domain`="Admin.Navigation.Menu", `icon`="", `route_name`="admin_extra_property_definitions_index" WHERE `id_tab` = ' . (int) $adminExtraPropertyDefinitionsId
+    );
+}

--- a/upgrade/sql/9.2.0.sql
+++ b/upgrade/sql/9.2.0.sql
@@ -154,3 +154,6 @@ CREATE TABLE IF NOT EXISTS `PREFIX_b2b_role_authorization_role` (
 INSERT INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES
   (NULL, 'actionCheckoutBuildProcess', 'Build checkout process', 'This hook is triggered before the checkout is rendered. Modules may return a checkout process provider. The provider is used only when exactly one enabled and valid provider is available.', '1')
 ON DUPLICATE KEY UPDATE `title` = VALUES(`title`), `description` = VALUES(`description`);
+
+-- https://github.com/PrestaShop/PrestaShop/pull/41775
+/* PHP:ps_920_extra_property_definitions_tab(); */;


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Adds the Back Office tab registration for the Extra Properties registry page introduced in PrestaShop/PrestaShop#41775. The 9.2.0 upgrade script creates the `AdminExtraPropertyDefinitions` tab under Advanced Parameters and relies on the existing tab helper to create the related authorization roles and copy access rights from the parent tab.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to https://github.com/PrestaShop/PrestaShop/pull/41775
| Sponsor company   | Kiwik
| How to test?      | Run an upgrade to PrestaShop 9.2.0 using this autoupgrade branch. Then verify that the `AdminExtraPropertyDefinitions` tab exists under Advanced Parameters with route `admin_extra_property_definitions_index`, and that the `ROLE_MOD_TAB_ADMINEXTRAPROPERTYDEFINITIONS_CREATE`, `READ`, `UPDATE`, and `DELETE` authorization roles are created with access copied from the parent `AdminAdvancedParameters` tab.