### PR TITLE
feat: add PS_SHOP_MODE migration for 9.2.0

### DIFF
--- a/upgrade/sql/9.2.0.sql
+++ b/upgrade/sql/9.2.0.sql
@@ -145,6 +145,9 @@ CREATE TABLE IF NOT EXISTS `PREFIX_b2b_role_authorization_role` (
   KEY `b2b_role_authorization_role_auth_role_idx` (`id_authorization_role`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+-- https://github.com/PrestaShop/PrestaShop/pull/40685
+/* PHP:add_configuration_if_not_exists('PS_SHOP_MODE', 'b2c_only'); */;
+
 -- https://github.com/PrestaShop/PrestaShop/pull/41028
 /* PHP:ps_920_business_entities_tabs(); */;
 


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Adds the `PS_SHOP_MODE` configuration migration in `upgrade/sql/9.2.0.sql`.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#40685
| Sponsor company   | Soledis
| How to test?      | Upgrade a shop from a pre-9.2.0 version to 9.2.0 using the autoupgrade module. After the upgrade, check that the `PS_SHOP_MODE` row exists in the `ps_configuration` table with the value `b2c_only` (e.g. `SELECT value FROM ps_configuration WHERE name = 'PS_SHOP_MODE';`). It must match the value a fresh 9.2.0 install gets from `configuration.xml`. Re-running the update must not error or change an existing value.