### PR TITLE
Drop the unused id_country index on address when upgrading

### DIFF
--- a/upgrade/php/ps_915_drop_address_country_index.php
+++ b/upgrade/php/ps_915_drop_address_country_index.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+use PrestaShop\Module\AutoUpgrade\Database\DbWrapper;
+
+function ps_915_drop_address_country_index(): bool
+{
+    // Shops that ran into the slow orders grid were told to drop this index by hand, so it can
+    // already be gone. DROP INDEX on a missing index is an error and MySQL has no IF EXISTS for
+    // indexes, so check before dropping rather than fail the upgrade on exactly those shops.
+    $existingIndex = DbWrapper::executeS(
+        'SHOW INDEX FROM `' . _DB_PREFIX_ . 'address` WHERE `Key_name` = \'id_country\''
+    );
+
+    if (empty($existingIndex)) {
+        return true;
+    }
+
+    return DbWrapper::execute('ALTER TABLE `' . _DB_PREFIX_ . 'address` DROP INDEX `id_country`');
+}

--- a/upgrade/sql/9.1.5.sql
+++ b/upgrade/sql/9.1.5.sql
@@ -1,0 +1,8 @@
+SET SESSION sql_mode='';
+SET NAMES 'utf8mb4';
+
+-- https://github.com/PrestaShop/PrestaShop/pull/42162
+-- Drop the unused id_country index on address. No query reads it - every core reference joins
+-- country on its primary key - and it misleads the optimizer on the orders grid into driving from
+-- country_lang instead of orders, turning a 50 row page into a scan with a filesort.
+/* PHP:ps_915_drop_address_country_index(); */;


### PR DESCRIPTION
Companion to PrestaShop/PrestaShop#42162, which removes the `id_country` index on `address` from the install schema. That side only changes new shops - existing ones keep the index, and they are the ones with enough orders to feel it.

### Why the index goes

It has no reader. Every core reference to `address.id_country` is a join against `country` that resolves through `country.PRIMARY` - `Customer.php` twice, `CustomerAddressQueryBuilder`, `AddressQueryBuilder`, and `OrderCountriesChoiceProvider` where the equality is against `country_lang`. No core query filters `address` by a literal country, and there is no foreign key on it.

What it does do is mislead the optimizer on the orders grid. Measured on a development shop with 60 005 orders and 45 006 addresses, running the join shape that grid builds:

| | median of 3 | plan |
| --- | --- | --- |
| with `id_country` | 152 ms | drives `country_lang` (`ALL`), then `country`, then `address` via `id_country`, `Using temporary; Using filesort` |
| without it | 45 ms | drives `orders` on `PRIMARY`, `rows=50`, backward index scan, no filesort |

PrestaShop/PrestaShop#41291 reports 4.7 s against 1.3 ms on 540k orders, which is the same plan flip at a larger scale.

### Why a PHP callback and not a plain ALTER

`9.0.1.sql` drops an index directly, so the bare statement would match precedent. It is the wrong shape here: the workaround circulating for #41291 is to run

```sql
ALTER TABLE `ps_address` DROP INDEX `id_country`;
```

by hand, so on exactly the shops that were hurting the index is already gone, and `DROP INDEX` on a missing index is an error. MySQL has no `IF EXISTS` for indexes and `DROP INDEX IF EXISTS` is MariaDB only, so the check has to happen before the statement. The callback returns `true` when there is nothing to drop.

### Version file

`9.1.5.sql`, matching the branch #42162 targets. If that PR is retargeted, this should move with it - say so and I will rename the file.

### What I could not run

The module's `.php-cs-fixer.dist.php` loads a ruleset from the module's own `vendor/`, which I do not have installed, so I did not run it and am not claiming a pass. The file follows the shape of the existing callbacks - same header, same `DbWrapper` import, same signature style. `php -l` is clean.
