### PR TITLE
Introduce stubs to avoid unstable code from PrestaShop while an update is running

### DIFF
--- a/classes/UpgradeContainer.php
+++ b/classes/UpgradeContainer.php
@@ -57,6 +57,7 @@ use PrestaShop\Module\AutoUpgrade\Twig\AssetsEnvironment;
 use PrestaShop\Module\AutoUpgrade\Twig\TransFilterExtension;
 use PrestaShop\Module\AutoUpgrade\Twig\TransFilterExtension3;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\CacheCleaner;
+use PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreServiceStub\CoreServiceStubRegistrar;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\FileFilter;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\FilesystemAdapter;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Module\ModuleAdapter;
@@ -211,6 +212,9 @@ class UpgradeContainer
 
     /** @var ConfigurationValidator */
     private $configurationValidator;
+
+    /** @var CoreServiceStubRegistrar */
+    private $coreServiceStubRegistrar;
 
     /** @var LocalChannelConfigurationValidator */
     private $localChannelConfigurationValidator;
@@ -787,7 +791,7 @@ class UpgradeContainer
     public function getSymfonyAdapter(): SymfonyAdapter
     {
         if (null === $this->symfonyAdapter) {
-            $this->symfonyAdapter = new SymfonyAdapter();
+            $this->symfonyAdapter = new SymfonyAdapter($this->getCoreServiceStubRegistrar());
         }
 
         return $this->symfonyAdapter;
@@ -988,6 +992,18 @@ class UpgradeContainer
         }
 
         return $this->configurationValidator;
+    }
+
+    public function getCoreServiceStubRegistrar(): CoreServiceStubRegistrar
+    {
+        if (null === $this->coreServiceStubRegistrar) {
+            $this->coreServiceStubRegistrar = new CoreServiceStubRegistrar(
+                $this->getLogger(),
+                $this->getTranslator()
+            );
+        }
+
+        return $this->coreServiceStubRegistrar;
     }
 
     /**

--- a/classes/UpgradeTools/CoreUpgrader/CoreServiceStub/CoreServiceStubRegistrar.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreServiceStub/CoreServiceStubRegistrar.php
@@ -24,6 +24,8 @@ namespace PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreServiceStu
 use PrestaShop\Module\AutoUpgrade\Log\LoggerInterface;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreServiceStub\Stubs\FaultTolerantExtraPropertyDefinitionRepository;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator;
+use ReflectionObject;
+use RuntimeException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Throwable;
 
@@ -35,16 +37,6 @@ use Throwable;
  * an early upgrade step can therefore fail on a schema that is not complete yet. For each
  * such case we register a stub that tolerates the incomplete schema until the migration
  * catches up.
- *
- * To add a new stub:
- *  - create the stub class in the Stubs/ subfolder (a decorator implementing the core
- *    contract is the usual shape), exposing a static register(ContainerInterface) method;
- *  - add an entry below mapping the core symbol that must exist for the stub to be relevant
- *    to the callable installing it.
- *
- * The map is keyed by a core class/interface name kept as a literal string: the existence
- * check runs before the stub class is referenced, so stub classes that implement a core
- * contract are never autoloaded against a core version that does not ship it.
  */
 class CoreServiceStubRegistrar
 {
@@ -66,13 +58,29 @@ class CoreServiceStubRegistrar
 
     public function register(ContainerInterface $container): void
     {
-        foreach ($this->getStubs() as $requiredCoreSymbol => $register) {
+        foreach ($this->getStubs() as $requiredCoreSymbol => $stubClass) {
             if (!interface_exists($requiredCoreSymbol) && !class_exists($requiredCoreSymbol)) {
                 continue;
             }
 
+            if (!$container->has($requiredCoreSymbol)) {
+                continue;
+            }
+
             try {
-                $register($container);
+                $decorated = $container->get($requiredCoreSymbol);
+                $stub = new $stubClass($decorated);
+
+                try {
+                    $container->set($requiredCoreSymbol, $stub);
+                } catch (Throwable $e) {
+                    // Fetching $decorated just above already resolved and cached the service,
+                    // so the container now considers it initialized and refuses a plain set() on
+                    // it ("already initialized"). Force the swap directly on the container's
+                    // internal service cache instead, so later callers in this same request
+                    // (ObjectModel in particular) get our stub rather than the raw service.
+                    $this->forceReplace($container, $requiredCoreSymbol, $stub);
+                }
             } catch (Throwable $e) {
                 $this->logger->warning($this->translator->trans('Unable to register the core service stub for %s during the update: %s', [$requiredCoreSymbol, $e->getMessage()]));
             }
@@ -80,14 +88,35 @@ class CoreServiceStubRegistrar
     }
 
     /**
-     * @return array<string, callable(ContainerInterface):void> core symbol => stub installer
+     * @return array<string, class-string> core symbol => decorating stub class
      */
     private function getStubs(): array
     {
         return [
             // PrestaShop 9.2+: the extra_property_definition table is created late in the
             // migration, after PHP scripts that already make ObjectModel query it.
-            'PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyDefinitionRepositoryInterface' => [FaultTolerantExtraPropertyDefinitionRepository::class, 'register'],
+            'PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyDefinitionRepositoryInterface' => FaultTolerantExtraPropertyDefinitionRepository::class,
         ];
+    }
+
+    /**
+     * @param mixed $service
+     */
+    private function forceReplace(ContainerInterface $container, string $id, $service): void
+    {
+        $reflectionClass = new ReflectionObject($container);
+        while ($reflectionClass && !$reflectionClass->hasProperty('services')) {
+            $reflectionClass = $reflectionClass->getParentClass();
+        }
+
+        if (!$reflectionClass) {
+            throw new RuntimeException(sprintf('Cannot override the "%s" service: cound\'t reach the container "%s".', $id, get_class($container)));
+        }
+
+        $servicesProperty = $reflectionClass->getProperty('services');
+        $servicesProperty->setAccessible(true);
+        $services = $servicesProperty->getValue($container);
+        $services[$id] = $service;
+        $servicesProperty->setValue($container, $services);
     }
 }

--- a/classes/UpgradeTools/CoreUpgrader/CoreServiceStub/CoreServiceStubRegistrar.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreServiceStub/CoreServiceStubRegistrar.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreServiceStub;
+
+use PrestaShop\Module\AutoUpgrade\Log\LoggerInterface;
+use PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreServiceStub\Stubs\FaultTolerantExtraPropertyDefinitionRepository;
+use PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Throwable;
+
+/**
+ * Replaces some core services with fault-tolerant stubs during the database update.
+ *
+ * While the new core files are already on the filesystem, the database is still being
+ * migrated and may lack tables or columns the new code expects. A core service queried by
+ * an early upgrade step can therefore fail on a schema that is not complete yet. For each
+ * such case we register a stub that tolerates the incomplete schema until the migration
+ * catches up.
+ *
+ * To add a new stub:
+ *  - create the stub class in the Stubs/ subfolder (a decorator implementing the core
+ *    contract is the usual shape), exposing a static register(ContainerInterface) method;
+ *  - add an entry below mapping the core symbol that must exist for the stub to be relevant
+ *    to the callable installing it.
+ *
+ * The map is keyed by a core class/interface name kept as a literal string: the existence
+ * check runs before the stub class is referenced, so stub classes that implement a core
+ * contract are never autoloaded against a core version that does not ship it.
+ */
+class CoreServiceStubRegistrar
+{
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var Translator
+     */
+    private $translator;
+
+    public function __construct(LoggerInterface $logger, Translator $translator)
+    {
+        $this->logger = $logger;
+        $this->translator = $translator;
+    }
+
+    public function register(ContainerInterface $container): void
+    {
+        foreach ($this->getStubs() as $requiredCoreSymbol => $register) {
+            if (!interface_exists($requiredCoreSymbol) && !class_exists($requiredCoreSymbol)) {
+                continue;
+            }
+
+            try {
+                $register($container);
+            } catch (Throwable $e) {
+                $this->logger->warning($this->translator->trans('Unable to register the core service stub for %s during the update: %s', [$requiredCoreSymbol, $e->getMessage()]));
+            }
+        }
+    }
+
+    /**
+     * @return array<string, callable(ContainerInterface):void> core symbol => stub installer
+     */
+    private function getStubs(): array
+    {
+        return [
+            // PrestaShop 9.2+: the extra_property_definition table is created late in the
+            // migration, after PHP scripts that already make ObjectModel query it.
+            'PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyDefinitionRepositoryInterface' => [FaultTolerantExtraPropertyDefinitionRepository::class, 'register'],
+        ];
+    }
+}

--- a/classes/UpgradeTools/CoreUpgrader/CoreServiceStub/CoreServiceStubRegistrar.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreServiceStub/CoreServiceStubRegistrar.php
@@ -71,16 +71,9 @@ class CoreServiceStubRegistrar
                 $decorated = $container->get($requiredCoreSymbol);
                 $stub = new $stubClass($decorated, $this->logger);
 
-                try {
-                    $container->set($requiredCoreSymbol, $stub);
-                } catch (Throwable $e) {
-                    // Fetching $decorated just above already resolved and cached the service,
-                    // so the container now considers it initialized and refuses a plain set() on
-                    // it ("already initialized"). Force the swap directly on the container's
-                    // internal service cache instead, so later callers in this same request
-                    // (ObjectModel in particular) get our stub rather than the raw service.
-                    $this->forceReplace($container, $requiredCoreSymbol, $stub);
-                }
+                // Overriding the service with $container->set() will always fail because we just called it.
+                // We must force it.
+                $this->forceReplace($container, $requiredCoreSymbol, $stub);
             } catch (Throwable $e) {
                 $this->logger->warning($this->translator->trans('Unable to register the core service stub for %s during the update: %s', [$requiredCoreSymbol, $e->getMessage()]));
             }

--- a/classes/UpgradeTools/CoreUpgrader/CoreServiceStub/CoreServiceStubRegistrar.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreServiceStub/CoreServiceStubRegistrar.php
@@ -69,7 +69,7 @@ class CoreServiceStubRegistrar
 
             try {
                 $decorated = $container->get($requiredCoreSymbol);
-                $stub = new $stubClass($decorated);
+                $stub = new $stubClass($decorated, $this->logger);
 
                 try {
                     $container->set($requiredCoreSymbol, $stub);

--- a/classes/UpgradeTools/CoreUpgrader/CoreServiceStub/Stubs/FaultTolerantExtraPropertyDefinitionRepository.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreServiceStub/Stubs/FaultTolerantExtraPropertyDefinitionRepository.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreServiceStub\Stubs;
+
+use Doctrine\DBAL\Exception\DriverException;
+use PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyDefinition;
+use PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyDefinitionCollection;
+use PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyDefinitionRepositoryInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Decorates the core extra property definition repository so it tolerates a missing
+ * `extra_property_definition` table during the update.
+ *
+ * The new core files are copied on the filesystem before the database is fully migrated.
+ * The version-ordered SQL upgrade runs PHP scripts (e.g. install_ps_apiresources at 9.0.0)
+ * that install modules and therefore write logs. With the new core, writing a log makes
+ * ObjectModel validate its extra properties, which queries the extra_property_definition
+ * table. That table is only created later in the sequence (9.2.0), so the query fails with
+ * a "table not found" error and aborts the update.
+ *
+ * While the table is missing we return an empty collection (which ObjectModel handles
+ * gracefully). Once the table has been created, the decorator transparently delegates to
+ * the real repository again, so no definitions are lost for the rest of the update.
+ *
+ * This class is only ever referenced when the core interface it implements exists, i.e.
+ * when updating to a PrestaShop version shipping the extra property feature.
+ */
+class FaultTolerantExtraPropertyDefinitionRepository implements ExtraPropertyDefinitionRepositoryInterface
+{
+    /**
+     * Service id used by ObjectModel to resolve the repository from the container.
+     */
+    const SERVICE_ID = ExtraPropertyDefinitionRepositoryInterface::class;
+
+    /**
+     * @var ExtraPropertyDefinitionRepositoryInterface
+     */
+    private $decorated;
+
+    public function __construct(ExtraPropertyDefinitionRepositoryInterface $decorated)
+    {
+        $this->decorated = $decorated;
+    }
+
+    /**
+     * Wraps the core repository service registered in the given container so it no longer
+     * fails when the extra_property_definition table does not exist yet.
+     */
+    public static function register(ContainerInterface $container): void
+    {
+        if (!$container->has(self::SERVICE_ID)) {
+            return;
+        }
+
+        $current = $container->get(self::SERVICE_ID);
+
+        // Avoid wrapping our own decorator again on subsequent update batches.
+        if ($current instanceof self) {
+            return;
+        }
+
+        $container->set(self::SERVICE_ID, new self($current));
+    }
+
+    public function getAllDefinitions(): ExtraPropertyDefinitionCollection
+    {
+        try {
+            return $this->decorated->getAllDefinitions();
+        } catch (DriverException $e) {
+            if (strpos($e->getMessage(), 'TableNotFoundException') !== false) {
+                return ExtraPropertyDefinitionCollection::empty();
+            }
+            throw $e;
+        }
+    }
+
+    public function findDefinitionByModuleAndField(string $entityName, ?string $moduleName, string $fieldName): ?ExtraPropertyDefinition
+    {
+        try {
+            return $this->decorated->findDefinitionByModuleAndField($entityName, $moduleName, $fieldName);
+        } catch (DriverException $e) {
+            if (strpos($e->getMessage(), 'TableNotFoundException') !== false) {
+                return null;
+            }
+            throw $e;
+        }
+    }
+
+    public function getDefinitionById(int $id): ?ExtraPropertyDefinition
+    {
+        try {
+            return $this->decorated->getDefinitionById($id);
+        } catch (DriverException $e) {
+            if (strpos($e->getMessage(), 'TableNotFoundException') !== false) {
+                return null;
+            }
+            throw $e;
+        }
+    }
+
+    public function getUnprotectedDefinitionById(int $id): ExtraPropertyDefinition
+    {
+        // This method must return a definition and has no safe empty fallback. It is not
+        // called during the update, so we simply delegate to the real repository.
+        return $this->decorated->getUnprotectedDefinitionById($id);
+    }
+}

--- a/classes/UpgradeTools/CoreUpgrader/CoreServiceStub/Stubs/FaultTolerantExtraPropertyDefinitionRepository.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreServiceStub/Stubs/FaultTolerantExtraPropertyDefinitionRepository.php
@@ -21,7 +21,9 @@
 
 namespace PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreServiceStub\Stubs;
 
-use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\DBAL\Exception\TableNotFoundException;
+use Exception;
+use PrestaShop\Module\AutoUpgrade\Log\LoggerInterface;
 use PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyDefinition;
 use PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyDefinitionCollection;
 use PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyDefinitionRepositoryInterface;
@@ -51,17 +53,22 @@ class FaultTolerantExtraPropertyDefinitionRepository implements ExtraPropertyDef
      */
     private $decorated;
 
-    public function __construct(ExtraPropertyDefinitionRepositoryInterface $decorated)
+    /** @var LoggerInterface */
+    private $logger;
+
+    public function __construct(ExtraPropertyDefinitionRepositoryInterface $decorated, LoggerInterface $logger)
     {
         $this->decorated = $decorated;
+        $this->logger = $logger;
     }
 
     public function getAllDefinitions(): ExtraPropertyDefinitionCollection
     {
         try {
             return $this->decorated->getAllDefinitions();
-        } catch (DriverException $e) {
-            if (strpos($e->getMessage(), 'TableNotFoundException') !== false) {
+        } catch (Exception $e) {
+            $this->logger->debug('FaultTolerantExtraPropertyDefinitionRepository: caught exception while fetching all definitions: ' . $e->getMessage());
+            if ($this->isExceptionAboutTableNotFound($e)) {
                 return ExtraPropertyDefinitionCollection::empty();
             }
             throw $e;
@@ -72,8 +79,9 @@ class FaultTolerantExtraPropertyDefinitionRepository implements ExtraPropertyDef
     {
         try {
             return $this->decorated->findDefinitionByModuleAndField($entityName, $moduleName, $fieldName);
-        } catch (DriverException $e) {
-            if (strpos($e->getMessage(), 'TableNotFoundException') !== false) {
+        } catch (Exception $e) {
+            $this->logger->debug('FaultTolerantExtraPropertyDefinitionRepository: caught exception while finding definition by module and field: ' . $e->getMessage());
+            if ($this->isExceptionAboutTableNotFound($e)) {
                 return null;
             }
             throw $e;
@@ -84,8 +92,9 @@ class FaultTolerantExtraPropertyDefinitionRepository implements ExtraPropertyDef
     {
         try {
             return $this->decorated->getDefinitionById($id);
-        } catch (DriverException $e) {
-            if (strpos($e->getMessage(), 'TableNotFoundException') !== false) {
+        } catch (Exception $e) {
+            $this->logger->debug('FaultTolerantExtraPropertyDefinitionRepository: caught exception while fetching definition by ID: ' . $e->getMessage());
+            if ($this->isExceptionAboutTableNotFound($e)) {
                 return null;
             }
             throw $e;
@@ -97,5 +106,18 @@ class FaultTolerantExtraPropertyDefinitionRepository implements ExtraPropertyDef
         // This method must return a definition and has no safe empty fallback. It is not
         // called during the update, so we simply delegate to the real repository.
         return $this->decorated->getUnprotectedDefinitionById($id);
+    }
+
+    private function isExceptionAboutTableNotFound(Exception $e): bool
+    {
+        $currentException = $e;
+        while ($currentException) {
+            if ($currentException instanceof TableNotFoundException) {
+                return true;
+            }
+            $currentException = $currentException->getPrevious();
+        }
+
+        return false;
     }
 }

--- a/classes/UpgradeTools/CoreUpgrader/CoreServiceStub/Stubs/FaultTolerantExtraPropertyDefinitionRepository.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreServiceStub/Stubs/FaultTolerantExtraPropertyDefinitionRepository.php
@@ -25,7 +25,6 @@ use Doctrine\DBAL\Exception\DriverException;
 use PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyDefinition;
 use PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyDefinitionCollection;
 use PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyDefinitionRepositoryInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Decorates the core extra property definition repository so it tolerates a missing
@@ -48,11 +47,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class FaultTolerantExtraPropertyDefinitionRepository implements ExtraPropertyDefinitionRepositoryInterface
 {
     /**
-     * Service id used by ObjectModel to resolve the repository from the container.
-     */
-    const SERVICE_ID = ExtraPropertyDefinitionRepositoryInterface::class;
-
-    /**
      * @var ExtraPropertyDefinitionRepositoryInterface
      */
     private $decorated;
@@ -60,26 +54,6 @@ class FaultTolerantExtraPropertyDefinitionRepository implements ExtraPropertyDef
     public function __construct(ExtraPropertyDefinitionRepositoryInterface $decorated)
     {
         $this->decorated = $decorated;
-    }
-
-    /**
-     * Wraps the core repository service registered in the given container so it no longer
-     * fails when the extra_property_definition table does not exist yet.
-     */
-    public static function register(ContainerInterface $container): void
-    {
-        if (!$container->has(self::SERVICE_ID)) {
-            return;
-        }
-
-        $current = $container->get(self::SERVICE_ID);
-
-        // Avoid wrapping our own decorator again on subsequent update batches.
-        if ($current instanceof self) {
-            return;
-        }
-
-        $container->set(self::SERVICE_ID, new self($current));
     }
 
     public function getAllDefinitions(): ExtraPropertyDefinitionCollection

--- a/classes/UpgradeTools/CoreUpgrader/CoreServiceStub/Stubs/index.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreServiceStub/Stubs/index.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/classes/UpgradeTools/CoreUpgrader/CoreServiceStub/index.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreServiceStub/index.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
@@ -24,7 +24,6 @@ namespace PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader;
 
 use Exception;
 use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
-use PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreServiceStub\CoreServiceStubRegistrar;
 use PrestaShop\PrestaShop\Adapter\Module\Repository\ModuleRepository;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Domain\MailTemplate\Command\GenerateThemeMailTemplatesCommand;
@@ -37,10 +36,7 @@ class CoreUpgrader80 extends CoreUpgrader
         $this->forceRemovingFiles();
         parent::initConstants();
         // Container may be needed to run upgrade scripts
-        $kernel = $this->container->getSymfonyAdapter()->initKernel();
-        // The destination core files run against a database that is not fully migrated yet:
-        // replace the core services that would fail on the incomplete schema with stubs.
-        (new CoreServiceStubRegistrar($this->logger, $this->container->getTranslator()))->register($kernel->getContainer());
+        $this->container->getSymfonyAdapter()->initKernel();
     }
 
     /**

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
@@ -24,6 +24,7 @@ namespace PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader;
 
 use Exception;
 use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
+use PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreServiceStub\CoreServiceStubRegistrar;
 use PrestaShop\PrestaShop\Adapter\Module\Repository\ModuleRepository;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Domain\MailTemplate\Command\GenerateThemeMailTemplatesCommand;
@@ -36,7 +37,10 @@ class CoreUpgrader80 extends CoreUpgrader
         $this->forceRemovingFiles();
         parent::initConstants();
         // Container may be needed to run upgrade scripts
-        $this->container->getSymfonyAdapter()->initKernel();
+        $kernel = $this->container->getSymfonyAdapter()->initKernel();
+        // The destination core files run against a database that is not fully migrated yet:
+        // replace the core services that would fail on the incomplete schema with stubs.
+        (new CoreServiceStubRegistrar($this->logger, $this->container->getTranslator()))->register($kernel->getContainer());
     }
 
     /**

--- a/classes/UpgradeTools/SymfonyAdapter.php
+++ b/classes/UpgradeTools/SymfonyAdapter.php
@@ -21,6 +21,7 @@
 
 namespace PrestaShop\Module\AutoUpgrade\UpgradeTools;
 
+use PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreServiceStub\CoreServiceStubRegistrar;
 use ReflectionClass;
 
 /**
@@ -28,6 +29,15 @@ use ReflectionClass;
  */
 class SymfonyAdapter
 {
+    /** @var CoreServiceStubRegistrar */
+    private $coreServiceStubRegistrar;
+
+    public function __construct(
+        CoreServiceStubRegistrar $coreServiceStubRegistrar
+    ) {
+        $this->coreServiceStubRegistrar = $coreServiceStubRegistrar;
+    }
+
     public function isKernelReachable(): bool
     {
         return defined('_PS_ROOT_DIR_') && class_exists('AppKernel', true);
@@ -61,6 +71,10 @@ class SymfonyAdapter
             $kernel->boot();
             // Starting from PrestaShop 9, some parts of the new context are defined by event listeners on kernel.request.
             // We may have to trigger it with dummy data in the future.
+
+            // The destination core files run against a database that may be not fully migrated yet:
+            // replace the core services that would fail on the incomplete schema with stubs.
+            $this->coreServiceStubRegistrar->register($kernel->getContainer());
         }
 
         return $kernel;

--- a/tests/phpstan/phpstan-1.7.2.5.neon
+++ b/tests/phpstan/phpstan-1.7.2.5.neon
@@ -5,6 +5,8 @@ includes:
 parameters:
 	excludePaths:
 		- ./../../classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
+		# Exclude the stubs as Symfony is not heavily used yet
+		- ./../../classes/UpgradeTools/CoreUpgrader/CoreServiceStub/Stubs
 	ignoreErrors:
 		- '#Call to method getContainer\(\) on an unknown class AppKernel.#'
 		- '#Call to method getMessage\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Exception\\CoreException.#'

--- a/tests/phpstan/phpstan-1.7.3.4.neon
+++ b/tests/phpstan/phpstan-1.7.3.4.neon
@@ -6,6 +6,8 @@ parameters:
 	excludePaths:
 		- ./../../classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
 		- ./../../classes/Twig/TransFilterExtension3.php
+		# Exclude the stubs as Symfony is not heavily used yet
+		- ./../../classes/UpgradeTools/CoreUpgrader/CoreServiceStub/Stubs
 	ignoreErrors:
 		- '#Call to method getContainer\(\) on an unknown class AppKernel.#'
 		- '#Call to method getMessage\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Exception\\CoreException.#'

--- a/tests/phpstan/phpstan-1.7.4.4.neon
+++ b/tests/phpstan/phpstan-1.7.4.4.neon
@@ -5,6 +5,8 @@ includes:
 parameters:
 	excludePaths:
 		- ./../../classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
+		# Exclude the stubs as Symfony is not heavily used yet
+		- ./../../classes/UpgradeTools/CoreUpgrader/CoreServiceStub/Stubs
 	ignoreErrors:
 		- '#Call to method getMessage\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Exception\\CoreException.#'
 		- '#Call to method handle\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\CommandBus\\CommandBusInterface.#'

--- a/tests/phpstan/phpstan-1.7.5.1.neon
+++ b/tests/phpstan/phpstan-1.7.5.1.neon
@@ -5,6 +5,8 @@ includes:
 parameters:
 	excludePaths:
 		- ./../../classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
+		# Exclude the stubs as Symfony is not heavily used yet
+		- ./../../classes/UpgradeTools/CoreUpgrader/CoreServiceStub/Stubs
 	ignoreErrors:
 		- '#Instantiated class PrestaShop\\PrestaShop\\Core\\Domain\\Theme\\ValueObject\\ThemeName not found.#'
 		- '#Call to method getContainer\(\) on an unknown class AdminKernel.#'

--- a/tests/phpstan/phpstan-1.7.6.neon
+++ b/tests/phpstan/phpstan-1.7.6.neon
@@ -5,6 +5,8 @@ includes:
 parameters:
 	excludePaths:
 		- ./../../classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
+		# Exclude the stubs as Symfony is not heavily used yet
+		- ./../../classes/UpgradeTools/CoreUpgrader/CoreServiceStub/Stubs
 	ignoreErrors:
 		- '#Call to method fetchLocale\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Cldr\\Update.#'
 		- '#Instantiated class PrestaShop\\PrestaShop\\Core\\Cldr\\Update not found.#'

--- a/tests/phpstan/phpstan-1.7.7.neon
+++ b/tests/phpstan/phpstan-1.7.7.neon
@@ -5,6 +5,8 @@ includes:
 parameters:
 	excludePaths:
 		- ./../../classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
+		# Exclude the stubs as Symfony is not heavily used yet
+		- ./../../classes/UpgradeTools/CoreUpgrader/CoreServiceStub/Stubs
 	ignoreErrors:
 		- '#Call to method fetchLocale\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Cldr\\Update.#'
 		- '#Instantiated class PrestaShop\\PrestaShop\\Core\\Cldr\\Update not found.#'

--- a/tests/phpstan/phpstan-1.7.8.neon
+++ b/tests/phpstan/phpstan-1.7.8.neon
@@ -5,6 +5,8 @@ includes:
 parameters:
 	excludePaths:
 		- ./../../classes/UpgradeTools/CoreUpgrader/CoreUpgrader80.php
+		# Exclude the stubs as Symfony is not heavily used yet
+		- ./../../classes/UpgradeTools/CoreUpgrader/CoreServiceStub/Stubs
 	ignoreErrors:
 		- '#Call to method fetchLocale\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Cldr\\Update.#'
 		- '#Instantiated class PrestaShop\\PrestaShop\\Core\\Cldr\\Update not found.#'

--- a/tests/phpstan/phpstan-8.0.0.neon
+++ b/tests/phpstan/phpstan-8.0.0.neon
@@ -7,6 +7,8 @@ parameters:
 		- ./../../classes/UpgradeTools/CoreUpgrader/CoreUpgrader17.php
 		- ./../../classes/Twig/TransFilterExtension.php
 		- ./../../classes/UpgradeContainer.php
+		# Exclude the stubs as Symfony is not heavily used yet
+		- ./../../classes/UpgradeTools/CoreUpgrader/CoreServiceStub/Stubs
 	ignoreErrors:
 		- '#Call to method getContainer\(\) on an unknown class AdminKernel.#'
 		- '#Method PrestaShop\\Module\\AutoUpgrade\\UpgradeTools\\SymfonyAdapter::initKernel\(\) has invalid return type AdminKernel.#'

--- a/tests/phpstan/phpstan-9.0.0.neon
+++ b/tests/phpstan/phpstan-9.0.0.neon
@@ -6,6 +6,8 @@ parameters:
 		- ./../../classes/UpgradeTools/CoreUpgrader/CoreUpgrader17.php
 		- ./../../classes/Twig/TransFilterExtension.php
 		- ./../../classes/UpgradeContainer.php
+		# Exclude the stub as the related class exists from PrestaShop v9.2
+		- ./../../classes/UpgradeTools/CoreUpgrader/CoreServiceStub/Stubs/FaultTolerantExtraPropertyDefinitionRepository.php
 	ignoreErrors:
 		- "#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(int\\)\\: mixed\\)\\|null, 'add_quotes' given\\.$#"
 		- "#^Property .*ModuleAdapter::\\$commandBus .* does not accept Symfony\\\\Component\\\\DependencyInjection\\\\object\\|null.$#"

--- a/tests/phpstan/phpstan-latest.neon
+++ b/tests/phpstan/phpstan-latest.neon
@@ -6,6 +6,8 @@ parameters:
 		- ./../../classes/UpgradeTools/CoreUpgrader/CoreUpgrader17.php
 		- ./../../classes/Twig/TransFilterExtension.php
 		- ./../../classes/UpgradeContainer.php
+		# TODO: remove this once PrestaShop 9.2 is out
+		- ./../../classes/UpgradeTools/CoreUpgrader/CoreServiceStub/Stubs
 	ignoreErrors:
 		- "#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(int\\)\\: mixed\\)\\|null, 'add_quotes' given\\.$#"
 		- "#^Property .*ModuleAdapter::\\$commandBus .* does not accept Symfony\\\\Component\\\\DependencyInjection\\\\object\\|null.$#"


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | https://github.com/PrestaShop/autoupgrade/pull/1850 introduces the extra properties on PrestaShop. When updating to this versions, the files are applied before updating the database. Unfortunately, some actions such as module installation causes the Core to load some ObjectModel instances and the extra properties with them. Because the database is not ready until the migration of 9.2.0 is applied, the process will fail saying a table is missing. This PR introduces some stubs for the core, which will catch the exception until the table is created.
| Type?             |new feature
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/autoupgrade/pull/1850#issuecomment-4834428340
| Sponsor company   | @PrestaShopCorp
| How to test?      | Updates to PrestaShop 9.2.0 aren't failing anymore because of this exception: `Base table or view not found: 1146 Table 'presta_827.ps_extra_property_definition' doesn't exist`


```
[2026-07-01 19:19:09] DEBUG - ChainedTasks - Step UpdateDatabase
[2026-07-01 19:19:09] INFO - UpdateDatabase - Mise à jour de la base de données en cours. 89 requêtes restantes
[2026-07-01 19:19:09] WARNING - FaultTolerantExtraPropertyDefinitionRepository - FaultTolerantExtraPropertyDefinitionRepository: caught exception while fetching all definitions: An exception occurred while executing a query: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'psreference.ks_extra_property_definition' doesn't exist
[2026-07-01 19:19:09] ERROR - UpdateCommand - An error occurred during the update process:
PDOException: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'psreference.ks_extra_property_definition' doesn't exist in /var/www/html/vendor/doctrine/dbal/src/Driver/PDO/Connection.php:71
Stack trace:
#0 /var/www/html/vendor/doctrine/dbal/src/Driver/PDO/Connection.php(71): PDO->query('SELECT eef.* FR...')
#1 /var/www/html/vendor/doctrine/dbal/src/Connection.php(1101): Doctrine\DBAL\Driver\PDO\Connection->query('SELECT eef.* FR...')
#2 /var/www/html/vendor/doctrine/dbal/src/Query/QueryBuilder.php(348): Doctrine\DBAL\Connection->executeQuery('SELECT eef.* FR...', Array, Array, NULL)
#3 /var/www/html/src/Core/ExtraProperty/Definition/ExtraPropertyDefinitionRepository.php(45): Doctrine\DBAL\Query\QueryBuilder->executeQuery()
#4 /var/www/html/src/Core/ExtraProperty/Definition/CachedExtraPropertyDefinitionRepository.php(57): PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyDefinitionRepository->getAllDefinitions()
#5 /var/www/html/vendor/symfony/cache/LockRegistry.php(113): PrestaShop\PrestaShop\Core\ExtraProperty\Definition\CachedExtraPropertyDefinitionRepository->PrestaShop\PrestaShop\Core\ExtraProperty\Definition\{closure}(Object(Symfony\Component\Cache\CacheItem), true)
#6 /var/www/html/vendor/symfony/cache/Traits/ContractsTrait.php(102): Symfony\Component\Cache\LockRegistry::compute(Object(Closure), Object(Symfony\Component\Cache\CacheItem), true, Object(Symfony\Component\Cache\Adapter\FilesystemAdapter), Object(Closure), NULL, 1.0)
#7 /var/www/html/vendor/symfony/cache-contracts/CacheTrait.php(67): Symfony\Component\Cache\Adapter\AbstractAdapter->Symfony\Component\Cache\Traits\{closure}(Object(Symfony\Component\Cache\CacheItem), true)
#8 /var/www/html/vendor/symfony/cache/Traits/ContractsTrait.php(111): Symfony\Component\Cache\Adapter\AbstractAdapter->contractsGet(Object(Symfony\Component\Cache\Adapter\FilesystemAdapter), 'extra_property_...', Object(Closure), 1.0, Array, NULL)
#9 /var/www/html/vendor/symfony/cache-contracts/CacheTrait.php(30): Symfony\Component\Cache\Adapter\AbstractAdapter->doGet(Object(Symfony\Component\Cache\Adapter\FilesystemAdapter), 'extra_property_...', Object(Closure), 1.0, Array)
#10 /var/www/html/src/Core/ExtraProperty/Definition/CachedExtraPropertyDefinitionRepository.php(58): Symfony\Component\Cache\Adapter\AbstractAdapter->get('extra_property_...', Object(Closure))
#11 /var/www/html/modules/autoupgrade/classes/UpgradeTools/CoreUpgrader/CoreServiceStub/Stubs/FaultTolerantExtraPropertyDefinitionRepository.php(67): PrestaShop\PrestaShop\Core\ExtraProperty\Definition\CachedExtraPropertyDefinitionRepository->getAllDefinitions()
#12 /var/www/html/classes/ObjectModel.php(2277): PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreServiceStub\Stubs\FaultTolerantExtraPropertyDefinitionRepository->getAllDefinitions()
#13 /var/www/html/classes/ObjectModel.php(1091): ObjectModelCore->getDefinitionCollection()
#14 /var/www/html/classes/ObjectModel.php(557): ObjectModelCore->validateExtraProperties()
#15 /var/www/html/classes/PrestaShopLogger.php(170): ObjectModelCore->add()
#16 /var/www/html/classes/module/Module.php(377): PrestaShopLoggerCore::addLog('Starting module...', 1, NULL, 'Module', NULL, true)
#17 /var/www/html/modules/autoupgrade/upgrade/php/install_ps_apiresources.php(24): ModuleCore->install()
#18 [internal function]: install_ps_apiresources()
#19 /var/www/html/modules/autoupgrade/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php(432): call_user_func_array('install_ps_apir...', Array)
#20 /var/www/html/modules/autoupgrade/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php(359): PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreUpgrader->runPhpQuery('9.0.0', '/* PHP:install_...')
#21 /var/www/html/modules/autoupgrade/classes/Task/Update/UpdateDatabase.php(178): PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreUpgrader->runQuery('9.0.0', '/* PHP:install_...')
#22 /var/www/html/modules/autoupgrade/classes/Task/Update/UpdateDatabase.php(61): PrestaShop\Module\AutoUpgrade\Task\Update\UpdateDatabase->updateDatabase(Object(PrestaShop\Module\AutoUpgrade\Progress\Backlog))
#23 /var/www/html/modules/autoupgrade/classes/Task/Runner/ChainedTasks.php(66): PrestaShop\Module\AutoUpgrade\Task\Update\UpdateDatabase->run()
#24 /var/www/html/modules/autoupgrade/classes/Commands/UpdateCommand.php(129): PrestaShop\Module\AutoUpgrade\Task\Runner\ChainedTasks->run()
#25 /var/www/html/modules/autoupgrade/sub-vendors/php8/vendor/symfony/console/Command/Command.php(326): PrestaShop\Module\AutoUpgrade\Commands\UpdateCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#26 /var/www/html/modules/autoupgrade/sub-vendors/php8/vendor/symfony/console/Application.php(1078): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#27 /var/www/html/modules/autoupgrade/sub-vendors/php8/vendor/symfony/console/Application.php(324): Symfony\Component\Console\Application->doRunCommand(Object(PrestaShop\Module\AutoUpgrade\Commands\UpdateCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#28 /var/www/html/modules/autoupgrade/sub-vendors/php8/vendor/symfony/console/Application.php(175): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#29 /var/www/html/modules/autoupgrade/bin/console(74): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#30 {main}

Next Doctrine\DBAL\Driver\PDO\Exception: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'psreference.ks_extra_property_definition' doesn't exist in /var/www/html/vendor/doctrine/dbal/src/Driver/PDO/Exception.php:28
Stack trace:
#0 /var/www/html/vendor/doctrine/dbal/src/Driver/PDO/Connection.php(76): Doctrine\DBAL\Driver\PDO\Exception::new(Object(PDOException))
#1 /var/www/html/vendor/doctrine/dbal/src/Connection.php(1101): Doctrine\DBAL\Driver\PDO\Connection->query('SELECT eef.* FR...')
#2 /var/www/html/vendor/doctrine/dbal/src/Query/QueryBuilder.php(348): Doctrine\DBAL\Connection->executeQuery('SELECT eef.* FR...', Array, Array, NULL)
#3 /var/www/html/src/Core/ExtraProperty/Definition/ExtraPropertyDefinitionRepository.php(45): Doctrine\DBAL\Query\QueryBuilder->executeQuery()
#4 /var/www/html/src/Core/ExtraProperty/Definition/CachedExtraPropertyDefinitionRepository.php(57): PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyDefinitionRepository->getAllDefinitions()
#5 /var/www/html/vendor/symfony/cache/LockRegistry.php(113): PrestaShop\PrestaShop\Core\ExtraProperty\Definition\CachedExtraPropertyDefinitionRepository->PrestaShop\PrestaShop\Core\ExtraProperty\Definition\{closure}(Object(Symfony\Component\Cache\CacheItem), true)
#6 /var/www/html/vendor/symfony/cache/Traits/ContractsTrait.php(102): Symfony\Component\Cache\LockRegistry::compute(Object(Closure), Object(Symfony\Component\Cache\CacheItem), true, Object(Symfony\Component\Cache\Adapter\FilesystemAdapter), Object(Closure), NULL, 1.0)
#7 /var/www/html/vendor/symfony/cache-contracts/CacheTrait.php(67): Symfony\Component\Cache\Adapter\AbstractAdapter->Symfony\Component\Cache\Traits\{closure}(Object(Symfony\Component\Cache\CacheItem), true)
#8 /var/www/html/vendor/symfony/cache/Traits/ContractsTrait.php(111): Symfony\Component\Cache\Adapter\AbstractAdapter->contractsGet(Object(Symfony\Component\Cache\Adapter\FilesystemAdapter), 'extra_property_...', Object(Closure), 1.0, Array, NULL)
#9 /var/www/html/vendor/symfony/cache-contracts/CacheTrait.php(30): Symfony\Component\Cache\Adapter\AbstractAdapter->doGet(Object(Symfony\Component\Cache\Adapter\FilesystemAdapter), 'extra_property_...', Object(Closure), 1.0, Array)
#10 /var/www/html/src/Core/ExtraProperty/Definition/CachedExtraPropertyDefinitionRepository.php(58): Symfony\Component\Cache\Adapter\AbstractAdapter->get('extra_property_...', Object(Closure))
#11 /var/www/html/modules/autoupgrade/classes/UpgradeTools/CoreUpgrader/CoreServiceStub/Stubs/FaultTolerantExtraPropertyDefinitionRepository.php(67): PrestaShop\PrestaShop\Core\ExtraProperty\Definition\CachedExtraPropertyDefinitionRepository->getAllDefinitions()
#12 /var/www/html/classes/ObjectModel.php(2277): PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreServiceStub\Stubs\FaultTolerantExtraPropertyDefinitionRepository->getAllDefinitions()
#13 /var/www/html/classes/ObjectModel.php(1091): ObjectModelCore->getDefinitionCollection()
#14 /var/www/html/classes/ObjectModel.php(557): ObjectModelCore->validateExtraProperties()
#15 /var/www/html/classes/PrestaShopLogger.php(170): ObjectModelCore->add()
#16 /var/www/html/classes/module/Module.php(377): PrestaShopLoggerCore::addLog('Starting module...', 1, NULL, 'Module', NULL, true)
#17 /var/www/html/modules/autoupgrade/upgrade/php/install_ps_apiresources.php(24): ModuleCore->install()
#18 [internal function]: install_ps_apiresources()
#19 /var/www/html/modules/autoupgrade/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php(432): call_user_func_array('install_ps_apir...', Array)
#20 /var/www/html/modules/autoupgrade/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php(359): PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreUpgrader->runPhpQuery('9.0.0', '/* PHP:install_...')
#21 /var/www/html/modules/autoupgrade/classes/Task/Update/UpdateDatabase.php(178): PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreUpgrader->runQuery('9.0.0', '/* PHP:install_...')
#22 /var/www/html/modules/autoupgrade/classes/Task/Update/UpdateDatabase.php(61): PrestaShop\Module\AutoUpgrade\Task\Update\UpdateDatabase->updateDatabase(Object(PrestaShop\Module\AutoUpgrade\Progress\Backlog))
#23 /var/www/html/modules/autoupgrade/classes/Task/Runner/ChainedTasks.php(66): PrestaShop\Module\AutoUpgrade\Task\Update\UpdateDatabase->run()
#24 /var/www/html/modules/autoupgrade/classes/Commands/UpdateCommand.php(129): PrestaShop\Module\AutoUpgrade\Task\Runner\ChainedTasks->run()
#25 /var/www/html/modules/autoupgrade/sub-vendors/php8/vendor/symfony/console/Command/Command.php(326): PrestaShop\Module\AutoUpgrade\Commands\UpdateCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#26 /var/www/html/modules/autoupgrade/sub-vendors/php8/vendor/symfony/console/Application.php(1078): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#27 /var/www/html/modules/autoupgrade/sub-vendors/php8/vendor/symfony/console/Application.php(324): Symfony\Component\Console\Application->doRunCommand(Object(PrestaShop\Module\AutoUpgrade\Commands\UpdateCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#28 /var/www/html/modules/autoupgrade/sub-vendors/php8/vendor/symfony/console/Application.php(175): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#29 /var/www/html/modules/autoupgrade/bin/console(74): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#30 {main}

Next Doctrine\DBAL\Exception\TableNotFoundException: An exception occurred while executing a query: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'psreference.ks_extra_property_definition' doesn't exist in /var/www/html/vendor/doctrine/dbal/src/Driver/API/MySQL/ExceptionConverter.php:49
Stack trace:
#0 /var/www/html/vendor/doctrine/dbal/src/Connection.php(1939): Doctrine\DBAL\Driver\API\MySQL\ExceptionConverter->convert(Object(Doctrine\DBAL\Driver\PDO\Exception), Object(Doctrine\DBAL\Query))
#1 /var/www/html/vendor/doctrine/dbal/src/Connection.php(1881): Doctrine\DBAL\Connection->handleDriverException(Object(Doctrine\DBAL\Driver\PDO\Exception), Object(Doctrine\DBAL\Query))
#2 /var/www/html/vendor/doctrine/dbal/src/Connection.php(1106): Doctrine\DBAL\Connection->convertExceptionDuringQuery(Object(Doctrine\DBAL\Driver\PDO\Exception), 'SELECT eef.* FR...', Array, Array)
#3 /var/www/html/vendor/doctrine/dbal/src/Query/QueryBuilder.php(348): Doctrine\DBAL\Connection->executeQuery('SELECT eef.* FR...', Array, Array, NULL)
#4 /var/www/html/src/Core/ExtraProperty/Definition/ExtraPropertyDefinitionRepository.php(45): Doctrine\DBAL\Query\QueryBuilder->executeQuery()
#5 /var/www/html/src/Core/ExtraProperty/Definition/CachedExtraPropertyDefinitionRepository.php(57): PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyDefinitionRepository->getAllDefinitions()
#6 /var/www/html/vendor/symfony/cache/LockRegistry.php(113): PrestaShop\PrestaShop\Core\ExtraProperty\Definition\CachedExtraPropertyDefinitionRepository->PrestaShop\PrestaShop\Core\ExtraProperty\Definition\{closure}(Object(Symfony\Component\Cache\CacheItem), true)
#7 /var/www/html/vendor/symfony/cache/Traits/ContractsTrait.php(102): Symfony\Component\Cache\LockRegistry::compute(Object(Closure), Object(Symfony\Component\Cache\CacheItem), true, Object(Symfony\Component\Cache\Adapter\FilesystemAdapter), Object(Closure), NULL, 1.0)
#8 /var/www/html/vendor/symfony/cache-contracts/CacheTrait.php(67): Symfony\Component\Cache\Adapter\AbstractAdapter->Symfony\Component\Cache\Traits\{closure}(Object(Symfony\Component\Cache\CacheItem), true)
#9 /var/www/html/vendor/symfony/cache/Traits/ContractsTrait.php(111): Symfony\Component\Cache\Adapter\AbstractAdapter->contractsGet(Object(Symfony\Component\Cache\Adapter\FilesystemAdapter), 'extra_property_...', Object(Closure), 1.0, Array, NULL)
#10 /var/www/html/vendor/symfony/cache-contracts/CacheTrait.php(30): Symfony\Component\Cache\Adapter\AbstractAdapter->doGet(Object(Symfony\Component\Cache\Adapter\FilesystemAdapter), 'extra_property_...', Object(Closure), 1.0, Array)
#11 /var/www/html/src/Core/ExtraProperty/Definition/CachedExtraPropertyDefinitionRepository.php(58): Symfony\Component\Cache\Adapter\AbstractAdapter->get('extra_property_...', Object(Closure))
#12 /var/www/html/modules/autoupgrade/classes/UpgradeTools/CoreUpgrader/CoreServiceStub/Stubs/FaultTolerantExtraPropertyDefinitionRepository.php(67): PrestaShop\PrestaShop\Core\ExtraProperty\Definition\CachedExtraPropertyDefinitionRepository->getAllDefinitions()
#13 /var/www/html/classes/ObjectModel.php(2277): PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreServiceStub\Stubs\FaultTolerantExtraPropertyDefinitionRepository->getAllDefinitions()
#14 /var/www/html/classes/ObjectModel.php(1091): ObjectModelCore->getDefinitionCollection()
#15 /var/www/html/classes/ObjectModel.php(557): ObjectModelCore->validateExtraProperties()
#16 /var/www/html/classes/PrestaShopLogger.php(170): ObjectModelCore->add()
#17 /var/www/html/classes/module/Module.php(377): PrestaShopLoggerCore::addLog('Starting module...', 1, NULL, 'Module', NULL, true)
#18 /var/www/html/modules/autoupgrade/upgrade/php/install_ps_apiresources.php(24): ModuleCore->install()
#19 [internal function]: install_ps_apiresources()
#20 /var/www/html/modules/autoupgrade/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php(432): call_user_func_array('install_ps_apir...', Array)
#21 /var/www/html/modules/autoupgrade/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php(359): PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreUpgrader->runPhpQuery('9.0.0', '/* PHP:install_...')
#22 /var/www/html/modules/autoupgrade/classes/Task/Update/UpdateDatabase.php(178): PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreUpgrader->runQuery('9.0.0', '/* PHP:install_...')
#23 /var/www/html/modules/autoupgrade/classes/Task/Update/UpdateDatabase.php(61): PrestaShop\Module\AutoUpgrade\Task\Update\UpdateDatabase->updateDatabase(Object(PrestaShop\Module\AutoUpgrade\Progress\Backlog))
#24 /var/www/html/modules/autoupgrade/classes/Task/Runner/ChainedTasks.php(66): PrestaShop\Module\AutoUpgrade\Task\Update\UpdateDatabase->run()
#25 /var/www/html/modules/autoupgrade/classes/Commands/UpdateCommand.php(129): PrestaShop\Module\AutoUpgrade\Task\Runner\ChainedTasks->run()
#26 /var/www/html/modules/autoupgrade/sub-vendors/php8/vendor/symfony/console/Command/Command.php(326): PrestaShop\Module\AutoUpgrade\Commands\UpdateCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#27 /var/www/html/modules/autoupgrade/sub-vendors/php8/vendor/symfony/console/Application.php(1078): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#28 /var/www/html/modules/autoupgrade/sub-vendors/php8/vendor/symfony/console/Application.php(324): Symfony\Component\Console\Application->doRunCommand(Object(PrestaShop\Module\AutoUpgrade\Commands\UpdateCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#29 /var/www/html/modules/autoupgrade/sub-vendors/php8/vendor/symfony/console/Application.php(175): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#30 /var/www/html/modules/autoupgrade/bin/console(74): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#31 {main}
```