### PR TITLE
Update 9.2.0 upgrade script for core 9.2.0 DB changes

### DIFF
--- a/upgrade/php/ps_920_quick_access_tab.php
+++ b/upgrade/php/ps_920_quick_access_tab.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+use PrestaShop\Module\AutoUpgrade\Database\DbWrapper;
+
+function ps_920_quick_access_tab()
+{
+    include_once __DIR__ . '/add_new_tab.php';
+
+    $advancedParametersTabId = (int) DbWrapper::getValue(
+        'SELECT `id_tab` FROM `' . _DB_PREFIX_ . 'tab` WHERE `class_name` = \'AdminAdvancedParameters\''
+    );
+
+    // The AdminQuickAccesses tab already exists on every shop but, as a hidden orphan tab, it had
+    // no authorization roles nor access grants. add_new_tab_17() is a no-op on the existing tab row,
+    // but it creates the 4 missing ROLE_MOD_TAB_ADMINQUICKACCESSES_{CREATE,READ,UPDATE,DELETE} roles
+    // and copies the access from the Advanced Parameters parent, making the tab manageable in
+    // Configure > Advanced Parameters > Permissions.
+    add_new_tab_17('AdminQuickAccesses', 'en:Quick Access', $advancedParametersTabId, false, 'AdminAdvancedParameters');
+
+    // add_new_tab_17() never re-parents/deactivates an already-existing tab, so move the legacy
+    // AdminQuickAccesses tab under Advanced Parameters and hide it from the sidebar navigation (#41508).
+    if ($advancedParametersTabId) {
+        DbWrapper::execute(
+            'UPDATE `' . _DB_PREFIX_ . 'tab` SET `id_parent` = ' . $advancedParametersTabId . ', `active` = 0
+             WHERE `class_name` = \'AdminQuickAccesses\''
+        );
+    }
+}

--- a/upgrade/sql/9.2.0.sql
+++ b/upgrade/sql/9.2.0.sql
@@ -193,3 +193,25 @@ CREATE TABLE IF NOT EXISTS `PREFIX_extra_property_definition` (
 /* PHP:add_column('order_return_detail', 'cancelled', 'tinyint(1) unsigned NOT NULL DEFAULT \'0\''); */;
 -- Add column is_cancelling_return field to define if it cancels returns
 /* PHP:add_column('order_return_state', 'is_cancelling_return', 'tinyint(1) unsigned NOT NULL DEFAULT \'0\''); */;
+
+-- https://github.com/PrestaShop/PrestaShop/pull/40031
+/* Extend the product condition enum with new values */
+ALTER TABLE `PREFIX_product` MODIFY COLUMN `condition`
+  ENUM('new', 'used', 'refurbished', 'open_box', 'damaged', 'new_with_defects') NOT NULL DEFAULT 'new';
+ALTER TABLE `PREFIX_product_shop` MODIFY COLUMN `condition`
+  ENUM('new', 'used', 'refurbished', 'open_box', 'damaged', 'new_with_defects') NOT NULL DEFAULT 'new';
+
+-- https://github.com/PrestaShop/PrestaShop/pull/40238
+/* Mark the "tag" feature flag as stable */
+UPDATE `PREFIX_feature_flag` SET `stability` = 'stable' WHERE `name` = 'tag';
+
+-- https://github.com/PrestaShop/PrestaShop/pull/41032
+/* New pricing feature flag (beta) */
+INSERT INTO `PREFIX_feature_flag` (`name`, `type`, `label_wording`, `label_domain`, `description_wording`, `description_domain`, `state`, `stability`) VALUES
+  ('new_pricing', 'env,query,dotenv,db', 'New pricing', 'Admin.Advparameters.Feature', 'Enable / Disable the new pricing system. This feature introduces an improved pricing engine.', 'Admin.Advparameters.Help', 0, 'beta');
+
+-- https://github.com/PrestaShop/PrestaShop/pull/41508 + https://github.com/PrestaShop/PrestaShop/pull/41630
+/* Quick Access migrated to Symfony: add the (already stable) feature flag, then move the existing AdminQuickAccesses tab under Advanced Parameters and create its missing permissions */
+INSERT INTO `PREFIX_feature_flag` (`name`, `type`, `label_wording`, `label_domain`, `description_wording`, `description_domain`, `state`, `stability`) VALUES
+  ('quick_access', 'env,dotenv,db', 'Quick access', 'Admin.Advparameters.Feature', 'Enable / Disable the migrated quick access page.', 'Admin.Advparameters.Help', 0, 'stable');
+/* PHP:ps_920_quick_access_tab(); */;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | dev
| Description?      | Adds the missing 9.2.0 core DB changes to the `9.2.0` upgrade script
| Type?             | improvement
| Category?         | UX
| BC breaks?        | no
| Deprecations?     | no
| Fixed issue or discussion? | Companion to the core PRs listed below

## Description

Completes `upgrade/sql/9.2.0.sql` so that a shop upgraded to 9.2.0 matches a fresh 9.2.0 install for the following core changes:

- **Product condition** — extend the `product.condition` enum (`ps_product` + `ps_product_shop`) with `open_box`, `damaged`, `new_with_defects` — PrestaShop/PrestaShop#40031
- **`tag` feature flag** — mark as stable — PrestaShop/PrestaShop#40238
- **`new_pricing` feature flag** — add in beta — PrestaShop/PrestaShop#41032
- **Quick Access migration** — PrestaShop/PrestaShop#41508 + PrestaShop/PrestaShop#41630:
  - add the `quick_access` feature flag (already stable)
  - the legacy `AdminQuickAccesses` tab exists on every shop as a hidden orphan (`id_parent=-1`) **with no authorization roles / access** — a new PHP helper (`upgrade/php/ps_920_quick_access_tab.php`) creates the 4 missing `ROLE_MOD_TAB_ADMINQUICKACCESSES_{CREATE,READ,UPDATE,DELETE}` roles + access (via the existing `add_new_tab_17` helper), then re-parents the tab under Advanced Parameters and hides it from the sidebar (`active=0`), making it manageable in *Advanced Parameters > Permissions*.

## How to test

On a 9.1.x shop, run the module upgrade to 9.2.0, then check:
- `SHOW COLUMNS FROM ps_product LIKE 'condition';` (and `ps_product_shop`) → enum lists all 6 values.
- `SELECT name, state, stability FROM ps_feature_flag WHERE name IN ('tag','new_pricing','quick_access');` → `tag`=0/stable, `new_pricing`=0/beta, `quick_access`=0/stable.
- `SELECT id_parent, active FROM ps_tab WHERE class_name='AdminQuickAccesses';` → `id_parent` = id of `AdminAdvancedParameters`, `active`=0.
- `SELECT slug FROM ps_authorization_role WHERE slug LIKE 'ROLE_MOD_TAB_ADMINQUICKACCESSES_%';` → 4 rows, with matching `ps_access` grants.
- BO: *Advanced Parameters > Permissions* lists `AdminQuickAccesses`; running the upgrade twice causes no duplicate rows / SQL errors.
