### PR TITLE
Add category_shop.active migration to 9.2.0 upgrade

### DIFF
--- a/upgrade/sql/9.2.0.sql
+++ b/upgrade/sql/9.2.0.sql
@@ -285,3 +285,8 @@ INSERT INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`
   (NULL, 'actionEmailBodyTemplateGridPresenterModifier', 'Modify email body template grid template data', 'This hook allows to modify data which is about to be used in template for email body template grid', '1'),
   (NULL, 'actionExtraPropertyDefinitionGridPresenterModifier', 'Modify extra property definition grid template data', 'This hook allows to modify data which is about to be used in template for extra property definition grid', '1')
 ON DUPLICATE KEY UPDATE `title` = VALUES(`title`), `description` = VALUES(`description`);
+
+-- https://github.com/PrestaShop/PrestaShop/pull/41643
+-- Make category visibility ("Displayed") configurable per shop.
+/* PHP:add_column('category_shop', 'active', 'tinyint(1) unsigned NOT NULL DEFAULT \'1\' AFTER `position`'); */;
+UPDATE `PREFIX_category_shop` cs INNER JOIN `PREFIX_category` c ON cs.id_category = c.id_category SET cs.active = c.active;


### PR DESCRIPTION
| Questions      | Answers
| -------------- | -------------------------------------------------------
| Branch?        | 7.6.x
| Type?          | improvement
| Category?      | CO
| BC breaks?     | no
| Deprecations?  | no
| Fixed issue?   | Companion for PrestaShop/PrestaShop#41643

Core PR PrestaShop/PrestaShop#41643 moves the category `active` flag from `category` to `category_shop` so visibility can be configured per shop in a multistore setup. Fresh installs get the column via `db_structure.sql`; existing shops need the same column added and back-filled during upgrade, otherwise every read on `category_shop.active` (Category, Search, Manufacturer, Supplier, the two grid query builders and CategoryRepository) fails after upgrade.

Follows the same idiom as #1887: `add_column()` for idempotence and an explicit `AFTER position` so upgraded shops match fresh-install column order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)