### PR TITLE
Migrate combination image associations to carry their shop

### DIFF
--- a/upgrade/sql/9.2.0.sql
+++ b/upgrade/sql/9.2.0.sql
@@ -232,3 +232,11 @@ UPDATE `PREFIX_feature_flag` SET `stability` = 'stable' WHERE `name` = 'merchand
 
 -- https://github.com/PrestaShop/PrestaShop/pull/42024
 DELETE FROM `PREFIX_feature_flag`  WHERE `name` = 'state';
+
+-- https://github.com/PrestaShop/PrestaShop/pull/42190
+/* Combination image associations become per shop: add the column, widen the primary key, then give every existing association to each shop its image belongs to so current installs keep the selection they have */
+ALTER TABLE `PREFIX_product_attribute_image` ADD COLUMN `id_shop` int(10) unsigned NOT NULL DEFAULT 0;
+ALTER TABLE `PREFIX_product_attribute_image` DROP PRIMARY KEY, ADD PRIMARY KEY (`id_product_attribute`, `id_image`, `id_shop`);
+INSERT IGNORE INTO `PREFIX_product_attribute_image` (`id_product_attribute`, `id_image`, `id_shop`) SELECT pai.`id_product_attribute`, pai.`id_image`, ims.`id_shop` FROM (SELECT `id_product_attribute`, `id_image` FROM `PREFIX_product_attribute_image` WHERE `id_shop` = 0) pai INNER JOIN `PREFIX_image_shop` ims ON ims.`id_image` = pai.`id_image`;
+DELETE FROM `PREFIX_product_attribute_image` WHERE `id_shop` = 0;
+ALTER TABLE `PREFIX_product_attribute_image` ALTER COLUMN `id_shop` DROP DEFAULT;


### PR DESCRIPTION
Migration for PrestaShop/PrestaShop#42190, which gives `product_attribute_image` the shop its association was made for so that choosing combination images in one shop stops discarding what the other shops chose (PrestaShop/PrestaShop#12638, PrestaShop/PrestaShop#39226).

The new shape mirrors `product_carrier`: `PRIMARY KEY (id_product_attribute, id_image, id_shop)`.

The order matters, because one existing row becomes one row per shop and the old two column key cannot hold them:

1. add the column with a temporary default so the existing rows stay valid,
2. widen the primary key, otherwise the extra rows collide,
3. give every existing association to each shop its image belongs to, read from `image_shop`,
4. drop the placeholder rows and the temporary default.

Existing installs therefore keep exactly the selection they have today: an association becomes visible in the shops that already had the image, and in nothing else.

Verified against a copy of a real 9.2 database with a second shop added and half the images associated to it:

```
before:  39 rows
after:   57 rows   (39 for shop 1, 18 for shop 2)
leftover id_shop = 0 rows: 0
PRIMARY KEY: id_product_attribute, id_image, id_shop
```

The `INSERT ... SELECT` reads through a derived table so MySQL is not selecting from the table it inserts into.
