### PR TITLE
Modify wording of unknown modules

### DIFF
--- a/views/templates/dialogs/dialog-modules-report-content.html.twig
+++ b/views/templates/dialogs/dialog-modules-report-content.html.twig
@@ -28,7 +28,7 @@
 {% if uncertain_modules is defined and uncertain_modules|length > 0 %}
   {% include "@ModuleAutoUpgrade/components/scrollable-list.html.twig" with {
     'title': 'Uncertain modules'|trans({}),
-    'description': 'The compatibility of the following modules with the destination version of PrestaShop cannot be checked. It could be because they are homemade or have been unlisted from the Marketplace. Please review them via the [1]Module Manager[/1].'|trans({
+    'description': 'The compatibility of the following modules with the destination version of PrestaShop could not be verified. Please review them via the [1]Module Manager[/1] and check their compatibility.'|trans({
       '[1]' : '<a class="link link--external" href="' ~ module_manager_url ~'" target="_blank">',
       '[/1]' : '<i class="material-icons">open_in_new</i></a>',
     }),

--- a/views/templates/dialogs/dialog-modules-report-content.html.twig
+++ b/views/templates/dialogs/dialog-modules-report-content.html.twig
@@ -28,7 +28,7 @@
 {% if uncertain_modules is defined and uncertain_modules|length > 0 %}
   {% include "@ModuleAutoUpgrade/components/scrollable-list.html.twig" with {
     'title': 'Uncertain modules'|trans({}),
-    'description': 'The compatibility of the following modules with the destination version of PrestaShop could not be verified. Please review them via the [1]Module Manager[/1] and check their compatibility.'|trans({
+    'description': 'The compatibility of the following modules with the destination version of PrestaShop could not be verified using data from the PrestaShop Marketplace. Please review them via the [1]Module Manager[/1] and confirm their compatibility with their developers.'|trans({
       '[1]' : '<a class="link link--external" href="' ~ module_manager_url ~'" target="_blank">',
       '[/1]' : '<i class="material-icons">open_in_new</i></a>',
     }),


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The current message suggests that modules whose compatibility cannot be verified may be "homemade" or unlisted from the Marketplace. This can be misleading. A module may be professionally developed and distributed directly by its developer without ever being listed on the PrestaShop Marketplace. In particular, this is common for local payment, shipping and other integrations in some markets. The term "homemade" may also imply lower quality to non-technical merchants, even though PrestaShop only knows that the module's compatibility could not be verified. This PR makes the message neutral and directs merchants to review the affected modules and check their compatibility with their developers.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | TRENDO s.r.o.
| How to test?      | 
