### PR TITLE
Create the extra_property_definition_shop table in the 9.2.0 upgrade script

### DIFF
--- a/upgrade/sql/9.2.0.sql
+++ b/upgrade/sql/9.2.0.sql
@@ -183,6 +183,14 @@ CREATE TABLE IF NOT EXISTS `PREFIX_extra_property_definition` (
   KEY `module_name` (`module_name`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+-- Shops an extra property definition is restricted to (no row = no explicit restriction).
+CREATE TABLE IF NOT EXISTS `PREFIX_extra_property_definition_shop` (
+  `id_extra_property_definition` int(10) unsigned NOT NULL,
+  `id_shop` int(10) unsigned NOT NULL,
+  PRIMARY KEY (`id_extra_property_definition`, `id_shop`),
+  KEY `id_shop` (`id_shop`)
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 -- https://github.com/PrestaShop/PrestaShop/pull/41775
 /* PHP:ps_920_extra_property_definitions_tab(); */;
 

--- a/upgrade/sql/9.2.0.sql
+++ b/upgrade/sql/9.2.0.sql
@@ -158,6 +158,7 @@ CREATE TABLE IF NOT EXISTS `PREFIX_b2b_role_authorization_role` (
 CREATE TABLE IF NOT EXISTS `PREFIX_extra_property_definition` (
   `id_extra_property_definition` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `entity_name` varchar(64) NOT NULL,
+  `table_name` varchar(64) DEFAULT NULL,
   `module_name` varchar(64) DEFAULT NULL,
   `property_name` varchar(64) NOT NULL,
   `type` ENUM ('int','bool','string','float','date','html','json','choice') NOT NULL DEFAULT 'string',

--- a/upgrade/sql/9.2.0.sql
+++ b/upgrade/sql/9.2.0.sql
@@ -159,6 +159,7 @@ CREATE TABLE IF NOT EXISTS `PREFIX_extra_property_definition` (
   `id_extra_property_definition` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `entity_name` varchar(64) NOT NULL,
   `table_name` varchar(64) DEFAULT NULL,
+  `controller_name` varchar(64) DEFAULT NULL,
   `module_name` varchar(64) DEFAULT NULL,
   `property_name` varchar(64) NOT NULL,
   `type` ENUM ('int','bool','string','float','date','html','json','choice') NOT NULL DEFAULT 'string',


### PR DESCRIPTION
## Description

Companion to **two** core PRs touching the extra property registry schema for 9.2.0:

- PrestaShop/PrestaShop#42490 (**merged**) — lets an extra property definition be restricted to a list of shops through a new `extra_property_definition_shop` association table (created at install in `install-dev/data/db_structure.sql`).
- PrestaShop/PrestaShop#42538 — supports entities with non-conventional naming (Order → `orders`, Combination → `product_attribute`) by persisting the resolved physical table in a new nullable `table_name` column on the `extra_property_definition` registry.

This PR adds the matching DDL to `upgrade/sql/9.2.0.sql`: the `extra_property_definition_shop` `CREATE TABLE IF NOT EXISTS` right below the `extra_property_definition` registry table it references, and the `table_name` column in that registry table's definition — both with the same column definitions and keys as the install structure.

No data seeding is needed: the absence of association rows is the shop feature's backward-compatible default ("no explicit restriction"), and a NULL `table_name` falls back to the entity name, which is correct for every definition created before #42538 (conventional naming was the only possibility).

## How to test

- Upgrade a 9.1.x shop to a 9.2.0 build containing both core PRs (or execute the new statements against a 9.2.0 database): `SHOW CREATE TABLE ps_extra_property_definition_shop` returns the table with the composite `(id_extra_property_definition, id_shop)` primary key and the `id_shop` key, and `SHOW COLUMNS FROM ps_extra_property_definition LIKE 'table_name'` returns the nullable varchar(64) column — identical to a fresh install.
- Running the script twice raises no error (`CREATE TABLE IF NOT EXISTS`).
- On the upgraded shop with multistore enabled, _Advanced Parameters > Extra Properties_ renders and saving a store association on a definition persists rows in the new table; registering a definition on the `combination` entity stores `table_name = product_attribute`.
