### PR TITLE
Insert actionNotFound in the 9.2.0 upgrade script

### DIFF
--- a/upgrade/sql/9.1.5.sql
+++ b/upgrade/sql/9.1.5.sql
@@ -1,0 +1,7 @@
+SET SESSION sql_mode='';
+SET NAMES 'utf8mb4';
+
+-- https://github.com/PrestaShop/PrestaShop/pull/41824
+INSERT INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES
+  (NULL, 'actionNotFound', 'Action when a page is not found', 'Allows modules to react when a page is not found - log it, redirect or perform other actions.', '1')
+ON DUPLICATE KEY UPDATE `title` = VALUES(`title`), `description` = VALUES(`description`);

--- a/upgrade/sql/9.2.0.sql
+++ b/upgrade/sql/9.2.0.sql
@@ -284,7 +284,8 @@ INSERT INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`
   (NULL, 'actionExtraPropertyDefinitionGridFilterFormModifier', 'Modify extra property definition grid filters', 'This hook allows to modify filters for extra property definition grid', '1'),
   (NULL, 'actionEmailBodyTemplateGridPresenterModifier', 'Modify email body template grid template data', 'This hook allows to modify data which is about to be used in template for email body template grid', '1'),
   (NULL, 'actionExtraPropertyDefinitionGridPresenterModifier', 'Modify extra property definition grid template data', 'This hook allows to modify data which is about to be used in template for extra property definition grid', '1'),
-  -- shipped in 9.1.5, so no base version makes the hooks-listing command report it
+  -- also declared in 9.1.5.sql, where it belonged: repeated here for shops already
+  -- upgraded to 9.1.5, which no longer run that script
   -- https://github.com/PrestaShop/PrestaShop/pull/41824
   (NULL, 'actionNotFound', 'Action when a page is not found', 'Allows modules to react when a page is not found - log it, redirect or perform other actions.', '1')
 ON DUPLICATE KEY UPDATE `title` = VALUES(`title`), `description` = VALUES(`description`);

--- a/upgrade/sql/9.2.0.sql
+++ b/upgrade/sql/9.2.0.sql
@@ -283,5 +283,8 @@ INSERT INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`
   (NULL, 'actionEmailBodyTemplateGridFilterFormModifier', 'Modify email body template grid filters', 'This hook allows to modify filters for email body template grid', '1'),
   (NULL, 'actionExtraPropertyDefinitionGridFilterFormModifier', 'Modify extra property definition grid filters', 'This hook allows to modify filters for extra property definition grid', '1'),
   (NULL, 'actionEmailBodyTemplateGridPresenterModifier', 'Modify email body template grid template data', 'This hook allows to modify data which is about to be used in template for email body template grid', '1'),
-  (NULL, 'actionExtraPropertyDefinitionGridPresenterModifier', 'Modify extra property definition grid template data', 'This hook allows to modify data which is about to be used in template for extra property definition grid', '1')
+  (NULL, 'actionExtraPropertyDefinitionGridPresenterModifier', 'Modify extra property definition grid template data', 'This hook allows to modify data which is about to be used in template for extra property definition grid', '1'),
+  -- shipped in 9.1.5, so no base version makes the hooks-listing command report it
+  -- https://github.com/PrestaShop/PrestaShop/pull/41824
+  (NULL, 'actionNotFound', 'Action when a page is not found', 'Allows modules to react when a page is not found - log it, redirect or perform other actions.', '1')
 ON DUPLICATE KEY UPDATE `title` = VALUES(`title`), `description` = VALUES(`description`);


### PR DESCRIPTION
## Description

Follow-up to PrestaShop/PrestaShop#41824, where @kpodemski pointed out that the new hook had not been added to the Update Assistant ([comment](https://github.com/PrestaShop/PrestaShop/pull/41824#issuecomment-5268547062)). That never happened, so `actionNotFound` is still not inserted into `ps_hook` by any upgrade script. This adds it to `upgrade/sql/9.2.0.sql`.

The hook is dispatched by three front controllers (`PageNotFoundController`, `ProductController`, `listing/CategoryController`) and shipped in **9.1.5** (#41824 targeted `9.1.x`, merged 2026-07-09).

It falls through the gap between two mechanisms:

- there is no `9.1.3.sql` / `9.1.4.sql` / `9.1.5.sql`, so nothing inserted it during the 9.1.x cycle;
- `prestashop:update:sql-upgrade-file-hooks-listing 9.1.5 …` does not report it as new for 9.2.0 either, because it is already present in the 9.1.5 `hook.xml` used as the comparison base.

So no base version can surface it, and it is absent from the generated block already in this file.

## Impact

A shop upgrading from 9.1.4 or earlier never gets the row. This is not fatal — `Hook::registerHook` creates a missing hook on the fly (`classes/Hook.php:626`) — but it does so with `title = name` and an empty description, and the hook stays absent from the DB (and from the BO positions page) until some module registers it. Fresh installs are unaffected, since the `install-dev` fixtures carry it.

## Implementation notes

The row was added to the existing generated block rather than as a second `INSERT`, so the file keeps a single `INSERT INTO PREFIX_hook`. The origin PR is referenced with an inline comment above the row, following the convention already used in `9.0.1-catchup.sql`.

Scope worth a maintainer's opinion: `9.2.0.sql` covers every shop that reaches 9.2.0, from 9.1.4 or from 9.1.5. It does not cover a shop upgrading from 9.1.4 to 9.1.5 and stopping there — that would need a `9.1.5-catchup.sql`. Given 9.1.x is closed, that seemed out of scope here, but happy to add it if you prefer.

## How to test

- Executing the block against a 9.2.0 database raises no SQL error (the inline comments inside the `VALUES` list are valid).
- `title` and `description` are copied verbatim from `install-dev/data/xml/hook.xml`.
- All 46 hooks of the block exist with identical `title` and `description` in a freshly installed 9.2.0 database, so the block stays a no-op there.
- On a shop upgraded from 9.1.4, `SELECT * FROM ps_hook WHERE name = 'actionNotFound'` returns the row with its proper title and description instead of nothing.