### PR TITLE
Add dashboard feature flag and Symfony dashboard hooks to 9.2.0 upgrade

### DIFF
--- a/upgrade/sql/9.2.0.sql
+++ b/upgrade/sql/9.2.0.sql
@@ -11,6 +11,7 @@ INSERT INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`
   (NULL, 'displayAdminDashboardZoneTwo', 'Symfony Dashboard - Zone two', 'Displays module content in the second column of the migrated (Symfony) dashboard page. Modern counterpart of the legacy dashboardZoneTwo hook.', '1'),
   (NULL, 'displayAdminDashboardZoneThree', 'Symfony Dashboard - Zone three', 'Displays module content in the third column of the migrated (Symfony) dashboard page. Modern counterpart of the legacy dashboardZoneThree hook.', '1'),
   (NULL, 'displayAdminDashboardTop', 'Symfony Dashboard - Top', 'Displays module content in the top area of the migrated (Symfony) dashboard page. Modern counterpart of the legacy displayDashboardTop hook.', '1'),
+  (NULL, 'displayAdminDashboardBottom', 'Symfony Dashboard - Bottom', 'Displays module content in a full-width area at the bottom of the migrated (Symfony) dashboard page.', '1'),
   (NULL, 'displayAdminDashboardToolbar', 'Symfony Dashboard - Toolbar', 'Displays module content in the toolbar area of the migrated (Symfony) dashboard page. Modern counterpart of the legacy displayDashboardToolbarTopMenu hook.', '1')
 ON DUPLICATE KEY UPDATE `title` = VALUES(`title`), `description` = VALUES(`description`);
 

--- a/upgrade/sql/9.2.0.sql
+++ b/upgrade/sql/9.2.0.sql
@@ -2,6 +2,18 @@
 INSERT INTO `PREFIX_feature_flag` (`name`, `type`, `label_wording`, `label_domain`, `description_wording`, `description_domain`, `state`, `stability`) VALUES
   ('improved_b2b', 'env,dotenv,db', 'Improved B2B', 'Admin.Advparameters.Feature', 'Enable / Disable the improved B2B mode. To use the feature activate the B2B mode in General Settings', 'Admin.Advparameters.Help', 0, 'beta');
 
+/* https://github.com/PrestaShop/PrestaShop/pull/42077 */
+INSERT INTO `PREFIX_feature_flag` (`name`, `type`, `label_wording`, `label_domain`, `description_wording`, `description_domain`, `state`, `stability`) VALUES
+  ('dashboard', 'env,dotenv,db', 'Dashboard page', 'Admin.Advparameters.Feature', 'Enable / Disable the migrated Symfony dashboard page. Native dashboard modules are not yet compatible with the new page and will not display until they are migrated.', 'Admin.Advparameters.Help', 0, 'beta');
+
+INSERT INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES
+  (NULL, 'displayAdminDashboardZoneOne', 'Symfony Dashboard - Zone one', 'Displays module content in the first column of the migrated (Symfony) dashboard page. Modern counterpart of the legacy dashboardZoneOne hook.', '1'),
+  (NULL, 'displayAdminDashboardZoneTwo', 'Symfony Dashboard - Zone two', 'Displays module content in the second column of the migrated (Symfony) dashboard page. Modern counterpart of the legacy dashboardZoneTwo hook.', '1'),
+  (NULL, 'displayAdminDashboardZoneThree', 'Symfony Dashboard - Zone three', 'Displays module content in the third column of the migrated (Symfony) dashboard page. Modern counterpart of the legacy dashboardZoneThree hook.', '1'),
+  (NULL, 'displayAdminDashboardTop', 'Symfony Dashboard - Top', 'Displays module content in the top area of the migrated (Symfony) dashboard page. Modern counterpart of the legacy displayDashboardTop hook.', '1'),
+  (NULL, 'displayAdminDashboardToolbar', 'Symfony Dashboard - Toolbar', 'Displays module content in the toolbar area of the migrated (Symfony) dashboard page. Modern counterpart of the legacy displayDashboardToolbarTopMenu hook.', '1')
+ON DUPLICATE KEY UPDATE `title` = VALUES(`title`), `description` = VALUES(`description`);
+
 /* https://github.com/PrestaShop/PrestaShop/pull/40632 */
 /* Insert B2B foundation */
 CREATE TABLE IF NOT EXISTS `PREFIX_business_entity` (


### PR DESCRIPTION
### Description

Adds the upgrade entries for the migrated (Symfony) Dashboard page to `upgrade/sql/9.2.0.sql`, so shops upgrading to 9.2.0 get the same data that a fresh 9.2.0 install gets from the core install fixtures.

Grouped next to the existing feature-flag insert:

- `dashboard` **feature flag** (beta, disabled by default)
- the five new dashboard **hooks**: `displayAdminDashboardZoneOne`, `displayAdminDashboardZoneTwo`, `displayAdminDashboardZoneThree`, `displayAdminDashboardTop`, `displayAdminDashboardToolbar` (idempotent via `ON DUPLICATE KEY UPDATE`)

### Why draft

The core PR is not merged yet and a release process is ongoing. Keeping this in draft until the core PR lands / the release window is clear.

### Related

- Core PR: PrestaShop/PrestaShop#42077
- Core issue: PrestaShop/PrestaShop#41968
- Example module: PrestaShop/example-modules#254
- Devdocs: PrestaShop/docs#2159
