### PR TITLE
Accept the admin maintenance bypass in the update self-check

### DIFF
--- a/classes/UpgradeSelfCheck.php
+++ b/classes/UpgradeSelfCheck.php
@@ -285,7 +285,7 @@ class UpgradeSelfCheck
                 }
 
                 return [
-                    'message' => $this->translator->trans('Maintenance mode needs to be enabled. Enable maintenance mode and add your maintenance IP in [1]Shop parameters > General > Maintenance[/1].', $params),
+                    'message' => $this->translator->trans('Maintenance mode needs to be enabled. Enable maintenance mode in [1]Shop parameters > General > Maintenance[/1], and keep a way to reach your store while it is closed: either allow admins to bypass maintenance mode, or add your maintenance IP.', $params),
                 ];
 
             case self::CACHE_ENABLED:
@@ -840,24 +840,43 @@ class UpgradeSelfCheck
 
     private function checkShopIsDeactivated(): bool
     {
-        // if multistore is not active, just check if shop is enabled and has a maintenance IP
+        // if multistore is not active, just check if shop is enabled and stays reachable by the merchant
         if (!Shop::isFeatureActive()) {
-            return !Configuration::get('PS_SHOP_ENABLE') && Configuration::get('PS_MAINTENANCE_IP');
+            return !Configuration::get('PS_SHOP_ENABLE') && $this->hasMaintenanceAccess();
         }
 
-        // multistore is active: all shops must be deactivated and have a maintenance IP, otherwise return false
+        // multistore is active: all shops must be deactivated and stay reachable, otherwise return false
         foreach (Shop::getCompleteListOfShopsID() as $shopId) {
             $shop = new Shop((int) $shopId);
             $groupId = (int) $shop->getGroup()->id;
             $isEnabled = Configuration::get('PS_SHOP_ENABLE', null, $groupId, (int) $shopId);
-            $maintenanceIp = Configuration::get('PS_MAINTENANCE_IP', null, $groupId, (int) $shopId);
 
-            if ($isEnabled || !$maintenanceIp) {
+            if ($isEnabled || !$this->hasMaintenanceAccess($groupId, (int) $shopId)) {
                 return false;
             }
         }
 
         return true;
+    }
+
+    /**
+     * A closed shop must still be reachable by the merchant, otherwise they cannot check the result
+     * of the update before reopening. Core grants that access in two ways, and honours both in
+     * Tools::isAllowedToBypassMaintenance(): a whitelisted maintenance IP, or -- since PrestaShop
+     * 8.1 -- an employee with an open back office session, when PS_MAINTENANCE_ALLOW_ADMINS is set.
+     *
+     * Requiring the IP alone predates that second way (the requirement comes from
+     * PrestaShop/PrestaShop#25642, filed 18 months before the option existed), so it blocks shops
+     * that are correctly closed and perfectly reachable. Shops older than 8.1 have no such option
+     * and simply fall back to requiring the IP, as before.
+     *
+     * @param int|null $groupId Shop group to read the configuration for, null for the current context
+     * @param int|null $shopId Shop to read the configuration for, null for the current context
+     */
+    private function hasMaintenanceAccess(?int $groupId = null, ?int $shopId = null): bool
+    {
+        return (bool) Configuration::get('PS_MAINTENANCE_IP', null, $groupId, $shopId)
+            || (bool) Configuration::get('PS_MAINTENANCE_ALLOW_ADMINS', null, $groupId, $shopId);
     }
 
     private function checkAdminDirectoryWritable(string $prodRootPath, string $adminPath, string $adminAutoUpgradePath): bool

--- a/storybook/stories/components/CheckRequirements.stories.js
+++ b/storybook/stories/components/CheckRequirements.stories.js
@@ -41,7 +41,7 @@ export const Default = {
         },
         {
           message:
-            'Maintenance mode needs to be enabled. Enable maintenance mode and add your maintenance IP in <a class="link">Shop parameters > General > Maintenance</a>.',
+            'Maintenance mode needs to be enabled. Enable maintenance mode in <a class="link">Shop parameters > General > Maintenance</a>, and keep a way to reach your store while it is closed: either allow admins to bypass maintenance mode, or add your maintenance IP.',
         },
         {
           message:


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | `UpgradeSelfCheck::checkShopIsDeactivated()` requires a non-empty `PS_MAINTENANCE_IP` on top of the shop being closed. That requirement comes from PrestaShop/PrestaShop#25642 (August 2021) and predates `PS_MAINTENANCE_ALLOW_ADMINS`, which shipped in PrestaShop 8.1 enabled by default and lets an employee with an open back office session bypass maintenance with no IP whitelisted at all. Core honours both routes in `Tools::isAllowedToBypassMaintenance()`; the self-check now accepts either. A shop closed on a default 8.1+ install is no longer blocked from updating for lacking an IP that core does not need.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/PrestaShop#42379
| How to test?      | On a shop that is NOT on localhost (the check is skipped there, see `checkIsLocalEnvironment()`): Shop parameters > General > Maintenance, set "Enable shop" to No, leave "Maintenance IP" empty, keep "Allow admins to bypass maintenance" on its default Yes. Before: the update prerequisite "Maintenance mode needs to be enabled" stays red and the update cannot start. After: the prerequisite is satisfied. Then set "Allow admins" to No with the IP still empty and check the prerequisite goes red again.

### The defect

`PS_MAINTENANCE_ALLOW_ADMINS` was added in 8.1 (`install-dev/data/xml/configuration.xml` ships it as `1`, and this
module's own PR #565 backfills it into upgraded shops via `upgrade/sql/8.1.0.sql`). Since then the maintenance IP is
no longer the only way for a merchant to reach their closed shop, but the self-check was never revisited, so a
correctly closed and perfectly reachable shop is refused.

Measured against a 9.x install by calling the private method directly (the public path short-circuits on localhost):

| scenario | before | after |
| --- | --- | --- |
| shop offline, allow-admins on (default), no IP | blocked | allowed |
| shop offline, allow-admins off, no IP | blocked | blocked |
| shop online | blocked | blocked |
| shop offline, IP set | allowed | allowed |

Only the first row changes. The check also still passes today when the IP field holds junk such as `asdf`, since it
only tests for a non-empty value - it is a presence check, not a reachability check, which is the second reason the
IP alone is a poor proxy for "the merchant can still get in".

Shops older than 8.1 have no such option, read `false`, and keep requiring the IP exactly as before, so this is a
pure widening: nothing that passed the check before can start failing.

### Wording

The requirement wording said "Enable maintenance mode and add your maintenance IP", presenting the IP as mandatory.
It now names both accepted ways of staying able to reach the store. This is a changed translatable string.

### The changed string has three other carriers - two deliberately left alone

A `*.php`-only grep said the wording was self-contained. It is not. Searching the whole tree found:

- `storybook/stories/components/CheckRequirements.stories.js:44` hardcodes a copy of the message for the
  visual story. **Updated in the same commit**, otherwise the storybook renders copy that no longer exists.
- `translations/ModulesAutoupgradeAdmin.*.xlf` (11 catalogs) carry the old source string. **Deliberately
  NOT touched.** Every commit under `translations/` is authored by "Github Actions - Module translation
  tool", and `.github/workflows/extract-translations.yml` regenerates them on every push to `dev`, so a
  hand edit would be overwritten. The catalogs re-extract after merge.
- `tests/UI/campaigns/functional/02_upgradeOnline.spec.ts` and `03_upgradeLocal.spec.ts` do not assert the
  message, but both run a `should add maintenance IP` step (`boMaintenancePage.addMyIpAddress`). They
  satisfy the gate the old way, so they pass unchanged either side of this fix - and that is also why the
  UI suite never caught this defect. **Left as is on purpose:** dropping that step would remove the only
  coverage of the IP path.

### Verification

- Unit suite on PHP 7.4 identical before and after: `Tests: 364, Assertions: 604, Errors: 12, Failures: 3, Warnings: 12`
  (all pre-existing and environmental - no `ext-zip`, no `intl` locale data in the throwaway container).
- php-cs-fixer clean; PHPStan against PrestaShop 9.0.0: `[OK] No errors`; the storybook file parses.
- UI tests: not run. A campaign can be launched on request.
- The multistore loop was NOT exercised end to end: `Shop::isFeatureActive()` also requires `COUNT(*) FROM ps_shop > 1`
  and the fixture has one shop. What was verified there is the only thing that changed in that branch - that a scoped
  read `Configuration::get('PS_MAINTENANCE_ALLOW_ADMINS', null, $groupId, $shopId)` resolves through the global row
  the same way the pre-existing `PS_MAINTENANCE_IP` read does.

### Notes for publishing

- The reporter's stated cause ("the module fails to read the current maintenance state") is wrong and their own
  screenshot contradicts it; the PR fixes a real adjacent defect, not the mechanism they described. Keep that
  distinction in the PR body - do not present the report as correct.
- No competing PR: no open autoupgrade PR touches `classes/UpgradeSelfCheck.php` (checked across all open PRs).
