### PR TITLE
Update column order in tables shipment and category

### DIFF
--- a/upgrade/sql/9.0.0.sql
+++ b/upgrade/sql/9.0.0.sql
@@ -48,8 +48,8 @@ UPDATE `PREFIX_feature_flag` SET `stability` = 'stable' WHERE `name` = 'carrier'
 DELETE FROM `PREFIX_feature_flag` WHERE `name` IN ('product_page_v2', 'title', 'order_state', 'multiple_image_format', 'attribute_group');
 
 /* Category redirect */
-/* PHP:add_column('category', 'redirect_type', 'ENUM(\'404\', \'410\', \'301\', \'302\') NOT NULL DEFAULT \'301\''); */;
-/* PHP:add_column('category', 'id_type_redirected', 'int(10) unsigned NOT NULL DEFAULT \'0\''); */;
+/* PHP:add_column('category', 'redirect_type', 'ENUM(\'404\', \'410\', \'301\', \'302\') NOT NULL DEFAULT \'301\' AFTER `date_upd`'); */;
+/* PHP:add_column('category', 'id_type_redirected', 'int(10) unsigned NOT NULL DEFAULT \'0\' AFTER `redirect_type`'); */;
 UPDATE `PREFIX_category` SET `redirect_type` = '404' WHERE `is_root_category` = 1;
 
 /* Increase size of customized data - https://github.com/PrestaShop/PrestaShop/pull/31109 */

--- a/upgrade/sql/9.2.0.sql
+++ b/upgrade/sql/9.2.0.sql
@@ -229,7 +229,7 @@ UPDATE `PREFIX_feature_flag` SET `stability` = 'stable' WHERE `name` = 'country'
 UPDATE `PREFIX_feature_flag` SET `stability` = 'stable' WHERE `name` = 'tax_rules_group';
 
 -- https://github.com/PrestaShop/PrestaShop/pull/40852
-/* PHP:add_column('shipment', 'deleted', 'TINYINT(1) NOT NULL DEFAULT 0'); */;
+/* PHP:add_column('shipment', 'deleted', 'TINYINT(1) NOT NULL DEFAULT 0 AFTER `tracking_number`'); */;
 
 -- https://github.com/PrestaShop/PrestaShop/pull/42024
 DELETE FROM `PREFIX_feature_flag`  WHERE `name` = 'state';


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add two missing `AFTER` in migration files to make sure everything is in the same order. No catchup file is created for this change, because it will mainly help to analyze future diffs of shops (updated vs freshly installed) and the order of columns has no impact on performance.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Run `./upgrade.sh` in https://github.com/PrestaShop/SeamlessUpgradeToolbox/tree/main/autoupgrade-scripts and check the resulting diff "dumps/diff_8.2.7_upgrated_9.2.0.patch". 