### PR TITLE
Warm up the core cache after the final cache clean on update completion

### DIFF
--- a/classes/Task/AbstractTask.php
+++ b/classes/Task/AbstractTask.php
@@ -28,6 +28,10 @@ use PrestaShop\Module\AutoUpgrade\Exceptions\ProcessException;
 use PrestaShop\Module\AutoUpgrade\Log\Logger;
 use PrestaShop\Module\AutoUpgrade\Task\Runner\ChainedTasks;
 use PrestaShop\Module\AutoUpgrade\UpgradeContainer;
+use PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreUpgrader;
+use PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreUpgrader17;
+use PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreUpgrader80;
+use PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreUpgrader81;
 use PrestaShop\Module\AutoUpgrade\UpgradeTools\Translator;
 use ReflectionClass;
 
@@ -84,6 +88,9 @@ abstract class AbstractTask
      */
     protected $next;
 
+    /** @var CoreUpgrader */
+    private $coreUpgrader;
+
     /**
      * @throws Exception
      */
@@ -100,6 +107,23 @@ abstract class AbstractTask
                 $this->logger->updateLogsPath($logPath);
             }
         }
+    }
+
+    public function getCoreUpgrader(): CoreUpgrader
+    {
+        if ($this->coreUpgrader !== null) {
+            return $this->coreUpgrader;
+        }
+
+        if (version_compare($this->container->getUpdateState()->getDestinationVersion(), '8', '<')) {
+            $this->coreUpgrader = new CoreUpgrader17($this->container, $this->logger);
+        } elseif (version_compare($this->container->getUpdateState()->getDestinationVersion(), '8.1', '<')) {
+            $this->coreUpgrader = new CoreUpgrader80($this->container, $this->logger);
+        } else {
+            $this->coreUpgrader = new CoreUpgrader81($this->container, $this->logger);
+        }
+
+        return $this->coreUpgrader;
     }
 
     /**

--- a/classes/Task/Update/UpdateComplete.php
+++ b/classes/Task/Update/UpdateComplete.php
@@ -94,7 +94,13 @@ class UpdateComplete extends AbstractTask
         // earlier during the database update. On PrestaShop 9.0+ the back office relies on that
         // (Symfony) cache; leaving it empty makes the admin entry point fall back to the front
         // office. Warm it up again so the updated shop boots straight into the back office.
-        if ($this->getCoreUpgrader()->shouldWarmupCoreCache()) {
+        //
+        // The warmup only ever runs from the CLI update path (see shouldWarmupCoreCache()). Guard
+        // on the SAPI *before* touching getCoreUpgrader() so the CoreUpgrader is never instantiated
+        // during the web (AJAX) completion request: its constructor calls Db::getInstance(), and the
+        // legacy Db class is not autoloaded at this late stage of the web flow, which fataled the
+        // whole "update complete" step.
+        if (php_sapi_name() === 'cli' && $this->getCoreUpgrader()->shouldWarmupCoreCache()) {
             $this->getCoreUpgrader()->warmupCoreCache();
         }
 

--- a/classes/Task/Update/UpdateComplete.php
+++ b/classes/Task/Update/UpdateComplete.php
@@ -90,6 +90,14 @@ class UpdateComplete extends AbstractTask
 
         $this->container->getCacheCleaner()->cleanFolders();
 
+        // cleanFolders() above wipes the Symfony cache folder, including the core cache warmed up
+        // earlier during the database update. On PrestaShop 9.0+ the back office relies on that
+        // (Symfony) cache; leaving it empty makes the admin entry point fall back to the front
+        // office. Warm it up again so the updated shop boots straight into the back office.
+        if ($this->getCoreUpgrader()->shouldWarmupCoreCache()) {
+            $this->getCoreUpgrader()->warmupCoreCache();
+        }
+
         return ExitCode::SUCCESS;
     }
 

--- a/classes/Task/Update/UpdateDatabase.php
+++ b/classes/Task/Update/UpdateDatabase.php
@@ -29,18 +29,11 @@ use PrestaShop\Module\AutoUpgrade\Task\AbstractTask;
 use PrestaShop\Module\AutoUpgrade\Task\ExitCode;
 use PrestaShop\Module\AutoUpgrade\Task\TaskName;
 use PrestaShop\Module\AutoUpgrade\Task\TaskType;
-use PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreUpgrader;
-use PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreUpgrader17;
-use PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreUpgrader80;
-use PrestaShop\Module\AutoUpgrade\UpgradeTools\CoreUpgrader\CoreUpgrader81;
 use PrestaShop\Module\AutoUpgrade\VersionUtils;
 
 class UpdateDatabase extends AbstractTask
 {
     const TASK_TYPE = TaskType::TASK_TYPE_UPDATE;
-
-    /** @var CoreUpgrader */
-    private $coreUpgrader;
 
     public function run(): int
     {
@@ -87,23 +80,6 @@ class UpdateDatabase extends AbstractTask
         $this->logger->info($this->translator->trans('Database updated. Now updating your Addons modules...'));
 
         return ExitCode::SUCCESS;
-    }
-
-    public function getCoreUpgrader(): CoreUpgrader
-    {
-        if ($this->coreUpgrader !== null) {
-            return $this->coreUpgrader;
-        }
-
-        if (version_compare($this->container->getUpdateState()->getDestinationVersion(), '8', '<')) {
-            $this->coreUpgrader = new CoreUpgrader17($this->container, $this->logger);
-        } elseif (version_compare($this->container->getUpdateState()->getDestinationVersion(), '8.1', '<')) {
-            $this->coreUpgrader = new CoreUpgrader80($this->container, $this->logger);
-        } else {
-            $this->coreUpgrader = new CoreUpgrader81($this->container, $this->logger);
-        }
-
-        return $this->coreUpgrader;
     }
 
     public function init(): void

--- a/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
+++ b/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php
@@ -862,17 +862,32 @@ abstract class CoreUpgrader
      */
     public function warmupCoreCache(): void
     {
+        // Rebuild the prod cache the way the core cache clearer (ExecKernelCacheClearer) does: run
+        // "cache:clear --no-warmup" first, so the container is rebuilt in a temporary directory and
+        // swapped in atomically, then warm it up. A bare "cache:warmup" on the folder that
+        // cleanFolders() just emptied warms it in place and can leave the freshly dumped container
+        // requiring a not-yet-written lazy service file (e.g. getExecKernelCacheClearerService),
+        // which raises "Failed to open stream" warnings.
+        $this->runCoreConsoleCommand('cache:clear --no-warmup --no-interaction --env=prod');
+        $this->runCoreConsoleCommand('cache:warmup --no-optional-warmers --no-interaction --env=prod');
+
+        $this->logger->debug($this->container->getTranslator()->trans('Core cache has been generated to avoid dependency conflicts.'));
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function runCoreConsoleCommand(string $command): void
+    {
         $rootPath = $this->container->getProperty(UpgradeContainer::PS_ROOT_PATH);
-        $command = 'php ' . $rootPath . '/bin/console cache:warmup --no-interaction --no-optional-warmers --env=prod';
         $output = [];
         $resultCode = 0;
 
-        exec($command, $output, $resultCode);
+        exec('php ' . $rootPath . '/bin/console ' . $command, $output, $resultCode);
 
         if ($resultCode !== 0) {
             throw new ProcessException($this->container->getTranslator()->trans("An error was raised when warming up the core cache: \n %s", [implode("\n", $output)]));
         }
-        $this->logger->debug($this->container->getTranslator()->trans('Core cache has been generated to avoid dependency conflicts.'));
     }
 
     /**


### PR DESCRIPTION
| Questions       | Answers                                                    |
| --------------- | ---------------------------------------------------------- |
| Description?    | Warm up the core cache again after the final cache clean at the end of the update, so a shop updated to 9.0+ boots straight into the back office. |
| Type?           | bug fix                                                    |
| BC breaks?      | no                                                         |
| Deprecations?   | no                                                         |
| Fixed ticket?   | Fixes #1867                                                |
| Sponsor company | @PrestaShopCorp                                            |
| How to test?    | Update a shop to 9.0.0 (CLI, local channel), then open the admin URL (e.g. `/admin-dev/`). Before this PR it 302-redirects to the front office (empty `var/cache/prod`); with this PR it lands on the back office login. |

### What happens

During the update, `UpdateDatabase` warms up the core cache (`CoreUpgrader::warmupCoreCache()`, for destination ≥ 9.0.0 on CLI), building `var/cache/prod`. The later `UpdateComplete` task then calls `CacheCleaner::cleanFolders()`, which clears `var/cache/` **after** that warm-up and wipes the just-built prod container. The shop is left with an empty prod cache, and because the PrestaShop 9.0 back office login is a Symfony route, the admin entry point can't boot and falls back to the front office until a manual cache rebuild.

### Fix

- Move `getCoreUpgrader()` (and its cached instance) up from `UpdateDatabase` to the shared `AbstractTask` so it can be reused.
- In `UpdateComplete`, after the final `cleanFolders()`, warm the core cache again (same `shouldWarmupCoreCache()` gate), so the freshly updated shop keeps a valid Symfony `prod` cache.

### Validation

Reproduced locally with the `Upgrade CLI` docker setup (8.1.7 → 9.0.0, local channel):

- Before: `/admin-dev/` redirects to the front office 30/30, `var/cache/prod` only holds `9.0.0en.xml`; the sanity `should login in BO` step times out on `#email`.
- After: `/admin-dev/` → `/admin-dev/login` 8/8, `var/cache/prod` holds the built container; the full `01_ordersBO/01_filterOrders` sanity campaign passes 11/11 with the unmodified test.

This is also the root cause of the intermittent `should login in BO` failures on 9.x destinations in the Upgrade CLI / Upgrade UI jobs.
