### PR TITLE
Update wording of uncertain modules on CLI, based on the same change on the web interface

### DIFF
--- a/classes/Commands/CheckModulesCommand.php
+++ b/classes/Commands/CheckModulesCommand.php
@@ -206,7 +206,7 @@ class CheckModulesCommand extends AbstractCommand
 
         if (!empty($checkResults['uncertain_modules'])) {
             $output->writeln("\t<warning>⚠</warning> " . count($checkResults['uncertain_modules']) . ' uncertain modules');
-            $output->writeln("\t  The compatibility of the following modules with the destination version of PrestaShop cannot be checked. It could be because they are homemade or have been unlisted from the Marketplace. Please review them via the Module Manager:");
+            $output->writeln("\t  The compatibility of the following modules with the destination version of PrestaShop could not be verified using data from the PrestaShop Marketplace. Please review them via the Module Manager and confirm their compatibility with their developers:");
             foreach ($checkResults['uncertain_modules'] as $module) {
                 $output->writeln("\t\t" . $module);
             }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Backport of a wording update on the CLI.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Call `bin/console update:check-modules <admin_folder>` with this [test_module_40410.zip](https://github.com/user-attachments/files/31950328/test_module_40410.zip) installed to trigger the message. It should be updated to match the one displayed on the back-office.

<img width="1427" height="222" alt="image" src="https://github.com/user-attachments/assets/4ce0b042-47ed-4b02-8ee9-129b97b107cc" />
